### PR TITLE
Docs: Cleanup auto-generated reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Note: Additional secret store options may be supported in the future. [More inf
 ### Retrieving Secrets
 
 ```python
-from airbyte_lib import get_secret, SecretSource
+from airbyte import get_secret, SecretSource
 
 source = get_connection("source-github")
 source.set_config(

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
-"""All exceptions used in the Airbyte Lib.
+"""All exceptions used in the PyAirbyte.
 
 This design is modeled after structlog's exceptions, in that we bias towards auto-generated
 property prints rather than sentence-like string concatenation.
@@ -111,7 +111,7 @@ class AirbyteError(Exception):
 
 @dataclass
 class AirbyteLibInternalError(AirbyteError):
-    """An internal error occurred in Airbyte Lib."""
+    """An internal error occurred in PyAirbyte."""
 
     guidance = "Please consider reporting this error to the Airbyte team."
     help_url = NEW_ISSUE_URL
@@ -125,7 +125,7 @@ class AirbyteLibInputError(AirbyteError, ValueError):
     """The input provided to PyAirbyte did not match expected validation rules.
 
     This inherits from ValueError so that it can be used as a drop-in replacement for
-    ValueError in the Airbyte Lib API.
+    ValueError in the PyAirbyte API.
     """
 
     # TODO: Consider adding a help_url that links to the auto-generated API reference.

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -11,19 +11,14 @@ import airbyte as ab
 
 
 def run() -> None:
-    """Generate docs for all public modules in airbyte_lib and save them to docs/generated.
-
-    Public modules are:
-    * The main airbyte_lib module
-    * All directory modules in airbyte_lib that don't start with an underscore.
-    """
-    public_modules = ["airbyte"]
+    """Generate docs for all public modules in AirbyteLib and save them to docs/generated."""
+    public_modules = []
 
     # recursively delete the docs/generated folder if it exists
     if pathlib.Path("docs/generated").exists():
         shutil.rmtree("docs/generated")
 
-    # All files and folders in `airbyte_lib` that don't start with "_" are treated as public.
+    # All files and folders that don't start with "_" are treated as public.
     for submodule in os.listdir("airbyte"):
         submodule_path = pathlib.Path(f"airbyte/{submodule}")
         if not submodule.startswith("_"):
@@ -31,8 +26,10 @@ def run() -> None:
 
     pdoc.render.configure(
         template_directory="docs",
-        show_source=False,
-        search=False,
+        show_source=True,
+        search=True,
+        logo="https://docs.airbyte.com/img/logo-dark.png",
+        favicon="https://docs.airbyte.com/img/favicon.png",
     )
     pdoc.pdoc(
         *public_modules,


### PR DESCRIPTION
This significantly cleans up the docs:

1. Add logo and favicon.
2. Landing page is now the module index.
3. Added search capability.
4. Fixed some renames that were missed previously.
5. Add 'show source' option on docs.
