### PR TITLE
Chore: Add telemetry tracking flag for `langchain-airbyte`, fix incorrect telemetry URL in first-time execution

### DIFF
--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -36,6 +36,9 @@ def is_langchain() -> bool:
 
     This checks for the presence of the 'langchain-airbyte' package.
 
+    TODO: A more robust check would inspect the call stack or another flag to see if we are actually
+          being invoked via LangChain, vs being installed side-by-side.
+
     This is cached for performance reasons.
     """
     return "langchain-airbyte" in sys.modules

--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -41,7 +41,7 @@ def is_langchain() -> bool:
 
     This is cached for performance reasons.
     """
-    return "langchain-airbyte" in sys.modules
+    return "langchain_airbyte" in sys.modules
 
 
 @lru_cache

--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -31,6 +31,17 @@ def is_ci() -> bool:
 
 
 @lru_cache
+def is_langchain() -> bool:
+    """Return True if running in a Langchain environment.
+
+    This checks for the presence of the 'langchain-airbyte' package.
+
+    This is cached for performance reasons.
+    """
+    return "langchain-airbyte" in sys.modules
+
+
+@lru_cache
 def is_colab() -> bool:
     return bool(get_colab_release_version())
 

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -227,6 +227,7 @@ def one_way_hash(
 def get_env_flags() -> dict[str, Any]:
     flags: dict[str, bool | str] = {
         "CI": meta.is_ci(),
+        "LANGCHAIN": meta.is_langchain(),
         "NOTEBOOK_RUNTIME": (
             "GOOGLE_COLAB"
             if meta.is_colab()

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -104,8 +104,9 @@ def _setup_analytics() -> str | bool:
     if not _ANALYTICS_FILE.exists():
         # This is a one-time message to inform the user that we are tracking anonymous usage stats.
         print(
-            "Anonymous usage reporting is enabled. For more information or to opt out, please"
-            " see https://docs.airbyte.io/pyairbyte/anonymized-usage-statistics"
+            "Thank you for using PyAirbyte!\n"
+            "Anonymous usage reporting is currently enabled. For more information, please"
+            " see https://docs.airbyte.com/telemetry"
         )
 
     if _ANALYTICS_FILE.exists():


### PR DESCRIPTION
An overly simple implementation, admittedly, but a decent start that should work as expected in most cases.

Note: I haven't tested this yet. I may try manually testing in a notebook.
