### PR TITLE
Chore: Loosen version requirements to match Colab defaults

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2795,4 +2795,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "c5abb5cfea1fddf5123c1c5d7d40c028134738fea39c06fc5f31e9c9361c343f"
+content-hash = "df1e1fd8ed710a60db7beee8c2e98686029238e5d7d025b96668c096955d5445"

--- a/poetry.lock
+++ b/poetry.lock
@@ -622,13 +622,13 @@ requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.17.2"
+version = "3.18.0"
 description = "Google BigQuery API client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-bigquery-3.17.2.tar.gz", hash = "sha256:6e1cf669a40e567ab3289c7b5f2056363da9fcb85d9a4736ee90240d4a7d84ea"},
-    {file = "google_cloud_bigquery-3.17.2-py2.py3-none-any.whl", hash = "sha256:cdadf5283dca55a1a350bacf8c8a7466169d3cf46c5a0a3abc5e9aa0b0a51dee"},
+    {file = "google-cloud-bigquery-3.18.0.tar.gz", hash = "sha256:74f0fc6f0ba9477f808d25924dc8a052c55f7ca91064e83e16d3ee5fb7ca77ab"},
+    {file = "google_cloud_bigquery-3.18.0-py2.py3-none-any.whl", hash = "sha256:3520552075502c69710d37b1e9600c84e6974ad271914677d16bfafa502857fb"},
 ]
 
 [package.dependencies]
@@ -1957,13 +1957,13 @@ pytest = [
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -2175,13 +2175,13 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
 ]
 
 [package.dependencies]
@@ -2338,26 +2338,6 @@ files = [
     {file = "ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360"},
     {file = "ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e"},
 ]
-
-[[package]]
-name = "segment-analytics-python"
-version = "2.3.2"
-description = "The hassle-free way to integrate analytics into any python application."
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "segment-analytics-python-2.3.2.tar.gz", hash = "sha256:9321b1e03b0129fa69edba0b38c63c2de229db91abe7f849e3df015b8fbc1c36"},
-    {file = "segment_analytics_python-2.3.2-py2.py3-none-any.whl", hash = "sha256:0ba881e019c396f17b4e0a66117691a189a555bc13da47de69cb8db8e3adecad"},
-]
-
-[package.dependencies]
-backoff = ">=2.1,<3.0"
-PyJWT = ">=2.8.0,<2.9.0"
-python-dateutil = ">=2.2,<3.0"
-requests = ">=2.7,<3.0"
-
-[package.extras]
-test = ["flake8 (==3.7.9)", "mock (==2.0.0)", "pylint (==2.8.0)"]
 
 [[package]]
 name = "setuptools"
@@ -2815,4 +2795,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ec1bb58d54014e91ddf38297abc404c2dfc7a13fcfd9131c215fe763b6b647aa"
+content-hash = "c5abb5cfea1fddf5123c1c5d7d40c028134738fea39c06fc5f31e9c9361c343f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2795,4 +2795,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "df1e1fd8ed710a60db7beee8c2e98686029238e5d7d025b96668c096955d5445"
+content-hash = "a6b886f25692bf3dc4f8503c6d81ef0b7d690fe93432e0bf58812c534b1fe037"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ python = ">=3.9,<4.0"
 airbyte-cdk = "^0.58.3"
 duckdb = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
 duckdb-engine = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
-google-auth = "^2.27.0"
-google-cloud-bigquery = "^3.17.2"
+google-auth = ">=2.27.0,<3.0"
+google-cloud-bigquery = ">=3.12.0,<4.0"
 jsonschema = "3.2.0"
 orjson = "^3.9.10"
 overrides = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ python = ">=3.9,<4.0"
 airbyte-cdk = "^0.58.3"
 duckdb = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
 duckdb-engine = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
-google-auth = "^2.28.1"
+google-auth = "^2.27.0"
 google-cloud-bigquery = "^3.17.2"
 jsonschema = "3.2.0"
 orjson = "^3.9.10"
 overrides = "^7.4.0"
-pandas = "2.1.4" # 2.2.0 breaks sqlalchemy interop - TODO: optionally retest higher versions
+pandas = ">=1.5.3,<=2.1.4" # 2.2.0 breaks sqlalchemy interop - TODO: optionally retest higher versions
 pendulum = "<=3.0.0"
 psycopg2-binary = "^2.9.9"
 # psycopg = {extras = ["binary", "pool"], version = "^3.1.16"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ duckdb = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
 duckdb-engine = "0.9.2"  # TODO: Change to "^0.10.0" once supported by MotherDuck
 google-auth = ">=2.27.0,<3.0"
 google-cloud-bigquery = ">=3.12.0,<4.0"
-jsonschema = "3.2.0"
+jsonschema = ">=3.2.0,<5.0"
 orjson = "^3.9.10"
 overrides = "^7.4.0"
 pandas = ">=1.5.3,<=2.1.4" # 2.2.0 breaks sqlalchemy interop - TODO: optionally retest higher versions


### PR DESCRIPTION
Resolves: #35 

In the latest version, complains about version conflicts and asks users to reload the Notebook.

This PR aims to widen supported versions for `google.auth` and `pandas`, to avoid conflicts with the default Colab environment.