### PR TITLE
Test: Add script to streamline integ test with any source

### DIFF
--- a/examples/run_integ_test_source.py
+++ b/examples/run_integ_test_source.py
@@ -13,7 +13,7 @@ from google.cloud import secretmanager
 
 import airbyte as ab
 
-def get_integ_test_config(connector_name: str):
+def get_integ_test_config(secret_name: str):
     if "GCP_GSM_CREDENTIALS" not in os.environ:
         raise Exception(
             f"GCP_GSM_CREDENTIALS env variable not set, can't fetch secrets for '{connector_name}'. "
@@ -26,12 +26,12 @@ def get_integ_test_config(connector_name: str):
     )
     return json.loads(
         secret_client.access_secret_version(
-            name=f"projects/dataline-integration-testing/secrets/{connector_name.upper()}/versions/latest"
+            name=f"projects/dataline-integration-testing/secrets/{secret_name}/versions/latest"
         ).payload.data.decode("UTF-8")
     )
 
 
-def main(connector_name: str):
+def main(connector_name: str, secret_name: str | None):
     config = get_integ_test_config(connector_name)
     source = ab.get_source(
         connector_name,
@@ -56,4 +56,6 @@ def main(connector_name: str):
 if __name__ == "__main__":
     # Get first arg from CLI
     connector_name = sys.argv[1]
-    main(connector_name)
+    # TODO: We can optionally take a second arg to override the default secret name.
+    secret_name = f"SECRET_{connector_name.upper()}__CREDS"
+    main(connector_name, secret_name)

--- a/examples/run_integ_test_source.py
+++ b/examples/run_integ_test_source.py
@@ -20,9 +20,10 @@ import airbyte as ab
 def get_integ_test_config(secret_name: str) -> dict[str, Any]:
     if "GCP_GSM_CREDENTIALS" not in os.environ:
         raise Exception(  # noqa: TRY002, TRY003
-            f"GCP_GSM_CREDENTIALS env variable not set, can't fetch secrets for '{connector_name}'. "
+            f"GCP_GSM_CREDENTIALS env var not set, can't fetch secrets for '{connector_name}'. "
             "Make sure they are set up as described: "
-            "https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md#get-gsm-access"
+            "https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/"
+            "README.md#get-gsm-access"
         )
 
     secret_client = secretmanager.SecretManagerServiceClient.from_service_account_info(
@@ -35,33 +36,44 @@ def get_integ_test_config(secret_name: str) -> dict[str, Any]:
     )
 
 
-def main(connector_name: str, secret_name: str | None) -> None:
+def main(
+    connector_name: str,
+    secret_name: str | None,
+    streams: list[str] | None,
+) -> None:
     config = get_integ_test_config(secret_name)
     source = ab.get_source(
         connector_name,
         config=config,
         install_if_missing=True,
     )
-    source.select_all_streams()
+    if streams:
+        source.select_streams(streams)
+    else:
+        source.select_all_streams()
     cache = ab.new_local_cache()
     try:
         read_result = source.read(cache=cache)
         print(
             f"Read from `{connector_name}` was successful. ",
-            f"Cache results were saved to: {cache.cache_dir}",
+            f"Cache results were saved to: {cache.config.cache_dir}",
             f"Streams list: {', '.join(read_result.streams.keys())}",
         )
-    except Exception as ex:
+    except Exception:
         print(
             f"Read from `{connector_name}` failed. ",
-            f"Cache files are located at: {cache.cache_dir}",
+            f"Cache files are located at: {cache.config.cache_dir}",
         )
-        sys.exit(1)
+        raise
 
 
 if __name__ == "__main__":
     # Get first arg from CLI
     connector_name = sys.argv[1]
+    streams_csv = sys.argv[2] if len(sys.argv) > 2 else None  # noqa: PLR2004
+    streams = None
+    if streams_csv:
+        streams = streams_csv.split(",")
     # TODO: We can optionally take a second arg to override the default secret name.
     secret_name = f"SECRET_{connector_name.upper()}__CREDS"
-    main(connector_name, secret_name)
+    main(connector_name, streams=streams, secret_name=secret_name)

--- a/examples/run_integ_test_source.py
+++ b/examples/run_integ_test_source.py
@@ -1,0 +1,59 @@
+"""This script will run any source that is registered in the Airbyte integration tests.
+
+
+Usage:
+    poetry run python examples/run_integ_test_source.py source-faker
+
+"""
+
+import json
+import sys
+
+from google.cloud import secretmanager
+
+import airbyte as ab
+
+def get_integ_test_config(connector_name: str):
+    if "GCP_GSM_CREDENTIALS" not in os.environ:
+        raise Exception(
+            f"GCP_GSM_CREDENTIALS env variable not set, can't fetch secrets for '{connector_name}'. "
+            "Make sure they are set up as described: "
+            "https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md#get-gsm-access"
+        )
+
+    secret_client = secretmanager.SecretManagerServiceClient.from_service_account_info(
+        json.loads(os.environ["GCP_GSM_CREDENTIALS"])
+    )
+    return json.loads(
+        secret_client.access_secret_version(
+            name=f"projects/dataline-integration-testing/secrets/{connector_name.upper()}/versions/latest"
+        ).payload.data.decode("UTF-8")
+    )
+
+
+def main(connector_name: str):
+    config = get_integ_test_config(connector_name)
+    source = ab.get_source(
+        connector_name,
+        config=config,
+        install_if_missing=True,
+        streams="*",
+    )
+    try:
+        read_result = source.read()
+        print(
+            f"Read from `{connector_name}` was successful. ",
+            f"Cache results were saved to: {read_result.cache.cache_dir}"
+        )
+    except Exception as ex:
+        print(
+            f"Read from `{connector_name}` failed. ",
+            f"Cache files are located at: {read_result.cache.cache_dir}"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    # Get first arg from CLI
+    connector_name = sys.argv[1]
+    main(connector_name)


### PR DESCRIPTION
~~This is not yet tested, and needs a bit more work.~~

This is working now. 😄 

The goal here is to be able to run a sync using any source by running the script and passing the name of the source you want to test:

```
poetry run python examples/run_integ_test_source.py SOURCE_NAME
```

Or to test a specific stream:

```bash
poetry run python examples/run_integ_test_source.py SOURCE_NAME STREAMS_CSV
```

If provided, the second `STREAMS_CSV` arg is expected to be a comma-delimited string (not a file) with one or more streams. For instance: `events` (with no comma) or `events,customers,users`.

For instance, here are the commands I used for testing Source Klaviyo:

```bash
# Run all streams
poetry run python examples/run_integ_test_source.py source-klaviyo

# Run just the events stream
poetry run python examples/run_integ_test_source.py source-klaviyo events
```