### PR TITLE
Docs: Move `StreamRecord` class to public module, add docs

### DIFF
--- a/airbyte/__init__.py
+++ b/airbyte/__init__.py
@@ -12,6 +12,7 @@ from airbyte.caches.bigquery import BigQueryCache
 from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import get_default_cache, new_local_cache
 from airbyte.datasets import CachedDataset
+from airbyte.records import StreamRecord
 from airbyte.results import ReadResult
 from airbyte.secrets import SecretSource, get_secret
 from airbyte.sources import registry
@@ -26,6 +27,7 @@ __all__ = [
     "datasets",
     "documents",
     "exceptions",
+    "records",
     "registry",
     "results",
     "secrets",
@@ -43,6 +45,7 @@ __all__ = [
     "ReadResult",
     "SecretSource",
     "Source",
+    "StreamRecord",
 ]
 
 __docformat__ = "google"

--- a/airbyte/_processors/file/base.py
+++ b/airbyte/_processors/file/base.py
@@ -12,8 +12,9 @@ import ulid
 
 from airbyte import exceptions as exc
 from airbyte._batch_handles import BatchHandle
-from airbyte._util.name_normalizers import LowerCaseNormalizer, StreamRecord
+from airbyte._util.name_normalizers import LowerCaseNormalizer
 from airbyte.progress import progress
+from airbyte.records import StreamRecord
 
 
 if TYPE_CHECKING:

--- a/airbyte/_processors/file/jsonl.py
+++ b/airbyte/_processors/file/jsonl.py
@@ -16,7 +16,7 @@ from airbyte._processors.file.base import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from airbyte._util.name_normalizers import StreamRecord
+    from airbyte.records import StreamRecord
 
 
 class JsonlWriter(FileWriterBase):

--- a/airbyte/_util/name_normalizers.py
+++ b/airbyte/_util/name_normalizers.py
@@ -4,26 +4,11 @@
 from __future__ import annotations
 
 import abc
-from datetime import datetime
-from typing import TYPE_CHECKING, Any
-
-import pytz
-import ulid
-
-from airbyte.constants import (
-    AB_EXTRACTED_AT_COLUMN,
-    AB_INTERNAL_COLUMNS,
-    AB_META_COLUMN,
-    AB_RAW_ID_COLUMN,
-)
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    from airbyte_protocol.models import (
-        AirbyteRecordMessage,
-    )
 
 
 class NameNormalizerBase(abc.ABC):
@@ -65,179 +50,8 @@ class LowerCaseNormalizer(NameNormalizerBase):
         return name.lower().replace(" ", "_").replace("-", "_")
 
 
-class StreamRecord(dict[str, Any]):
-    """The StreamRecord class is a case-aware, case-insensitive dictionary implementation.
-
-    It has these behaviors:
-    - When a key is retrieved, deleted, or checked for existence, it is always checked in a
-      case-insensitive manner.
-    - The original case is stored in a separate dictionary, so that the original case can be
-      retrieved when needed.
-
-    This behavior mirrors how a case-aware, case-insensitive SQL database would handle column
-    references.
-
-    There are two ways this class can store keys internally:
-    - If normalize_keys is True, the keys are normalized using the given normalizer.
-    - If normalize_keys is False, the original case of the keys is stored.
-
-    In regards to missing values, the dictionary accepts an 'expected_keys' input. When set, the
-    dictionary will be initialized with the given keys. If a key is not found in the input data, it
-    will be initialized with a value of None. When provided, the 'expected_keys' input will also
-    determine the original case of the keys.
-    """
-
-    def _display_case(self, key: str) -> str:
-        """Return the original case of the key."""
-        return self._pretty_case_keys[self._normalizer.normalize(key)]
-
-    def _index_case(self, key: str) -> str:
-        """Return the internal case of the key.
-
-        If normalize_keys is True, return the normalized key.
-        Otherwise, return the original case of the key.
-        """
-        if self._normalize_keys:
-            return self._normalizer.normalize(key)
-
-        return self._display_case(key)
-
-    @classmethod
-    def from_record_message(
-        cls,
-        record_message: AirbyteRecordMessage,
-        *,
-        prune_extra_fields: bool,
-        normalize_keys: bool = True,
-        normalizer: type[NameNormalizerBase] | None = None,
-        expected_keys: list[str] | None = None,
-    ) -> StreamRecord:
-        """Return a StreamRecord from a RecordMessage."""
-        data_dict: dict[str, Any] = record_message.data.copy()
-        data_dict[AB_RAW_ID_COLUMN] = str(ulid.ULID())
-        data_dict[AB_EXTRACTED_AT_COLUMN] = datetime.fromtimestamp(
-            record_message.emitted_at / 1000, tz=pytz.utc
-        )
-        data_dict[AB_META_COLUMN] = {}
-
-        return cls(
-            from_dict=data_dict,
-            prune_extra_fields=prune_extra_fields,
-            normalize_keys=normalize_keys,
-            normalizer=normalizer,
-            expected_keys=expected_keys,
-        )
-
-    def __init__(
-        self,
-        from_dict: dict,
-        *,
-        prune_extra_fields: bool,
-        normalize_keys: bool = True,
-        normalizer: type[NameNormalizerBase] | None = None,
-        expected_keys: list[str] | None = None,
-    ) -> None:
-        """Initialize the dictionary with the given data.
-
-        Args:
-        - normalize_keys: If `True`, the keys will be normalized using the given normalizer.
-        - expected_keys: If provided, the dictionary will be initialized with these given keys.
-        - expected_keys: If provided and `prune_extra_fields` is True, then unexpected fields
-          will be removed. This option is ignored if `expected_keys` is not provided.
-        """
-        # If no normalizer is provided, use LowerCaseNormalizer.
-        self._normalize_keys = normalize_keys
-        self._normalizer: type[NameNormalizerBase] = normalizer or LowerCaseNormalizer
-
-        # If no expected keys are provided, use all keys from the input dictionary.
-        if not expected_keys:
-            expected_keys = list(from_dict.keys())
-            prune_extra_fields = False  # No expected keys provided.
-        else:
-            expected_keys = list(expected_keys)
-
-        for internal_col in AB_INTERNAL_COLUMNS:
-            if internal_col not in expected_keys:
-                expected_keys.append(internal_col)
-
-        # Store a lookup from normalized keys to pretty cased (originally cased) keys.
-        self._pretty_case_keys: dict[str, str] = {
-            self._normalizer.normalize(pretty_case.lower()): pretty_case
-            for pretty_case in expected_keys
-        }
-
-        if normalize_keys:
-            index_keys = [self._normalizer.normalize(key) for key in expected_keys]
-        else:
-            index_keys = expected_keys
-
-        self.update({k: None for k in index_keys})  # Start by initializing all values to None
-        for k, v in from_dict.items():
-            index_cased_key = self._index_case(k)
-            if prune_extra_fields and index_cased_key not in index_keys:
-                # Dropping undeclared field
-                continue
-
-            self[index_cased_key] = v
-
-    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
-        if super().__contains__(key):
-            return super().__getitem__(key)
-
-        if super().__contains__(self._index_case(key)):
-            return super().__getitem__(self._index_case(key))
-
-        raise KeyError(key)
-
-    def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
-        if super().__contains__(key):
-            super().__setitem__(key, value)
-            return
-
-        if super().__contains__(self._index_case(key)):
-            super().__setitem__(self._index_case(key), value)
-            return
-
-        # Store the pretty cased (originally cased) key:
-        self._pretty_case_keys[self._normalizer.normalize(key)] = key
-
-        # Store the data with the normalized key:
-        super().__setitem__(self._index_case(key), value)
-
-    def __delitem__(self, key: str) -> None:
-        if super().__contains__(key):
-            super().__delitem__(key)
-            return
-
-        if super().__contains__(self._index_case(key)):
-            super().__delitem__(self._index_case(key))
-            return
-
-        raise KeyError(key)
-
-    def __contains__(self, key: object) -> bool:
-        assert isinstance(key, str), "Key must be a string."
-        return super().__contains__(key) or super().__contains__(self._index_case(key))
-
-    def __iter__(self) -> Any:  # noqa: ANN401
-        return iter(super().__iter__())
-
-    def __len__(self) -> int:
-        return super().__len__()
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, StreamRecord):
-            return dict(self) == dict(other)
-
-        if isinstance(other, dict):
-            return {k.lower(): v for k, v in self.items()} == {
-                k.lower(): v for k, v in other.items()
-            }
-        return False
-
 
 __all__ = [
     "NameNormalizerBase",
     "LowerCaseNormalizer",
-    "StreamRecord",
 ]

