### PR TITLE
Feat: Streamline stream selection and support for `select_streams("*")`

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -68,4 +68,4 @@ jobs:
 
     # Job-specifc step(s):
     - name: Check code format
-      run: poetry run ruff format --check .
+      run: poetry run mypy .

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -67,5 +67,5 @@ jobs:
         cache: 'poetry'
 
     # Job-specifc step(s):
-    - name: Check code format
+    - name: Check MyPy typing
       run: poetry run mypy .

--- a/airbyte/_factories/connector_factories.py
+++ b/airbyte/_factories/connector_factories.py
@@ -42,7 +42,7 @@ def get_source(
     name: str,
     config: dict[str, Any] | None = None,
     *,
-    streams: Literal["*"] | list[str] | None = None,
+    streams: str | list[str] | None = None,
     version: str | None = None,
     pip_url: str | None = None,
     local_executable: Path | str | None = None,

--- a/airbyte/_factories/connector_factories.py
+++ b/airbyte/_factories/connector_factories.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import shutil
 import warnings
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from airbyte import exceptions as exc
 from airbyte._executor import PathExecutor, VenvExecutor

--- a/airbyte/_factories/connector_factories.py
+++ b/airbyte/_factories/connector_factories.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import shutil
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from airbyte import exceptions as exc
 from airbyte._executor import PathExecutor, VenvExecutor
@@ -42,6 +42,7 @@ def get_source(
     name: str,
     config: dict[str, Any] | None = None,
     *,
+    streams: Literal["*"] | list[str] | None = None,
     version: str | None = None,
     pip_url: str | None = None,
     local_executable: Path | str | None = None,
@@ -53,6 +54,9 @@ def get_source(
         name: connector name
         config: connector config - if not provided, you need to set it later via the set_config
             method.
+        streams: list of stream names to select for reading. If set to "*", all streams will be
+            selected. If not provided, you can set it later via the `select_streams()` or
+            `select_all_streams()` method.
         version: connector version - if not provided, the currently installed version will be used.
             If no version is installed, the latest available version will be used. The version can
             also be set to "latest" to force the use of the latest available version.
@@ -88,6 +92,7 @@ def get_source(
         return Source(
             name=name,
             config=config,
+            streams=streams,
             executor=PathExecutor(
                 name=name,
                 path=local_executable,

--- a/airbyte/source.py
+++ b/airbyte/source.py
@@ -524,6 +524,7 @@ class Source:
         self,
         cache: SQLCacheBase | None = None,
         *,
+        streams: str | list[str] | None = None,
         write_strategy: str | WriteStrategy = WriteStrategy.AUTO,
         force_full_refresh: bool = False,
     ) -> ReadResult:
@@ -535,6 +536,8 @@ class Source:
                 one of "append", "upsert", "replace", or "auto". If a WriteStrategy, it must be one
                 of WriteStrategy.APPEND, WriteStrategy.UPSERT, WriteStrategy.REPLACE, or
                 WriteStrategy.AUTO.
+            streams: Optional if already set. A list of stream names to select for reading. If set
+                to "*", all streams will be selected.
             force_full_refresh: If True, the source will operate in full refresh mode. Otherwise,
                 streams will be read in incremental mode if supported by the connector. This option
                 must be True when using the "replace" strategy.
@@ -561,6 +564,9 @@ class Source:
                         "available_strategies": [s.value for s in WriteStrategy],
                     },
                 ) from None
+
+        if streams:
+            self.select_streams(streams)
 
         if not self._selected_stream_names:
             raise exc.AirbyteLibNoStreamsSelectedError(

--- a/airbyte/source.py
+++ b/airbyte/source.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 import warnings
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import jsonschema
 import pendulum
@@ -95,7 +95,7 @@ class Source:
         if config is not None:
             self.set_config(config, validate=validate)
         if streams is not None:
-            self.set_streams(streams)
+            self.select_streams(streams)
 
     def set_streams(self, streams: list[str]) -> None:
         """Deprecated. See select_streams()."""
@@ -115,11 +115,19 @@ class Source:
         """
         self._selected_stream_names = self.get_available_streams()
 
-    def select_streams(self, streams: list[str]) -> None:
+    def select_streams(self, streams: Literal["*"] | list[str]) -> None:
         """Select the stream names that should be read from the connector.
 
         Currently, if this is not set, all streams will be read.
         """
+        if streams == "*":
+            self.select_all_streams()
+            return
+
+        if isinstance(streams, str):
+            # If a single stream is provided, convert it to a one-item list
+            streams = [streams]
+
         available_streams = self.get_available_streams()
         for stream in streams:
             if stream not in available_streams:

--- a/airbyte/source.py
+++ b/airbyte/source.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 import warnings
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import jsonschema
 import pendulum
@@ -76,7 +76,7 @@ class Source:
         executor: Executor,
         name: str,
         config: dict[str, Any] | None = None,
-        streams: list[str] | None = None,
+        streams: str | list[str] | None = None,
         *,
         validate: bool = False,
     ) -> None:
@@ -115,8 +115,11 @@ class Source:
         """
         self._selected_stream_names = self.get_available_streams()
 
-    def select_streams(self, streams: Literal["*"] | list[str]) -> None:
+    def select_streams(self, streams: str | list[str]) -> None:
         """Select the stream names that should be read from the connector.
+
+        Args:
+        - streams: A list of stream names to select. If set to "*", all streams will be selected.
 
         Currently, if this is not set, all streams will be read.
         """


### PR DESCRIPTION
This PR allows a more streamlined single-step source creation and setup.

Instead of requiring multiple steps:

```py
    source = ab.get_source(
        "source-github",
        config=GITHUB_CONFIG,
    )
    source.select_streams(["pull_requests", "issues"])
    read_result = source.read()
```

We can now do all in a single step:

```py
    read_result = ab.get_source(
        "source-github",
        config=GITHUB_CONFIG,
        streams=["pull_requests", "issues"],
    ).read()
```

If `"*"` is specified, it will be treated as "all", equivalent to `select_all_streams()`.

For tutorials, the multi-step process is often preferable, because it allows each step to be debugged in turn. However, for demos, the reverse is true: fewer lines and fewer statement makes the process easier to read and easier to understand overall.

This also allows streams to be specified in `read()`.
