### PR TITLE
Fix: Expand default decimal size to `(38, 9)` to resolve issues with large number values

### DIFF
--- a/airbyte/_processors/sql/duckdb.py
+++ b/airbyte/_processors/sql/duckdb.py
@@ -94,12 +94,13 @@ class DuckDBSqlProcessor(SqlProcessorBase):
             "\n, ".join(
                 [
                     self._quote_identifier(self.normalizer.normalize(prop_name))
-                    + ": "
+                    + ': "'
                     + str(
                         self._get_sql_column_definitions(stream_name)[
                             self.normalizer.normalize(prop_name)
                         ]
                     )
+                    + '"'
                     for prop_name in columns_list
                 ]
             ),

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -13,7 +13,7 @@ from rich import print
 CONVERSION_MAP = {
     "string": sqlalchemy.types.VARCHAR,
     "integer": sqlalchemy.types.BIGINT,
-    "number": sqlalchemy.types.DECIMAL(38, 10),
+    "number": sqlalchemy.types.DECIMAL(38, 9),
     "boolean": sqlalchemy.types.BOOLEAN,
     "date": sqlalchemy.types.DATE,
     "timestamp_with_timezone": sqlalchemy.types.TIMESTAMP,

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -13,7 +13,7 @@ from rich import print
 CONVERSION_MAP = {
     "string": sqlalchemy.types.VARCHAR,
     "integer": sqlalchemy.types.BIGINT,
-    "number": sqlalchemy.types.DECIMAL,
+    "number": sqlalchemy.types.DECIMAL(38, 10),
     "boolean": sqlalchemy.types.BOOLEAN,
     "date": sqlalchemy.types.DATE,
     "timestamp_with_timezone": sqlalchemy.types.TIMESTAMP,
@@ -116,11 +116,18 @@ class SQLTypeConverter:
         """Convert a value to a SQL type."""
         try:
             airbyte_type, _ = _get_airbyte_type(json_schema_property_def)
-            return self.conversion_map[airbyte_type]()
+            sql_type = self.conversion_map[airbyte_type]
         except SQLTypeConversionError:
             print(f"Could not determine airbyte type from JSON schema: {json_schema_property_def}")
         except KeyError:
             print(f"Could not find SQL type for airbyte type: {airbyte_type}")
+        else:
+            # No exceptions were raised, so we can return the SQL type.
+            if isinstance(sql_type, type):
+                # This is a class. Call its constructor.
+                sql_type = sql_type()
+
+            return sql_type
 
         json_schema_type = json_schema_property_def.get("type", None)
         json_schema_format = json_schema_property_def.get("format", None)

--- a/tests/integration_tests/fixtures/source-test/source_test/run.py
+++ b/tests/integration_tests/fixtures/source-test/source_test/run.py
@@ -33,6 +33,7 @@ sample_catalog = {
                         "Column1": {"type": "string"},
                         "Column2": {"type": "number"},
                         "empty_column": {"type": "string"},
+                        "big_number": {"type": "number"},
                     },
                 },
             },
@@ -102,7 +103,12 @@ sample_record2_stream1 = {
 sample_record_stream2 = {
     "type": "RECORD",
     "record": {
-        "data": {"Column1": "value1", "Column2": 1},
+        "data": {
+            "Column1": "value1",
+            "Column2": 1,
+            "empty_column": None,
+            "big_number": 1234567890123456,
+        },
         "stream": "stream2",
         "emitted_at": 1704067200,
     },

--- a/tests/integration_tests/test_source_test_fixture.py
+++ b/tests/integration_tests/test_source_test_fixture.py
@@ -113,7 +113,12 @@ def expected_test_stream_data() -> dict[str, list[dict[str, str | int]]]:
             {"column1": "value2", "column2": 2},
         ],
         "stream2": [
-            {"column1": "value1", "column2": 1, "empty_column": None},
+            {
+                "column1": "value1",
+                "column2": 1,
+                "empty_column": None,
+                "big_number": 1234567890123456
+            },
         ],
         "always-empty-stream": [],
     }


### PR DESCRIPTION
Resolves: #177

- #177

~~Note: The choice of `DECIMAL(38, 10)` is somewhat arbitrary, but it forces use of a large internal (int) data type in DuckDB, and it should be big enough (28 digits) on the left side of the decimal while also providing a meaningful amount of precision on the right side (10 digits).~~

After some digging, I found that Java destinations prefer scale of `9`: `DECIMAL(38, 9)`.

I've updated the PR to use this size.

----

Per internal slack inquiry: https://airbytehq-team.slack.com/archives/C03C4AVJWG4/p1713209219674449?thread_ts=1713208569.977779&cid=C03C4AVJWG4

Relevant code on the Java side:

https://github.com/airbytehq/airbyte/blob/d8e8a0dab4d951fb39ab2fb7048d167f096948c2/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcSqlGenerator.kt#L80

