### PR TITLE
(Stale) Chore: Add linting and formatting on pytest tests

### DIFF
--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -48,10 +48,9 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          # TODO: Re-enable 3.9 and 3.11 once we have stable tests across all versions.
-          # '3.9',
+          '3.9',
           '3.10',
-          # '3.11',
+          '3.11',
         ]
       fail-fast: false
 

--- a/airbyte/_util/document_rendering.py
+++ b/airbyte/_util/document_rendering.py
@@ -2,7 +2,7 @@
 """Methods for converting Airbyte records into documents."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import yaml
 from pydantic import BaseModel
@@ -27,7 +27,7 @@ def _to_title_case(name: str, /) -> str:
 class CustomRenderingInstructions(BaseModel):
     """Instructions for rendering a stream's records as documents."""
 
-    title_property: str | None
+    title_property: Optional[str]
     content_properties: list[str]
     frontmatter_properties: list[str]
     metadata_properties: list[str]
@@ -36,9 +36,9 @@ class CustomRenderingInstructions(BaseModel):
 class DocumentRenderer(BaseModel):
     """Instructions for rendering a stream's records as documents."""
 
-    title_property: str | None
-    content_properties: list[str] | None
-    metadata_properties: list[str] | None
+    title_property: Optional[str]
+    content_properties: Optional[list[str]]
+    metadata_properties: Optional[list[str]]
     render_metadata: bool = False
 
     # TODO: Add primary key and cursor key support:

--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import abc
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, Optional, final
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -34,7 +34,7 @@ class CacheBase(BaseModel):
     schema_name: str = "airbyte_raw"
     """The name of the schema to write to."""
 
-    table_prefix: str | None = None
+    table_prefix: Optional[str] = None
     """ A prefix to add to all table names.
     If 'None', a prefix will be created based on the source name.
     """
@@ -43,7 +43,7 @@ class CacheBase(BaseModel):
     """A suffix to add to all table names."""
 
     _sql_processor_class: type[SqlProcessorBase] = PrivateAttr()
-    _sql_processor: SqlProcessorBase | None = PrivateAttr(default=None)
+    _sql_processor: Optional[SqlProcessorBase] = PrivateAttr(default=None)
 
     @final
     @property

--- a/airbyte/caches/duckdb.py
+++ b/airbyte/caches/duckdb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path  # noqa: TCH003  # Used in Pydantic init
+from typing import Union
 
 from overrides import overrides
 
@@ -23,7 +24,7 @@ warnings.filterwarnings(
 class DuckDBCache(CacheBase):
     """A DuckDB cache."""
 
-    db_path: Path | str
+    db_path: Union[Path, str]
     """Normally db_path is a Path object.
 
     There are some cases, such as when connecting to MotherDuck, where it could be a string that

--- a/airbyte/documents.py
+++ b/airbyte/documents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 if TYPE_CHECKING:
@@ -30,10 +30,10 @@ class Document(BaseModel):
     This class is duck-typed to be compatible with LangChain project's `Document` class.
     """
 
-    id: str | None = None
+    id: str | None = Field(default=None)
     content: str
     metadata: dict[str, Any]
-    last_modified: datetime.datetime | None = None
+    last_modified: datetime.datetime | None = Field(default=None)
 
     def __str__(self) -> str:
         return self.content

--- a/airbyte/documents.py
+++ b/airbyte/documents.py
@@ -2,7 +2,7 @@
 """Methods for converting Airbyte records into documents."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -30,10 +30,10 @@ class Document(BaseModel):
     This class is duck-typed to be compatible with LangChain project's `Document` class.
     """
 
-    id: str | None = Field(default=None)
+    id: Optional[str] = Field(default=None)
     content: str
     metadata: dict[str, Any]
-    last_modified: datetime.datetime | None = Field(default=None)
+    last_modified: Optional[datetime.datetime] = Field(default=None)
 
     def __str__(self) -> str:
         return self.content

--- a/examples/run_file_source.py
+++ b/examples/run_file_source.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""A simple test of PyAirbyte, using the File source connector.
+
+Usage (from PyAirbyte root directory):
+> poetry run python ./examples/run_file.py
+
+No setup is needed, but you may need to delete the .venv-source-file folder
+if your installation gets interrupted or corrupted.
+"""
+
+from __future__ import annotations
+
+import airbyte as ab
+
+
+source = ab.get_source(
+    "source-file",
+    install_if_missing=True,
+)
+source.check()
+
+# print(list(source.get_records("pokemon")))
+source.read(cache=ab.new_local_cache("poke"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,8 @@ ignore = [
     "FIX002", # Allow "TODO:" until release (then switch to requiring links via TDO003)
     "PLW0603", # Using the global statement to update _cache is discouraged
     "TD003", # Require links for TODOs # TODO: Re-enable when we disable FIX002
+
+    "UP007", # Allow legacy `Union[a, b]` and `Optional[a]` for Pydantic, until we drop Python 3.9 (Pydantic doesn't like it)
 ]
 fixable = ["ALL"]
 unfixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,8 +173,13 @@ unfixable = [
     "T201" # print() calls (avoid silent loss of code / log messages)
 ]
 line-length = 100
-extend-exclude = ["docs", "test", "tests"]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**" = [
+    # Rules to ignore in tests:
+    "ANN201", # Missing return type annotation for public function
+]
 
 [tool.ruff.isort]
 force-sort-within-sections = false


### PR DESCRIPTION
Previously these were fully ignored. This PR enables linting and formatting for the tests directory, and it provides a specific location within `pyproject.toml` where non-applicable rules can be ignored. For instance, all `test_...` functions return `None` so there's no need to require return type declarations.
