### PR TITLE
Feat: Add an Executor for Docker sources

### DIFF
--- a/airbyte/_executor.py
+++ b/airbyte/_executor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import shlex
+import shutil
 import subprocess
 import sys
 from abc import ABC, abstractmethod
@@ -449,4 +450,56 @@ class PathExecutor(Executor):
 
     def execute(self, args: list[str]) -> Iterator[str]:
         with _stream_from_subprocess([str(self.path), *args]) as stream:
+            yield from stream
+
+
+class DockerExecutor(Executor):
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        executable: list[str],
+        target_version: str | None = None,
+    ) -> None:
+        self.executable: list[str] = executable
+        name = name or executable[0]
+        super().__init__(name=name, target_version=target_version)
+
+    def ensure_installation(
+        self,
+        *,
+        auto_fix: bool = True,
+    ) -> None:
+        """Ensure that the connector executable can be found.
+
+        The auto_fix parameter is ignored for this executor type.
+        """
+        _ = auto_fix
+        try:
+            assert (
+                shutil.which("docker") is not None
+            ), "Docker couldn't be found on your system. Please Install it."
+            self.execute(["spec"])
+        except Exception as e:
+            # TODO: Improve error handling. We should try to distinguish between
+            #       a connector that is not installed and a connector that is not
+            #       working properly.
+            raise exc.AirbyteConnectorExecutableNotFoundError(
+                connector_name=self.name,
+            ) from e
+
+    def install(self) -> NoReturn:
+        raise exc.AirbyteConnectorInstallationError(
+            message="Connector cannot be installed because it is not managed by PyAirbyte.",
+            connector_name=self.name,
+        )
+
+    def uninstall(self) -> NoReturn:
+        raise exc.AirbyteConnectorInstallationError(
+            message="Connector cannot be uninstalled because it is not managed by PyAirbyte.",
+            connector_name=self.name,
+        )
+
+    def execute(self, args: list[str]) -> Iterator[str]:
+        with _stream_from_subprocess([*self.executable, *args]) as stream:
             yield from stream

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,26 +5,23 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 import shutil
 import socket
 import subprocess
 import time
-from requests.exceptions import HTTPError
-
-import ulid
-from airbyte._util.meta import is_windows
-from airbyte.caches.duckdb import DuckDBCache
+from pathlib import Path
 
 import docker
 import psycopg2 as psycopg
 import pytest
+import ulid
 from _pytest.nodes import Item
-
-from airbyte.caches import PostgresCache
 from airbyte._executor import _get_bin_dir
