### PR TITLE
Feat: Always run config pre-validation

### DIFF
--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -262,10 +262,10 @@ class AirbyteConnectorMissingSpecError(AirbyteConnectorError):
 
 
 class AirbyteConnectorValidationFailedError(AirbyteConnectorError):
-    """Connector check failed."""
+    """Connector config validation failed."""
 
     guidance = (
-        "Please double-check your config or review the connector's logs for more information."
+        "Please double-check your config and review the validation errors for more information."
     )
 
 

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -261,6 +261,14 @@ class AirbyteConnectorMissingSpecError(AirbyteConnectorError):
     """Connector did not return a spec."""
 
 
+class AirbyteConnectorValidationFailedError(AirbyteConnectorError):
+    """Connector check failed."""
+
+    guidance = (
+        "Please double-check your config or review the connector's logs for more information."
+    )
+
+
 class AirbyteConnectorCheckFailedError(AirbyteConnectorError):
     """Connector check failed."""
 

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -566,7 +566,7 @@ class Source:
         streams: str | list[str] | None = None,
         write_strategy: str | WriteStrategy = WriteStrategy.AUTO,
         force_full_refresh: bool = False,
-        skip_validation: bool = True,
+        skip_validation: bool = False,
     ) -> ReadResult:
         """Read from the connector and write to the cache.
 


### PR DESCRIPTION
Resolves #126 

When connectors fail due to incorrect config, they often do not do so gracefully.

This update will make pre-validation of config the default behavior, which gives us more control over the user experience.