### PR TITLE
Fix: Resolve bug in Colab notebook name detection

### DIFF
--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -76,12 +76,11 @@ def is_jupyter() -> bool:
 @lru_cache
 def get_notebook_name() -> str | None:
     if is_colab():
-        session_info = None
-        response = None
+        session_info: dict | None = None
         with suppress(Exception):
             response = requests.get(COLAB_SESSION_URL)
             if response.status_code == 200:  # noqa: PLR2004  # Magic number
-                session_info = response.json()
+                session_info = response.json()[0]
 
         if session_info and "name" in session_info:
             return session_info["name"]


### PR DESCRIPTION
This fixes a parsing issue which prevents detection of the notebook name in Colab environments.

(Auto-merge enabled.)