### PR TITLE
CI: Add auto-release draft

### DIFF
--- a/.github/release.drafter.yml
+++ b/.github/release.drafter.yml
@@ -1,0 +1,41 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+autolabeler:
+  - label: 'chore'
+    title:
+      - '/chore\:/i'
+  - label: 'bug'
+    title:
+      - '/fix\:/i'
+  - label: 'enhancement'
+    title:
+      - '/feature/i'

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts the next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic_pr_check.yml
+++ b/.github/workflows/semantic_pr_check.yml
@@ -1,0 +1,45 @@
+name: "Verify Semantic PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate_pr_title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # See: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+          types: |
+            fix
+            feat
+            docs
+            ci
+            chore
+            build
+            test
+
+          # # We don't use scopes as of now
+          # scopes: |
+          #   core
+          #   ui
+          #   JIRA-\d+
+
+          # Require capitalization for the first letter of the subject.
+          subjectPattern: ^[A-Z].*$
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            start with an uppercase character.


### PR DESCRIPTION
This adds two new CI workflows:

1. Auto-release drafter. After PRs are merged, a release draft is created automatically.
2. Semantic PR Titles checker. PRs are required to follow the semantic PRs convention, which is basically the conventional commit spec, adapted to PRs.