--- a/airbyte/_util/name_normalizers.py
+++ b/airbyte/_util/name_normalizers.py
@@ -50,7 +50,6 @@ class LowerCaseNormalizer(NameNormalizerBase):
         return name.lower().replace(" ", "_").replace("-", "_")
 
 
-
 __all__ = [
     "NameNormalizerBase",
     "LowerCaseNormalizer",

--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""PyAirbyte Records module.
+
+## Understanding record handling in PyAirbyte
+
+PyAirbyte models record handling after Airbyte's "Destination V2" or "Dv2" record handling. This
+includes the following implementation details:
+
+### Field Name Normalization
+
+1. PyAirbyte normalizes top-level keys to lowercase.
+2. PyAirbyte does not normalize nested keys on sub-properties.
+
+### Table Name Normalization
+
+Similar to column handling, PyAirbyte normalizes table names to the lowercase version of the stream
+name and may remove or normalize special characters.
+
+### Airbyte-Managed Metadata Columns
+
+PyAirbyte adds the following columns to every record:
+
+- `ab_raw_id`: A unique identifier for the record.
+- `ab_extracted_at`: The time the record was extracted.
+- `ab_meta`: A dictionary of extra metadata about the record.
+
+The names of these columns are included in the `airbyte.constants` module for programmatic
+reference.
+
+## Module Overview
+
+This module contains the StreamRecord class, which is a case-aware, case-insensitive dictionary.
+It is used to store records in PyAirbyte. Since it is subclassed from `dict`, it can be used like a
+normal dictionary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import pytz
+import ulid
+
+from airbyte._util.name_normalizers import LowerCaseNormalizer, NameNormalizerBase
+from airbyte.constants import (
+    AB_EXTRACTED_AT_COLUMN,
+    AB_INTERNAL_COLUMNS,
+    AB_META_COLUMN,
+    AB_RAW_ID_COLUMN,
+)
+
+
+if TYPE_CHECKING:
+    from airbyte_protocol.models import (
+        AirbyteRecordMessage,
+    )
+
+
+class StreamRecord(dict[str, Any]):
+    """The StreamRecord class is a case-aware, case-insensitive dictionary implementation.
+
+    It has these behaviors:
+    - When a key is retrieved, deleted, or checked for existence, it is always checked in a
+      case-insensitive manner.
+    - The original case is stored in a separate dictionary, so that the original case can be
+      retrieved when needed.
+
+    This behavior mirrors how a case-aware, case-insensitive SQL database would handle column
+    references.
+
+    There are two ways this class can store keys internally:
+    - If normalize_keys is True, the keys are normalized using the given normalizer.
+    - If normalize_keys is False, the original case of the keys is stored.
+
+    In regards to missing values, the dictionary accepts an 'expected_keys' input. When set, the
+    dictionary will be initialized with the given keys. If a key is not found in the input data, it
+    will be initialized with a value of None. When provided, the 'expected_keys' input will also
+    determine the original case of the keys.
+    """
+
+    def _display_case(self, key: str) -> str:
+        """Return the original case of the key."""
+        return self._pretty_case_keys[self._normalizer.normalize(key)]
+
+    def _index_case(self, key: str) -> str:
+        """Return the internal case of the key.
+
+        If normalize_keys is True, return the normalized key.
+        Otherwise, return the original case of the key.
+        """
+        if self._normalize_keys:
+            return self._normalizer.normalize(key)
+
+        return self._display_case(key)
+
+    @classmethod
+    def from_record_message(
+        cls,
+        record_message: AirbyteRecordMessage,
+        *,
+        prune_extra_fields: bool,
+        normalize_keys: bool = True,
+        normalizer: type[NameNormalizerBase] | None = None,
+        expected_keys: list[str] | None = None,
+    ) -> StreamRecord:
+        """Return a StreamRecord from a RecordMessage."""
+        data_dict: dict[str, Any] = record_message.data.copy()
+        data_dict[AB_RAW_ID_COLUMN] = str(ulid.ULID())
+        data_dict[AB_EXTRACTED_AT_COLUMN] = datetime.fromtimestamp(
+            record_message.emitted_at / 1000, tz=pytz.utc
+        )
+        data_dict[AB_META_COLUMN] = {}
+
+        return cls(
+            from_dict=data_dict,
+            prune_extra_fields=prune_extra_fields,
+            normalize_keys=normalize_keys,
+            normalizer=normalizer,
+            expected_keys=expected_keys,
+        )
+
+    def __init__(
+        self,
+        from_dict: dict,
+        *,
+        prune_extra_fields: bool,
+        normalize_keys: bool = True,
+        normalizer: type[NameNormalizerBase] | None = None,
+        expected_keys: list[str] | None = None,
+    ) -> None:
+        """Initialize the dictionary with the given data.
+
+        Args:
+        - normalize_keys: If `True`, the keys will be normalized using the given normalizer.
+        - expected_keys: If provided, the dictionary will be initialized with these given keys.
+        - expected_keys: If provided and `prune_extra_fields` is True, then unexpected fields
+          will be removed. This option is ignored if `expected_keys` is not provided.
+        """
+        # If no normalizer is provided, use LowerCaseNormalizer.
+        self._normalize_keys = normalize_keys
+        self._normalizer: type[NameNormalizerBase] = normalizer or LowerCaseNormalizer
+
+        # If no expected keys are provided, use all keys from the input dictionary.
+        if not expected_keys:
+            expected_keys = list(from_dict.keys())
+            prune_extra_fields = False  # No expected keys provided.
+        else:
+            expected_keys = list(expected_keys)
+
+        for internal_col in AB_INTERNAL_COLUMNS:
+            if internal_col not in expected_keys:
+                expected_keys.append(internal_col)
+
+        # Store a lookup from normalized keys to pretty cased (originally cased) keys.
+        self._pretty_case_keys: dict[str, str] = {
+            self._normalizer.normalize(pretty_case.lower()): pretty_case
+            for pretty_case in expected_keys
+        }
+
+        if normalize_keys:
+            index_keys = [self._normalizer.normalize(key) for key in expected_keys]
+        else:
+            index_keys = expected_keys
+
+        self.update({k: None for k in index_keys})  # Start by initializing all values to None
+        for k, v in from_dict.items():
+            index_cased_key = self._index_case(k)
+            if prune_extra_fields and index_cased_key not in index_keys:
+                # Dropping undeclared field
+                continue
+
+            self[index_cased_key] = v
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        if super().__contains__(key):
+            return super().__getitem__(key)
+
+        if super().__contains__(self._index_case(key)):
+            return super().__getitem__(self._index_case(key))
+
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
+        if super().__contains__(key):
+            super().__setitem__(key, value)
+            return
+
+        if super().__contains__(self._index_case(key)):
+            super().__setitem__(self._index_case(key), value)
+            return
+
+        # Store the pretty cased (originally cased) key:
+        self._pretty_case_keys[self._normalizer.normalize(key)] = key
+
+        # Store the data with the normalized key:
+        super().__setitem__(self._index_case(key), value)
+
+    def __delitem__(self, key: str) -> None:
+        if super().__contains__(key):
+            super().__delitem__(key)
+            return
+
+        if super().__contains__(self._index_case(key)):
+            super().__delitem__(self._index_case(key))
+            return
+
+        raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        assert isinstance(key, str), "Key must be a string."
+        return super().__contains__(key) or super().__contains__(self._index_case(key))
+
+    def __iter__(self) -> Any:  # noqa: ANN401
+        return iter(super().__iter__())
+
+    def __len__(self) -> int:
+        return super().__len__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, StreamRecord):
+            return dict(self) == dict(other)
+
+        if isinstance(other, dict):
+            return {k.lower(): v for k, v in self.items()} == {
+                k.lower(): v for k, v in other.items()
+            }
+        return False

