### PR TITLE
Feat: Add `Source.connector_version` property

### DIFF
--- a/airbyte/_executor.py
+++ b/airbyte/_executor.py
@@ -8,8 +8,9 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from shutil import rmtree
-from typing import IO, TYPE_CHECKING, Any, NoReturn, cast, override
+from typing import IO, TYPE_CHECKING, Any, NoReturn, cast
 
+from overrides import overrides
 from rich import print
 from typing_extensions import Literal
 
@@ -78,10 +79,18 @@ class Executor(ABC):
     def uninstall(self) -> None:
         pass
 
-    def get_installed_version(self) -> None:
+    def get_installed_version(
+        self,
+        *,
+        raise_on_error: bool = False,
+        recheck: bool = False,
+    ) -> str | None:
+        """Detect the version of the connector installed."""
+        _ = raise_on_error, recheck  # Unused
         raise NotImplementedError(
             f"'{type(self).__name__}' class cannot yet detect connector versions."
         )
+
 
 @contextmanager
 def _stream_from_subprocess(args: list[str]) -> Generator[Iterable[str], None, None]:
@@ -250,7 +259,7 @@ class VenvExecutor(Executor):
             f"{self.docs_url}#reference\n"
         )
 
-    @override
+    @overrides
     def get_installed_version(
         self,
         *,

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -435,6 +435,11 @@ class Source:  # noqa: PLR0904  # Ignore max publish methods
             stream_metadata=configured_stream,
         )
 
+    @property
+    def connector_version(self) -> str:
+        """Return the version of the connector as reported by the executor."""
+        return self.executor.get_installed_version()
+
     def get_documents(
         self,
         stream: str,

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -436,8 +436,11 @@ class Source:  # noqa: PLR0904  # Ignore max publish methods
         )
 
     @property
-    def connector_version(self) -> str:
-        """Return the version of the connector as reported by the executor."""
+    def connector_version(self) -> str | None:
+        """Return the version of the connector as reported by the executor.
+
+        Returns None if the version cannot be determined.
+        """
         return self.executor.get_installed_version()
 
     def get_documents(

--- a/tests/integration_tests/test_source_test_fixture.py
+++ b/tests/integration_tests/test_source_test_fixture.py
@@ -239,7 +239,7 @@ def test_version_enforcement(
                 install_if_missing=False,
             )
             if requested_version:  # Don't raise if a version is not requested
-                assert source.executor._get_installed_version(raise_on_error=True) == (
+                assert source.executor.get_installed_version(raise_on_error=True) == (
                     requested_version or latest_available_version
                 ).replace("latest", latest_available_version)
             source.executor.ensure_installation(auto_fix=False)


### PR DESCRIPTION
Allows users to detect the version number of a source connector.

Relates to:

- https://github.com/airbytehq/PyAirbyte/issues/212