### PR TITLE
Feat: Allow incremental refresh with replace strategy

### DIFF
--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -589,7 +589,6 @@ class Source:
                     "Using `REPLACE` strategy without also setting `full_refresh_mode=True` "
                     "could result in data loss. "
                     "To silence this warning, use the following: "
-                    "`import warnings; "
                     'warnings.filterwarnings("ignore", '
                     'category="airbyte.warnings.PyAirbyteDataLossWarning")`'
                 ),

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -35,6 +35,7 @@ from airbyte.datasets._lazy import LazyDataset
 from airbyte.progress import progress
 from airbyte.results import ReadResult
 from airbyte.strategies import WriteStrategy
+from airbyte.warnings import PyAirbyteDataLossWarning
 
 
 if TYPE_CHECKING:
@@ -586,8 +587,13 @@ class Source:
             warnings.warn(
                 message=(
                     "Using `REPLACE` strategy without also setting `full_refresh_mode=True` "
-                    "could result in data loss."
+                    "could result in data loss. "
+                    "To silence this warning, use the following: "
+                    "`import warnings; "
+                    'warnings.filterwarnings("ignore", '
+                    'category="airbyte.warnings.PyAirbyteDataLossWarning")`'
                 ),
+                category=PyAirbyteDataLossWarning,
                 stacklevel=1,
             )
         if cache is None:

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -583,12 +583,12 @@ class Source:
                 must be True when using the "replace" strategy.
         """
         if write_strategy == WriteStrategy.REPLACE and not force_full_refresh:
-            raise exc.AirbyteLibInputError(
-                message="The replace strategy requires full refresh mode.",
-                context={
-                    "write_strategy": write_strategy,
-                    "force_full_refresh": force_full_refresh,
-                },
+            warnings.warn(
+                message=(
+                    "Using `REPLACE` strategy without also setting `full_refresh_mode=True` "
+                    "could result in data loss."
+                ),
+                stacklevel=1,
             )
         if cache is None:
             cache = get_default_cache()

--- a/airbyte/warnings.py
+++ b/airbyte/warnings.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Warnings for the PyAirbyte library."""
+
+from __future__ import annotations
+
+
+class PyAirbyteDataLossWarning(Warning):
+    """Warning for potential data loss.
+
+    Users can ignore this warning by running:
+    > warnings.filterwarnings("ignore", category="airbyte.exceptions.PyAirbyteDataLossWarning")
+    """


### PR DESCRIPTION
This is discouraged in normal situations, but there are valid use cases.

The use case brought up [in slack](https://airbytehq-team.slack.com/archives/C06FZ238P8W/p1710823746305029?thread_ts=1710320283.398979&cid=C06FZ238P8W) was an SQS queue - wherein we want to process only new records and not already-seen records.



