### PR TITLE
Feat: Add singular `fetch_connector_secret()` for `GoogleGSMSecretManager`, fix GSM edge cases, and add CI tests

### DIFF
--- a/airbyte/secrets/google_gsm.py
+++ b/airbyte/secrets/google_gsm.py
@@ -31,13 +31,11 @@ read_result = source.read()
 
 from __future__ import annotations
 
-from cProfile import label
 import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from duckdb import project
 from google.cloud import secretmanager_v1 as secretmanager
 
 from airbyte import exceptions as exc

--- a/airbyte/secrets/google_gsm.py
+++ b/airbyte/secrets/google_gsm.py
@@ -130,10 +130,16 @@ class GoogleGSMSecretManager(CustomSecretManager):
 
     def get_secret(self, secret_name: str) -> SecretString | None:
         """Get a named secret from Google Colab user secrets."""
+        full_name = secret_name
+        if "projects/" not in full_name:
+            # This is not yet fully qualified
+            full_name = f"projects/{self.project}/secrets/{secret_name}/versions/latest"
+
+        if "/versions/" not in full_name:
+            full_name += "/versions/latest"
+
         return SecretString(
-            self.secret_client.access_secret_version(
-                name=f"projects/{self.project}/secrets/{secret_name}/versions/latest"
-            ).payload.data.decode("UTF-8")
+            self.secret_client.access_secret_version(name=full_name).payload.data.decode("UTF-8")
         )
 
     def fetch_secrets(
@@ -155,11 +161,10 @@ class GoogleGSMSecretManager(CustomSecretManager):
             Iterable[SecretHandle]: An iterable of `SecretHandle` objects for the matching secrets.
         """
         gsm_secrets: ListSecretsPager = self.secret_client.list_secrets(
-            secretmanager.ListSecretsRequest(
-                request={
-                    "filter": filter_string,
-                }
-            )
+            request=secretmanager.ListSecretsRequest(
+                filter=filter_string,
+                parent=f"projects/{self.project}",
+            ),
         )
 
         return [

--- a/tests/integration_tests/secrets/test_gsm_secrets.py
+++ b/tests/integration_tests/secrets/test_gsm_secrets.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Tests for the GSM secrets manager."""
+from __future__ import annotations
+
+from airbyte.secrets.google_gsm import GoogleGSMSecretManager
+
+
+def test_get_gsm_secret(ci_secret_manager: GoogleGSMSecretManager) -> dict:
+    assert ci_secret_manager.get_secret(
+        "SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS",
+    ).parse_json()
+
+
+def test_get_gsm_secrets_with_filter(ci_secret_manager: GoogleGSMSecretManager) -> None:
+    """Test fetching connector secrets."""
+    secrets = ci_secret_manager.fetch_secrets(
+        filter_string="labels.connector=source-bigquery",
+    )
+    assert secrets is not None
+    secrets_list = list(secrets)
+    assert len(secrets_list) > 0
+    assert secrets_list[0].parse_json() is not None
+
+
+def test_get_gsm_secrets_by_label(ci_secret_manager: GoogleGSMSecretManager) -> None:
+    """Test fetching connector secrets."""
+    secrets = ci_secret_manager.fetch_secrets_by_label(
+        label_key="connector",
+        label_value="source-salesforce",
+    )
+    assert secrets is not None
+    secrets_list = list(secrets)
+    assert len(secrets_list) > 0
+    assert secrets_list[0].parse_json() is not None
+
+
+def test_get_connector_secrets(ci_secret_manager: GoogleGSMSecretManager) -> None:
+    """Test fetching connector secrets."""
+    secrets = ci_secret_manager.fetch_connector_secrets(
+        "source-salesforce"
+    )
+    assert secrets is not None
+    secrets_list = list(secrets)
+    assert len(secrets_list) > 0
+    assert secrets_list[0].parse_json() is not None

--- a/tests/integration_tests/secrets/test_gsm_secrets.py
+++ b/tests/integration_tests/secrets/test_gsm_secrets.py
@@ -2,6 +2,7 @@
 """Tests for the GSM secrets manager."""
 from __future__ import annotations
 
+from airbyte.secrets.base import SecretHandle
 from airbyte.secrets.google_gsm import GoogleGSMSecretManager
 
 
@@ -19,7 +20,7 @@ def test_get_gsm_secrets_with_filter(ci_secret_manager: GoogleGSMSecretManager) 
     assert secrets is not None
     secrets_list = list(secrets)
     assert len(secrets_list) > 0
-    assert secrets_list[0].parse_json() is not None
+    assert secrets_list[0].get_value().is_json()
 
 
 def test_get_gsm_secrets_by_label(ci_secret_manager: GoogleGSMSecretManager) -> None:
@@ -31,7 +32,7 @@ def test_get_gsm_secrets_by_label(ci_secret_manager: GoogleGSMSecretManager) -> 
     assert secrets is not None
     secrets_list = list(secrets)
     assert len(secrets_list) > 0
-    assert secrets_list[0].parse_json() is not None
+    assert secrets_list[0].get_value().is_json()
 
 
 def test_get_connector_secrets(ci_secret_manager: GoogleGSMSecretManager) -> None:
@@ -42,4 +43,14 @@ def test_get_connector_secrets(ci_secret_manager: GoogleGSMSecretManager) -> Non
     assert secrets is not None
     secrets_list = list(secrets)
     assert len(secrets_list) > 0
-    assert secrets_list[0].parse_json() is not None
+    assert secrets_list[0].get_value().is_json()
+
+
+def test_first_connector_secret(ci_secret_manager: GoogleGSMSecretManager) -> None:
+    """Test fetching connector secrets."""
+    secret = ci_secret_manager.fetch_connector_secret(
+        "source-salesforce"
+    )
+    assert secret is not None
+    assert isinstance(secret, SecretHandle)
+    assert secret.get_value().is_json()


### PR DESCRIPTION
We were lacking integration tests for the GSM-based secret fetching (by label and connector).

This PR adds needed integration tests and fixes bugs that otherwise prevent successful retrieval.

This also adds a singular `fetch_connector_secret()` which just gives the first secret that would be returned by `fetch_connector_secrets()`.