### PR TITLE
Chore: Add `.gitignore` rules for secrets dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Directories and subdirectories called 'secrets' or '.secrets'
+.secrets
+secrets
+
 # Virtual Environments
 .venv
 .venv-*


### PR DESCRIPTION
If we run `connectors_ci`, it will create these directories. This PR ensures we keep git history safe from accidentally committed secrets in `secrets` or `.secrets` dirs.