### PR TITLE
CI: Skip lint checks in pytest when redundant

### DIFF
--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -43,7 +43,10 @@ jobs:
     - name: Run Pytest (Fast Tests Only)
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      run: poetry run pytest -m "not slow and not requires_creds" --durations=5 --exitfirst
+      run: >
+        poetry run pytest -m
+        "not slow and not requires_creds and not linting"
+        --durations=5 --exitfirst
 
   pytest-no-creds:
     name: Pytest (No Creds)
@@ -111,4 +114,4 @@ jobs:
     - name: Run Pytest
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      run: poetry run pytest
+      run: poetry run pytest -m "not linting"

--- a/tests/lint_tests/test_mypy.py
+++ b/tests/lint_tests/test_mypy.py
@@ -6,6 +6,7 @@ import subprocess
 import pytest
 
 
+@pytest.mark.linting
 def test_mypy_typing():
     # Run the check command
     check_result = subprocess.run(

--- a/tests/lint_tests/test_ruff.py
+++ b/tests/lint_tests/test_ruff.py
@@ -6,6 +6,7 @@ import subprocess
 import pytest
 
 
+@pytest.mark.linting
 def test_ruff_linting():
     # Run the check command
     check_result = subprocess.run(
@@ -22,6 +23,7 @@ def test_ruff_linting():
     )
 
 
+@pytest.mark.linting
 def test_ruff_linting_fixable():
     # Run the check command
     fix_diff_result = subprocess.run(
@@ -38,6 +40,7 @@ def test_ruff_linting_fixable():
     )
 
 
+@pytest.mark.linting
 def test_ruff_format():
     # Define the command to run Ruff
     command = ["poetry", "run", "ruff", "format", "--check", "--diff"]


### PR DESCRIPTION
We have lint checks in pytest so that developers can see in one place whether their code is ready to push.

However, in CI, we have a dedicated lint job and it is redundant to show these results also in the pytest jobs.

If there is a lint/format problem, but if all other tests are successful, this change will show pytest tests as 'green' and only the lint/format jobs will show as red. This helps the developer know what is needed at-a-glance, without having to jump into pytest logs when all other tests are fine.

