### PR TITLE
CI: Add 'no-creds' test in CI, fix "only on forks" condition of full pytest suite

### DIFF
--- a/.github/workflows/on-demand-pr-test-command.yml
+++ b/.github/workflows/on-demand-pr-test-command.yml
@@ -1,0 +1,67 @@
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number'
+        type: number
+        required: true
+
+jobs:
+  # This is copied from the `python_pytest.yml` file.
+  # Only the first two steps of the job are different, and they check out the PR's branch.
+  pytest-on-demand:
+    name: On-Demand PR Pytest (All, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    # Don't run on forks. Run on pushes to main, and on PRs that are not from forks.
+    strategy:
+      matrix:
+        python-version: [
+          '3.9',
+          '3.10',
+          '3.11',
+        ]
+        os: [
+          Ubuntu,
+          Windows,
+        ]
+      fail-fast: false
+
+    runs-on: "${{ matrix.os }}-latest"
+    steps:
+
+    # Custom steps to fetch the PR and checkout the code:
+
+    - name: Fetch PR
+      id: fetch-pr
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const pr = await github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: ${{ github.event.inputs.pr_number }}
+          });
+          return pr.data.head.sha;
+          result-encoding: string
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.fetch-pr.outputs.result }}
+
+    # Same as the `python_pytest.yml` file:
+
+    - name: Set up Poetry
+      uses: Gr1N/setup-poetry@v8
+      with:
+        poetry-version: "1.7.1"
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run Pytest
+      env:
+        GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      run: poetry run pytest

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -73,8 +73,10 @@ jobs:
 
   pytest:
     name: Pytest (All, Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    # Don't run on forks
-    if: github.repository_owner == 'airbytehq'
+    # Don't run on forks. Run on pushes to main, and on PRs that are not from forks.
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:
         python-version: [

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -65,7 +65,7 @@ jobs:
       run: poetry install
 
     # Job-specific step(s):
-    - name: Run Pytest (Fast Tests Only)
+    - name: Run Pytest (No-Creds)
       env:
         # Force this to an invalid value to ensure tests that no creds are required are run.
         GCP_GSM_CREDENTIALS: "no-creds"

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -81,3 +81,29 @@ jobs:
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       run: poetry run pytest
+
+  pytest-no-creds:
+    name: Pytest (No Creds)
+    runs-on: ubuntu-latest
+    steps:
+    # Common steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Poetry
+      uses: Gr1N/setup-poetry@v8
+      with:
+        poetry-version: "1.7.1"
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
+
+    # Job-specific step(s):
+    - name: Run Pytest (Fast Tests Only)
+      env:
+        # Force this to an invalid value to ensure tests that no creds are required are run.
+        GCP_GSM_CREDENTIALS: "no-creds"
+      run: poetry run pytest -m "not requires_creds"

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -2,10 +2,10 @@
 #
 # There are three jobs which run in parallel:
 # 1. pytest-fast: Run fast tests only, and fail fast so the dev knows asap if they broke something.
-# 1. pytest-no-creds: Run tests only if they don't require creds. The main use case is to run tests
+# 2. pytest-no-creds: Run tests only if they don't require creds. The main use case is to run tests
 #    on forks, where secrets are not available. We flush the GCP_GSM_CREDENTIALS env var to an
 #    invalid value to ensure that tests that require creds are not run.
-# 2. pytest: Run all tests, across multiple python versions.
+# 3. pytest: Run all tests, across multiple python versions.
 #
 # Note that pytest-fast also skips tests that require credentials, allowing it to run on forks.
 name: Run Tests

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -1,7 +1,10 @@
 # This workflow will run pytest.
 #
-# There are two jobs which run in parallel:
+# There are three jobs which run in parallel:
 # 1. pytest-fast: Run fast tests only, and fail fast so the dev knows asap if they broke something.
+# 1. pytest-no-creds: Run tests only if they don't require creds. The main use case is to run tests
+#    on forks, where secrets are not available. We flush the GCP_GSM_CREDENTIALS env var to an
+#    invalid value to ensure that tests that require creds are not run.
 # 2. pytest: Run all tests, across multiple python versions.
 #
 # Note that pytest-fast also skips tests that require credentials, allowing it to run on forks.
@@ -42,6 +45,32 @@ jobs:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       run: poetry run pytest -m "not slow and not requires_creds" --durations=5 --exitfirst
 
+  pytest-no-creds:
+    name: Pytest (No Creds)
+    runs-on: ubuntu-latest
+    steps:
+    # Common steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Poetry
+      uses: Gr1N/setup-poetry@v8
+      with:
+        poetry-version: "1.7.1"
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
+
+    # Job-specific step(s):
+    - name: Run Pytest (Fast Tests Only)
+      env:
+        # Force this to an invalid value to ensure tests that no creds are required are run.
+        GCP_GSM_CREDENTIALS: "no-creds"
+      run: poetry run pytest -m "not requires_creds"
+
   pytest:
     name: Pytest (All, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     # Don't run on forks
@@ -81,29 +110,3 @@ jobs:
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       run: poetry run pytest
-
-  pytest-no-creds:
-    name: Pytest (No Creds)
-    runs-on: ubuntu-latest
-    steps:
-    # Common steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
-      with:
-        poetry-version: "1.7.1"
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'poetry'
-    - name: Install dependencies
-      run: poetry install
-
-    # Job-specific step(s):
-    - name: Run Pytest (Fast Tests Only)
-      env:
-        # Force this to an invalid value to ensure tests that no creds are required are run.
-        GCP_GSM_CREDENTIALS: "no-creds"
-      run: poetry run pytest -m "not requires_creds"

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -20,6 +20,8 @@ jobs:
           commands: |
             autofix
             test-pr
+          static-args: |
+            pr=${{ github.event.issue.number }}
 
           # Only run for users with 'write' permission on the main repository
           permission: write

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v4
         with:
+          repository: ${{ github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pr
           commands: |
             autofix
+            test-pr
+
+          # Only run for users with 'write' permission on the main repository
+          permission: write

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
     inputs:
-      pr_number:
+      pr:
         description: 'PR Number'
         type: number
         required: true
@@ -38,7 +38,7 @@ jobs:
           const pr = await github.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: ${{ github.event.inputs.pr_number }}
+            pull_number: ${{ github.event.inputs.pr }}
           });
           return pr.data.head.sha;
           result-encoding: string


### PR DESCRIPTION
Add a CI test to ensure that all tests that require creds are correctly marked with the `pytest.mark.requires_creds` decorator. Otherwise, those tests will fail in this new workflow.