### PR TITLE
Chore: Add anonymous user ID in tracking events

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [autofix-command]
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 jobs:
   python-autofix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pydoc_preview.yml
+++ b/.github/workflows/pydoc_preview.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request: {}
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
 jobs:
   preview_docs:

--- a/.github/workflows/pydoc_publish.yml
+++ b/.github/workflows/pydoc_publish.yml
@@ -8,6 +8,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,6 +5,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -6,6 +6,9 @@ on:
       - main
     pull_request: {}
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 jobs:
   ruff-lint-check:
     name: Ruff Lint Check

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -13,6 +13,9 @@ on:
       - main
     pull_request: {}
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 jobs:
   pytest-fast:
     name: Pytest (Fast)

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/semantic_pr_check.yml
+++ b/.github/workflows/semantic_pr_check.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -105,7 +105,7 @@ def _setup_analytics() -> str | bool:
         _ANALYTICS_FILE.write_text(yaml.dump(new_file_contents))
     except Exception as ex:
         print(
-            f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {str(ex)}"
+            f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {ex!s}"
         )
     print(
         "Anonymous usage reporting is enabled. For more information or to opt out, please"

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -97,9 +97,6 @@ def _setup_analytics() -> str | bool:
 
     # File is missing or incomplete. Create a new one.
     anonymous_user_id = str(ulid.ULID())
-    new_file_contents = {
-        "anonymous_user_id": anonymous_user_id,
-    }
     try:
         _ANALYTICS_FILE.parent.mkdir(exist_ok=True, parents=True)
         _ANALYTICS_FILE.write_text(

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -121,7 +121,7 @@ def _setup_analytics() -> str | bool:
             "# This file is used by PyAirbyte to track anonymous usage statistics.\n"
             "# For more information or to opt out, please see\n"
             "# - https://docs.airbyte.io/pyairbyte/anonymized-usage-statistics\n"
-            f"anonymous_user_id: {anonymous_user_id}"
+            f"anonymous_user_id: {anonymous_user_id}\n"
         )
     except Exception as ex:
         print(f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {ex!s}")

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -76,7 +76,7 @@ DO_NOT_TRACK = "DO_NOT_TRACK"
 """Environment variable to opt-out of telemetry."""
 
 
-_ANALYTICS_FILE = Path.home() / ".airbyte" / "analytics.json"
+_ANALYTICS_FILE = Path.home() / ".airbyte" / "analytics.yml"
 _ANALYTICS_ID: str | bool | None = None
 
 
@@ -102,7 +102,12 @@ def _setup_analytics() -> str | bool:
     }
     try:
         _ANALYTICS_FILE.parent.mkdir(exist_ok=True, parents=True)
-        _ANALYTICS_FILE.write_text(yaml.dump(new_file_contents))
+        _ANALYTICS_FILE.write_text(
+            "# This file is used by PyAirbyte to track anonymous usage statistics.\n"
+            "# For more information or to opt out, please see\n"
+            "# - https://docs.airbyte.io/pyairbyte/anonymized-usage-statistics\n"
+            f"anonymous_user_id: {anonymous_user_id}"
+        )
     except Exception as ex:
         print(f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {ex!s}")
     print(

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -120,7 +120,7 @@ def _setup_analytics() -> str | bool:
         _ANALYTICS_FILE.write_text(
             "# This file is used by PyAirbyte to track anonymous usage statistics.\n"
             "# For more information or to opt out, please see\n"
-            "# - https://docs.airbyte.io/pyairbyte/anonymized-usage-statistics\n"
+            "# - https://docs.airbyte.com/operator-guides/telemetry\n"
             f"anonymous_user_id: {anonymous_user_id}\n"
         )
     except Exception as ex:

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -85,6 +85,7 @@ def _setup_analytics() -> str | bool:
 
     Return the anonymous user ID or False if the user has opted out.
     """
+    anonymous_user_id: str | None = None
     if _ENV_ANALYTICS_ID in os.environ:
         # If the user has chosen to override their analytics ID, use that value and
         # remember it for future invocations.

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -104,9 +104,7 @@ def _setup_analytics() -> str | bool:
         _ANALYTICS_FILE.parent.mkdir(exist_ok=True, parents=True)
         _ANALYTICS_FILE.write_text(yaml.dump(new_file_contents))
     except Exception as ex:
-        print(
-            f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {ex!s}"
-        )
+        print(f"Failed to create the analytics file at '{_ANALYTICS_FILE}'. " f"Error was: {ex!s}")
     print(
         "Anonymous usage reporting is enabled. For more information or to opt out, please"
         " see https://docs.airbyte.io/pyairbyte/anonymized-usage-statistics"

--- a/tests/unit_tests/test_anonymous_usage_stats.py
+++ b/tests/unit_tests/test_anonymous_usage_stats.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import itertools
 from contextlib import nullcontext as does_not_raise
 import json
+import os
+from pathlib import Path
 import re
-from unittest.mock import Mock, call, patch
+from unittest.mock import MagicMock, call, patch
 from freezegun import freeze_time
 
 import responses
@@ -16,8 +18,6 @@ import pytest
 from airbyte.version import get_version
 import airbyte as ab
 from airbyte._util import telemetry
-import requests
-import datetime
 
 
 @responses.activate
@@ -174,3 +174,45 @@ def test_tracking(
             }
         )
     ])
+
+def test_setup_analytics_existing_file(monkeypatch):
+    # Mock the environment variable and the analytics file
+    monkeypatch.setattr(Path, 'exists', lambda x: True)
+    monkeypatch.setattr(Path, 'read_text', lambda x: "anonymous_user_id: test_id\n")
+    assert telemetry._setup_analytics() == 'test_id'
+
+
+def test_setup_analytics_missing_file(monkeypatch):
+    """Mock the environment variable and the missing analytics file."""
+    monkeypatch.setenv(telemetry._ENV_ANALYTICS_ID, 'test_id')
+    monkeypatch.setattr(Path, 'exists', lambda x: False)
+
+    mock_path = MagicMock()
+    monkeypatch.setattr(Path, 'write_text', mock_path)
+
+    assert telemetry._setup_analytics() == 'test_id'
+
+    assert mock_path.call_count == 1
+
+
+def test_setup_analytics_corrupt_file(monkeypatch):
+    """Mock the environment variable and the missing analytics file."""
+    monkeypatch.setattr(Path, 'exists', lambda x: True)
+    monkeypatch.setattr(Path, 'read_text', lambda x: "not-a-valid ::: yaml file\n")
+
+    mock = MagicMock()
+    monkeypatch.setattr(Path, 'write_text', mock)
+
+    assert telemetry._setup_analytics()
+
+    assert mock.call_count == 1
+
+
+def test_get_analytics_id(monkeypatch):
+    # Mock the _ANALYTICS_ID variable
+    monkeypatch.setattr(telemetry, '_ANALYTICS_ID', 'test_id')
+
+    mock = MagicMock()
+    monkeypatch.setattr(Path, 'write_text', mock)
+
+    assert telemetry._get_analytics_id() == 'test_id'

--- a/tests/unit_tests/test_anonymous_usage_stats.py
+++ b/tests/unit_tests/test_anonymous_usage_stats.py
@@ -175,6 +175,7 @@ def test_tracking(
         )
     ])
 
+
 def test_setup_analytics_existing_file(monkeypatch):
     # Mock the environment variable and the analytics file
     monkeypatch.delenv(telemetry._ENV_ANALYTICS_ID, raising=False)
@@ -194,6 +195,20 @@ def test_setup_analytics_missing_file(monkeypatch):
     assert telemetry._setup_analytics() == 'test_id'
 
     assert mock_path.call_count == 1
+
+
+def test_setup_analytics_read_only_filesystem(monkeypatch):
+    """Mock the environment variable and simulate a read-only filesystem."""
+    monkeypatch.setenv(telemetry._ENV_ANALYTICS_ID, 'test_id')
+    monkeypatch.setattr(Path, 'exists', lambda x: False)
+
+    mock_write_text = MagicMock(side_effect=PermissionError("Read-only filesystem"))
+    monkeypatch.setattr(Path, 'write_text', mock_write_text)
+
+    # We should not raise an exception
+    assert telemetry._setup_analytics() == "test_id"
+
+    assert mock_write_text.call_count == 1
 
 
 def test_setup_analytics_corrupt_file(monkeypatch):

--- a/tests/unit_tests/test_anonymous_usage_stats.py
+++ b/tests/unit_tests/test_anonymous_usage_stats.py
@@ -177,6 +177,7 @@ def test_tracking(
 
 def test_setup_analytics_existing_file(monkeypatch):
     # Mock the environment variable and the analytics file
+    monkeypatch.delenv(telemetry._ENV_ANALYTICS_ID, raising=False)
     monkeypatch.setattr(Path, 'exists', lambda x: True)
     monkeypatch.setattr(Path, 'read_text', lambda x: "anonymous_user_id: test_id\n")
     assert telemetry._setup_analytics() == 'test_id'
@@ -197,6 +198,7 @@ def test_setup_analytics_missing_file(monkeypatch):
 
 def test_setup_analytics_corrupt_file(monkeypatch):
     """Mock the environment variable and the missing analytics file."""
+    monkeypatch.delenv(telemetry._ENV_ANALYTICS_ID, raising=False)
     monkeypatch.setattr(Path, 'exists', lambda x: True)
     monkeypatch.setattr(Path, 'read_text', lambda x: "not-a-valid ::: yaml file\n")
 
@@ -210,6 +212,7 @@ def test_setup_analytics_corrupt_file(monkeypatch):
 
 def test_get_analytics_id(monkeypatch):
     # Mock the _ANALYTICS_ID variable
+    monkeypatch.delenv(telemetry._ENV_ANALYTICS_ID, raising=False)
     monkeypatch.setattr(telemetry, '_ANALYTICS_ID', 'test_id')
 
     mock = MagicMock()


### PR DESCRIPTION
This is ready for review.

1. On first run, PyAirbyte will check for an existing analytics file.
2. If not found, and if `DO_NOT_TRACK` is not set, a new ID will be generated and will be stored in a yaml file at `~/.airbyte/analytics.yml`
3. If `AIRBYTE_ANALYTICS_ID` env var is set, then the provided ID will be used instead of a randomly generated one. In this case, the provided analytics ID will also be saved to the analytics file, overriding any previously set value.
4. This PR updates all of our CI jobs to pass in a (newly created) repository variable ([here](https://github.com/airbytehq/PyAirbyte/settings/variables/actions)), which contains a newly generated ULID that is specific to our CI flows.