--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -8,8 +8,32 @@ includes the below implementation details.
 
 ### Field Name Normalization
 
-1. PyAirbyte normalizes top-level record keys to lowercase.
+1. PyAirbyte normalizes top-level record keys to lowercase, replacing spaces and hyphens with
+   underscores.
 2. PyAirbyte does not normalize nested keys on sub-properties.
+
+For example, the following record:
+
+```json
+{
+
+    "My-Field": "value",
+    "Nested": {
+        "MySubField": "value"
+    }
+}
+```
+
+Would be normalized to:
+
+```json
+{
+    "my_field": "value",
+    "nested": {
+        "MySubField": "value"
+    }
+}
+```
 
 ### Table Name Normalization
 

--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -3,12 +3,12 @@
 
 ## Understanding record handling in PyAirbyte
 
-PyAirbyte models record handling after Airbyte's "Destination V2" or "Dv2" record handling. This
-includes the following implementation details:
+PyAirbyte models record handling after Airbyte's "Destination V2" ("Dv2") record handling. This
+includes the below implementation details.
 
 ### Field Name Normalization
 
-1. PyAirbyte normalizes top-level keys to lowercase.
+1. PyAirbyte normalizes top-level record keys to lowercase.
 2. PyAirbyte does not normalize nested keys on sub-properties.
 
 ### Table Name Normalization
