### PR TITLE
Fix: Add schema in Postgres Cache to swapping method

### DIFF
--- a/airbyte/_processors/sql/base.py
+++ b/airbyte/_processors/sql/base.py
@@ -794,9 +794,9 @@ class SqlProcessorBase(RecordProcessor):
         deletion_name = f"{final_table_name}_deleteme"
         commands = "\n".join(
             [
-                f"ALTER TABLE {self._fully_qualified(final_table_name)} RENAME"
+                f"ALTER TABLE {self._fully_qualified(final_table_name)} RENAME "
                 f"TO {deletion_name};",
-                f"ALTER TABLE {self._fully_qualified(temp_table_name)} RENAME"
+                f"ALTER TABLE {self._fully_qualified(temp_table_name)} RENAME "
                 f"TO {final_table_name};",
                 f"DROP TABLE {self._fully_qualified(deletion_name)};",
             ]

--- a/airbyte/_processors/sql/base.py
+++ b/airbyte/_processors/sql/base.py
@@ -794,9 +794,11 @@ class SqlProcessorBase(RecordProcessor):
         deletion_name = f"{final_table_name}_deleteme"
         commands = "\n".join(
             [
-                f"ALTER TABLE {final_table_name} RENAME TO {deletion_name};",
-                f"ALTER TABLE {temp_table_name} RENAME TO {final_table_name};",
-                f"DROP TABLE {deletion_name};",
+                f"ALTER TABLE {self._fully_qualified(final_table_name)} RENAME"
+                f"TO {deletion_name};",
+                f"ALTER TABLE {self._fully_qualified(temp_table_name)} RENAME"
+                f"TO {final_table_name};",
+                f"DROP TABLE {self._fully_qualified(deletion_name)};",
             ]
         )
         self._execute_sql(commands)


### PR DESCRIPTION
Fixes #148 

I dug a bit around and found out, that the Problem was, that the schema name was missing in the final swaping. I just added the method used at other places to add the schema.

I separated the statements in several lines so that i won't go over the defined Line Limit from 100.

Tests were all successful except for the integration Tests of some caches, since i don't have access to them.
![image](https://github.com/airbytehq/PyAirbyte/assets/35485536/9ce5fa25-672d-42cb-a918-999237a42727)

Also tested the fix manuallay with the pokeapi source and the linkedinpages source mentioned in #148. Everything worked and data was in the final tables.