+from airbyte._util.meta import is_windows
+from airbyte.caches import PostgresCache
+from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import new_local_cache
-
+from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +66,8 @@ def pytest_collection_modifyitems(items: list[Item]) -> None:
         if (
             "new_postgres_cache" in item.fixturenames
             or "postgres_cache" in item.fixturenames
+            or "source_docker_faker_seed_a" in item.fixturenames
+            or "source_docker_faker_seed_b" in item.fixturenames
         ):
             if True or not is_docker_available():
                 item.add_marker(

--- a/tests/integration_tests/test_docker_executable.py
+++ b/tests/integration_tests/test_docker_executable.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+"""Integration tests which leverage the source-faker connector to test the framework end-to-end with the Docker Executor."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import airbyte as ab
+import pytest
+import ulid
+from airbyte.caches.base import CacheBase
+from airbyte.caches.duckdb import DuckDBCache
+from airbyte.caches.postgres import PostgresCache
+from airbyte.caches.util import new_local_cache
+
+# Product count is always the same, regardless of faker scale.
+NUM_PRODUCTS = 100
+
+SEED_A = 1234
+SEED_B = 5678
+
+# Number of records in each of the 'users' and 'purchases' streams.
+FAKER_SCALE_A = 200
+# We want this to be different from FAKER_SCALE_A.
+FAKER_SCALE_B = 300
+
+
+# Patch PATH to include the source-faker executable.
+
+
+@pytest.fixture(scope="function")  # Each test gets a fresh source-faker instance.
+def source_faker_seed_a() -> ab.Source:
+    """Fixture to return a source-faker connector instance."""
+    source = ab.get_source(
+        "source-faker",
+        docker_executable=True,
+        config={
+            "count": FAKER_SCALE_A,
+            "seed": SEED_A,
+            "parallelism": 16,  # Otherwise defaults to 4.
+        },
+    )
+    source.check()
+    source.select_streams([
+        "users",
+        "products",
+        "purchases",
+    ])
+    return source
+
+
+@pytest.fixture(scope="function")  # Each test gets a fresh source-faker instance.
+def source_faker_seed_b() -> ab.Source:
+    """Fixture to return a source-faker connector instance."""
+    source = ab.get_source(
+        "source-faker",
+        docker_executable=True,
+        config={
+            "count": FAKER_SCALE_B,
+            "seed": SEED_B,
+            "parallelism": 16,  # Otherwise defaults to 4.
+        },
+    )
+    source.check()
+    source.select_streams([
+        "products",
+        "purchases",
+        "users",
+    ])
+    return source
+
+
+@pytest.fixture(scope="function")
+def duckdb_cache() -> Generator[DuckDBCache, None, None]:
+    """Fixture to return a fresh cache."""
+    cache: DuckDBCache = new_local_cache()
+    yield cache
+    # TODO: Delete cache DB file after test is complete.
+    return
+
+
+@pytest.fixture(scope="function")
+def postgres_cache(new_postgres_cache) -> Generator[PostgresCache, None, None]:
+    """Fixture to return a fresh cache."""
+    yield new_postgres_cache
+    # TODO: Delete cache DB file after test is complete.
+    return
+
+
+@pytest.fixture
+def all_cache_types(
+    duckdb_cache: DuckDBCache,
+    postgres_cache: PostgresCache,
+):
+    _ = postgres_cache
+    return [
+        duckdb_cache,
+        postgres_cache,
+    ]
+
+
+def test_which_source_faker() -> None:
+    """Test that source-faker is available on PATH."""
+    assert shutil.which(
+        "source-faker"
+    ), f"Can't find source-faker on PATH: {os.environ['PATH']}"
+
+
+def test_faker_pks(
+    source_faker_seed_a: ab.Source,
+    duckdb_cache: DuckDBCache,
+) -> None:
+    """Test that the append strategy works as expected."""
+
+    catalog = source_faker_seed_a.configured_catalog
+
+    assert catalog.streams[0].primary_key
+    assert catalog.streams[1].primary_key
+
+    read_result = source_faker_seed_a.read(duckdb_cache, write_strategy="append")
+    assert read_result.cache.processor._get_primary_keys("products") == ["id"]
+    assert read_result.cache.processor._get_primary_keys("purchases") == ["id"]
+
+
+@pytest.mark.slow
+def test_replace_strategy(
+    source_faker_seed_a: ab.Source,
+    all_cache_types: CacheBase,
+) -> None:
+    """Test that the append strategy works as expected."""
+    for (
+        cache
+    ) in all_cache_types:  # Function-scoped fixtures can't be used in parametrized().
+        for _ in range(2):
+            result = source_faker_seed_a.read(
+                cache, write_strategy="replace", force_full_refresh=True
+            )
+            assert len(list(result.cache.streams["products"])) == NUM_PRODUCTS
+            assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_A
+
+
+@pytest.mark.slow
+def test_append_strategy(
+    source_faker_seed_a: ab.Source,
+    all_cache_types: CacheBase,
+) -> None:
+    """Test that the append strategy works as expected."""
+    for (
+        cache
+    ) in all_cache_types:  # Function-scoped fixtures can't be used in parametrized().
+        for iteration in range(1, 3):
+            result = source_faker_seed_a.read(cache, write_strategy="append")
+            assert (
+                len(list(result.cache.streams["products"])) == NUM_PRODUCTS * iteration
+            )
+            assert (
+                len(list(result.cache.streams["purchases"]))
+                == FAKER_SCALE_A * iteration
+            )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("strategy", ["merge", "auto"])
+def test_merge_strategy(
+    strategy: str,
+    source_faker_seed_a: ab.Source,
+    source_faker_seed_b: ab.Source,
+    all_cache_types: CacheBase,
+) -> None:
+    """Test that the merge strategy works as expected.
+
+    Since all streams have primary keys, we should expect the auto strategy to be identical to the
+    merge strategy.
+    """
+    for (
+        cache
+    ) in all_cache_types:  # Function-scoped fixtures can't be used in parametrized().
+        # First run, seed A (counts should match the scale or the product count)
+        result = source_faker_seed_a.read(cache, write_strategy=strategy)
+        assert len(list(result.cache.streams["products"])) == NUM_PRODUCTS
+        assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_A
+
+        # Second run, also seed A (should have same exact data, no change in counts)
+        result = source_faker_seed_a.read(cache, write_strategy=strategy)
+        assert len(list(result.cache.streams["products"])) == NUM_PRODUCTS
+        assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_A
+
+        # Third run, seed B - should increase record count to the scale of B, which is greater than A.
+        # TODO: See if we can reliably predict the exact number of records, since we use fixed seeds.
+        result = source_faker_seed_b.read(cache, write_strategy=strategy)
+        assert len(list(result.cache.streams["products"])) == NUM_PRODUCTS
+        assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_B
+
+        # Third run, seed A again - count should stay at scale B, since A is smaller.
+        # TODO: See if we can reliably predict the exact number of records, since we use fixed seeds.
+        result = source_faker_seed_a.read(cache, write_strategy=strategy)
+        assert len(list(result.cache.streams["products"])) == NUM_PRODUCTS
+        assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_B
+
+
+def test_incremental_sync(
+    source_faker_seed_a: ab.Source,
+    source_faker_seed_b: ab.Source,
+    duckdb_cache: CacheBase,
+) -> None:
+    config_a = source_faker_seed_a.get_config()
+    config_b = source_faker_seed_b.get_config()
+    config_a["always_updated"] = False
+    config_b["always_updated"] = False
+    source_faker_seed_a.set_config(config_a)
+    source_faker_seed_b.set_config(config_b)
+
+    result1 = source_faker_seed_a.read(duckdb_cache)
+    assert len(list(result1.cache.streams["products"])) == NUM_PRODUCTS
+    assert len(list(result1.cache.streams["purchases"])) == FAKER_SCALE_A
+    assert result1.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2
+
+    assert not duckdb_cache.processor._catalog_manager.get_state("source-faker") == []
+
+    # Second run should not return records as it picks up the state and knows it's up to date.
+    result2 = source_faker_seed_b.read(duckdb_cache)
+
+    assert result2.processed_records == 0
+    assert len(list(result2.cache.streams["products"])) == NUM_PRODUCTS
+    assert len(list(result2.cache.streams["purchases"])) == FAKER_SCALE_A
+
+
+def test_incremental_state_cache_persistence(
+    source_faker_seed_a: ab.Source,
+    source_faker_seed_b: ab.Source,
+) -> None:
+    config_a = source_faker_seed_a.get_config()
+    config_b = source_faker_seed_b.get_config()
+    config_a["always_updated"] = False
+    config_b["always_updated"] = False
+    source_faker_seed_a.set_config(config_a)
+    source_faker_seed_b.set_config(config_b)
+    cache_name = str(ulid.ULID())
+    cache = new_local_cache(cache_name)
+    result = source_faker_seed_a.read(cache)
+    assert result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2
+    second_cache = new_local_cache(cache_name)
+    # The state should be persisted across cache instances.
+    result2 = source_faker_seed_b.read(second_cache)
+    assert result2.processed_records == 0
+
+    assert (
+        second_cache.processor._catalog_manager
+        and second_cache.processor._catalog_manager.get_state("source-faker")
+    )
+    assert len(list(result2.cache.streams["products"])) == NUM_PRODUCTS
+    assert len(list(result2.cache.streams["purchases"])) == FAKER_SCALE_A
+
+
+def test_incremental_state_prefix_isolation(
+    source_faker_seed_a: ab.Source,
+    source_faker_seed_b: ab.Source,
+) -> None:
+    """
+    Test that state in the cache correctly isolates streams when different table prefixes are used
+    """
+    config_a = source_faker_seed_a.get_config()
+    config_a["always_updated"] = False
+    source_faker_seed_a.set_config(config_a)
+    cache_name = str(ulid.ULID())
+    db_path = Path(f"./.cache/{cache_name}.duckdb")
+    cache = DuckDBCache(db_path=db_path, table_prefix="prefix_")
+    different_prefix_cache = DuckDBCache(
+        db_path=db_path, table_prefix="different_prefix_"
+    )
+
+    result = source_faker_seed_a.read(cache)
+    assert result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2
+
+    result2 = source_faker_seed_b.read(different_prefix_cache)
+    assert result2.processed_records == NUM_PRODUCTS + FAKER_SCALE_B * 2
+
+    assert len(list(result2.cache.streams["products"])) == NUM_PRODUCTS
+    assert len(list(result2.cache.streams["purchases"])) == FAKER_SCALE_B
+
+
+def test_config_spec(source_faker_seed_a: ab.Source) -> None:
+    assert source_faker_seed_a.config_spec
+
+
+def test_example_config_file(source_faker_seed_a: ab.Source) -> None:
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp:
+        source_faker_seed_a.print_config_spec(
+            format="json",
+            output_file=temp.name,
+        )
+        assert Path(temp.name).exists()


### PR DESCRIPTION
## What
Adding a `DockerExecutor` class to the `get_source` factory. 

## Why
I absolutely love this library as it allows me to rapidly pull data from a variety of different sources and load them into a "local DW" in duckDB for quick analysis using SQL. All this without having to deploy or startup any servers!! However, on numerous occasions I needed to pull in data from Java based Airbyte sources such as PostgreSQL and MySQL and couldn't use PyAirbyte to do that. Therefore, it would be great if the library supported the execution of Docker images that adhere to the Airbyte protocol. This will greatly increase the number of compatible sources and allow users to develop additional sources in their language of choice.

## How
`DockerExecutor` is almost identical to `PathExecutor` but instead of receiving a path to the executable it expects a list of docker commands. These commands are passed down from the factory and include the mounting of the the `temp_dir` used for materializing the JSON config files.

```python
if docker_executable:
    version = version or "latest"

    temp_dir = tempfile.gettempdir()
    return Source(
        name=name,
        config=config,
        streams=streams,
        executor=DockerExecutor(
            name=name,
            executable=[
                "docker",
                "run",
                "--rm",
                "-i",
                "--volume",
                f"{temp_dir}:{temp_dir}",
                f"airbyte/{name}:{version}",
            ],
        ),
    )

``` 

**Example Usage**
```python
source = ab.get_source(
    "source-faker",
    docker_executable=True,
    config={
        "count": 10,
    },
)
```

Tested via `test_docker_executable.py` which is a replica of `test_source_faker_integration.py` with ```docker_executable=True```

P.S. This is my first ever open source contribution 😃