@@ -32,6 +32,7 @@ reference.
 This module contains the StreamRecord class, which is a case-aware, case-insensitive dictionary.
 It is used to store records in PyAirbyte. Since it is subclassed from `dict`, it can be used like a
 normal dictionary.
+
 """
 
 from __future__ import annotations

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -30,7 +30,6 @@ from airbyte_protocol.models import (
 )
 
 from airbyte import exceptions as exc
-from airbyte._util.name_normalizers import StreamRecord
 from airbyte._util.telemetry import (
     EventState,
     EventType,
@@ -41,6 +40,7 @@ from airbyte._util.telemetry import (
 from airbyte.caches.util import get_default_cache
 from airbyte.datasets._lazy import LazyDataset
 from airbyte.progress import progress
+from airbyte.records import StreamRecord
 from airbyte.results import ReadResult
 from airbyte.strategies import WriteStrategy
 from airbyte.warnings import PyAirbyteDataLossWarning

--- a/tests/unit_tests/test_text_normalization.py
+++ b/tests/unit_tests/test_text_normalization.py
@@ -1,7 +1,7 @@
 from math import exp
 import pytest
-from airbyte._util.name_normalizers import StreamRecord, LowerCaseNormalizer
 from airbyte.constants import AB_INTERNAL_COLUMNS
+from airbyte.records import StreamRecord
 
 def test_case_insensitive_dict() -> None:
     # Initialize a StreamRecord


### PR DESCRIPTION
Following from:

- #14 

This PR simply moves the class to a public module and adds user-facing reference documentation.