### PR TITLE
Fix: Pass `streams` list from `get_source()` to `Source` constructor

### DIFF
--- a/airbyte/_factories/connector_factories.py
+++ b/airbyte/_factories/connector_factories.py
@@ -119,7 +119,8 @@ def get_source(
         executor.ensure_installation()
 
     return Source(
-        executor=executor,
         name=name,
         config=config,
+        streams=streams,
+        executor=executor,
     )


### PR DESCRIPTION
Found this bug while creating a notebook for langchain. The `streams` arg of `get_source()` was only passed to the first constructor and not the second one in that factory function.

This simply fixes that omissiong.

Tested on a Colab notebook to confirm the fix:

- https://colab.research.google.com/drive/1IiP224qBttdSVYA31mutgokDsMk-1DAq#scrollTo=8sJRgmsinjPK