### PR TITLE
Chore: Add Poe task support and code coverage reporting

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/.github/workflows/fix-pr-command.yml
+++ b/.github/workflows/fix-pr-command.yml
@@ -74,7 +74,7 @@ jobs:
           [1]: ${{ steps.vars.outputs.run-url }}
 
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/.github/workflows/pydoc_preview.yml
+++ b/.github/workflows/pydoc_preview.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/.github/workflows/pydoc_publish.yml
+++ b/.github/workflows/pydoc_publish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python
@@ -64,7 +64,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
 
     # Job-specifc step(s):
     - name: Format code
@@ -47,6 +49,8 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
 
     # Job-specifc step(s):
     - name: Check code format
@@ -68,6 +72,8 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
 
     # Job-specifc step(s):
     - name: Check MyPy typing

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -90,14 +90,17 @@ jobs:
         "not requires_creds and not linting and not super_slow"
 
     - name: Print Coverage Report
+      if: always()
       run: poetry run coverage report
 
     - name: Create Coverage Artifacts
+      if: always()
       run: |
         poetry run coverage html -d htmlcov
         poetry run coverage xml -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: nocreds-test-coverage
@@ -148,14 +151,17 @@ jobs:
         "not linting and not super_slow"
 
     - name: Print Coverage Report
+      if: always()
       run: poetry run coverage report
 
     - name: Create Coverage Artifacts
+      if: always()
       run: |
         poetry run coverage html -d htmlcov
         poetry run coverage xml -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python
@@ -59,7 +59,7 @@ jobs:
 
     - name: Upload coverage to GitHub Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: fasttest-coverage
         path: htmlcov/
@@ -72,7 +72,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python
@@ -104,7 +104,7 @@ jobs:
 
     - name: Upload coverage to GitHub Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: nocreds-test-coverage
         path: htmlcov/
@@ -134,7 +134,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python
@@ -165,7 +165,7 @@ jobs:
 
     - name: Upload coverage to GitHub Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
         path: htmlcov/

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -48,14 +48,17 @@ jobs:
         --durations=5 --exitfirst
 
     - name: Print Coverage Report
+      if: always()
       run: poetry run coverage report
 
     - name: Create Coverage Artifacts
+      if: always()
       run: |
         poetry run coverage html -d htmlcov
         poetry run coverage xml -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: fasttest-coverage

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -39,14 +39,27 @@ jobs:
     - name: Install dependencies
       run: poetry install
 
-    # Job-specific step(s):
-    - name: Run Pytest (Fast Tests Only)
+    - name: Run Pytest with Coverage (Fast Tests Only)
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       run: >
-        poetry run pytest -m
+        poetry run coverage run -m pytest -m
         "not slow and not requires_creds and not linting"
         --durations=5 --exitfirst
+
+    - name: Print Coverage Report
+      run: poetry run coverage report
+
+    - name: Create Coverage Artifacts
+      run: |
+        poetry run coverage html -d htmlcov
+        poetry run coverage xml -o htmlcov/coverage.xml
+
+    - name: Upload coverage to GitHub Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: fasttest-coverage
+        path: htmlcov/
 
   pytest-no-creds:
     name: Pytest (No Creds)
@@ -73,8 +86,22 @@ jobs:
         # Force this to a blank value.
         GCP_GSM_CREDENTIALS: ""
       run: >
-        poetry run pytest -m
+        poetry run coverage run -m pytest -m
         "not requires_creds and not linting and not super_slow"
+
+    - name: Print Coverage Report
+      run: poetry run coverage report
+
+    - name: Create Coverage Artifacts
+      run: |
+        poetry run coverage html -d htmlcov
+        poetry run coverage xml -o htmlcov/coverage.xml
+
+    - name: Upload coverage to GitHub Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: nocreds-test-coverage
+        path: htmlcov/
 
   pytest:
     name: Pytest (All, Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -117,4 +144,19 @@ jobs:
       env:
         GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       run: >
-        poetry run pytest -m "not linting and not super_slow"
+        poetry run coverage run -m pytest -m
+        "not linting and not super_slow"
+
+    - name: Print Coverage Report
+      run: poetry run coverage report
+
+    - name: Create Coverage Artifacts
+      run: |
+        poetry run coverage html -d htmlcov
+        poetry run coverage xml -o htmlcov/coverage.xml
+
+    - name: Upload coverage to GitHub Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
+        path: htmlcov/

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -70,7 +70,7 @@ jobs:
     # Same as the `python_pytest.yml` file:
 
     - name: Set up Poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@v9
       with:
         poetry-version: "1.7.1"
     - name: Set up Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,25 @@ Releases are published automatically to PyPi in response to a "published" event 
 To publish to PyPi, simply [create a GitHub Release](https://github.com/airbytehq/PyAirbyte/releases/new) with the correct version. Once you publish the release on GitHub it will automatically trigger a PyPi publish workflow in GitHub actions.
 
 > **Warning**
-> 
+>
 > Be careful - "Cmd+Enter" will not 'save' but will instead 'publish'. (If you want to save a draft, use the mouse. 😅)
 
 > **Note**
-> 
+>
 > There is no version to bump. Version is calculated during build and publish, using the [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) plugin.
+
+## Coverage
+
+To run a coverage report, run:
+
+```console
+poetry run poe coverage
+```
+
+This will generate a coverage report in the `htmlcov` folder.
+
+Note: If you have pre-installed [Poe](https://poethepoet.natn.io/index.html)
+(`pipx install poethepoet`), then you can omit the `poetry run` prefix.
 
 ## Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To publish to PyPi, simply [create a GitHub Release](https://github.com/airbyteh
 To run a coverage report, run:
 
 ```console
-poetry run poe coverage
+poetry run poe coverage-html
 ```
 
 This will generate a coverage report in the `htmlcov` folder.

--- a/poetry.lock
+++ b/poetry.lock
@@ -390,6 +390,70 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.5.1"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0884920835a033b78d1c73b6d3bbcda8161a900f38a488829a83982925f6c2e"},
+    {file = "coverage-7.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:39afcd3d4339329c5f58de48a52f6e4e50f6578dd6099961cf22228feb25f38f"},
+    {file = "coverage-7.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a7b0ceee8147444347da6a66be737c9d78f3353b0681715b668b72e79203e4a"},
+    {file = "coverage-7.5.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a9ca3f2fae0088c3c71d743d85404cec8df9be818a005ea065495bedc33da35"},
+    {file = "coverage-7.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd215c0c7d7aab005221608a3c2b46f58c0285a819565887ee0b718c052aa4e"},
+    {file = "coverage-7.5.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4bf0655ab60d754491004a5efd7f9cccefcc1081a74c9ef2da4735d6ee4a6223"},
+    {file = "coverage-7.5.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:61c4bf1ba021817de12b813338c9be9f0ad5b1e781b9b340a6d29fc13e7c1b5e"},
+    {file = "coverage-7.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:db66fc317a046556a96b453a58eced5024af4582a8dbdc0c23ca4dbc0d5b3146"},
+    {file = "coverage-7.5.1-cp310-cp310-win32.whl", hash = "sha256:b016ea6b959d3b9556cb401c55a37547135a587db0115635a443b2ce8f1c7228"},
+    {file = "coverage-7.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:df4e745a81c110e7446b1cc8131bf986157770fa405fe90e15e850aaf7619bc8"},
+    {file = "coverage-7.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:796a79f63eca8814ca3317a1ea443645c9ff0d18b188de470ed7ccd45ae79428"},
+    {file = "coverage-7.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4fc84a37bfd98db31beae3c2748811a3fa72bf2007ff7902f68746d9757f3746"},
+    {file = "coverage-7.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6175d1a0559986c6ee3f7fccfc4a90ecd12ba0a383dcc2da30c2b9918d67d8a3"},
+    {file = "coverage-7.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fc81d5878cd6274ce971e0a3a18a8803c3fe25457165314271cf78e3aae3aa2"},
+    {file = "coverage-7.5.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:556cf1a7cbc8028cb60e1ff0be806be2eded2daf8129b8811c63e2b9a6c43bca"},
+    {file = "coverage-7.5.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9981706d300c18d8b220995ad22627647be11a4276721c10911e0e9fa44c83e8"},
+    {file = "coverage-7.5.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d7fed867ee50edf1a0b4a11e8e5d0895150e572af1cd6d315d557758bfa9c057"},
+    {file = "coverage-7.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ef48e2707fb320c8f139424a596f5b69955a85b178f15af261bab871873bb987"},
+    {file = "coverage-7.5.1-cp311-cp311-win32.whl", hash = "sha256:9314d5678dcc665330df5b69c1e726a0e49b27df0461c08ca12674bcc19ef136"},
+    {file = "coverage-7.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:5fa567e99765fe98f4e7d7394ce623e794d7cabb170f2ca2ac5a4174437e90dd"},
+    {file = "coverage-7.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b6cf3764c030e5338e7f61f95bd21147963cf6aa16e09d2f74f1fa52013c1206"},
+    {file = "coverage-7.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2ec92012fefebee89a6b9c79bc39051a6cb3891d562b9270ab10ecfdadbc0c34"},
+    {file = "coverage-7.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16db7f26000a07efcf6aea00316f6ac57e7d9a96501e990a36f40c965ec7a95d"},
+    {file = "coverage-7.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:beccf7b8a10b09c4ae543582c1319c6df47d78fd732f854ac68d518ee1fb97fa"},
+    {file = "coverage-7.5.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8748731ad392d736cc9ccac03c9845b13bb07d020a33423fa5b3a36521ac6e4e"},
+    {file = "coverage-7.5.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7352b9161b33fd0b643ccd1f21f3a3908daaddf414f1c6cb9d3a2fd618bf2572"},
+    {file = "coverage-7.5.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7a588d39e0925f6a2bff87154752481273cdb1736270642aeb3635cb9b4cad07"},
+    {file = "coverage-7.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:68f962d9b72ce69ea8621f57551b2fa9c70509af757ee3b8105d4f51b92b41a7"},
+    {file = "coverage-7.5.1-cp312-cp312-win32.whl", hash = "sha256:f152cbf5b88aaeb836127d920dd0f5e7edff5a66f10c079157306c4343d86c19"},
+    {file = "coverage-7.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:5a5740d1fb60ddf268a3811bcd353de34eb56dc24e8f52a7f05ee513b2d4f596"},
+    {file = "coverage-7.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e2213def81a50519d7cc56ed643c9e93e0247f5bbe0d1247d15fa520814a7cd7"},
+    {file = "coverage-7.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5037f8fcc2a95b1f0e80585bd9d1ec31068a9bcb157d9750a172836e98bc7a90"},
+    {file = "coverage-7.5.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c3721c2c9e4c4953a41a26c14f4cef64330392a6d2d675c8b1db3b645e31f0e"},
+    {file = "coverage-7.5.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca498687ca46a62ae590253fba634a1fe9836bc56f626852fb2720f334c9e4e5"},
+    {file = "coverage-7.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cdcbc320b14c3e5877ee79e649677cb7d89ef588852e9583e6b24c2e5072661"},
+    {file = "coverage-7.5.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:57e0204b5b745594e5bc14b9b50006da722827f0b8c776949f1135677e88d0b8"},
+    {file = "coverage-7.5.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8fe7502616b67b234482c3ce276ff26f39ffe88adca2acf0261df4b8454668b4"},
+    {file = "coverage-7.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9e78295f4144f9dacfed4f92935fbe1780021247c2fabf73a819b17f0ccfff8d"},
+    {file = "coverage-7.5.1-cp38-cp38-win32.whl", hash = "sha256:1434e088b41594baa71188a17533083eabf5609e8e72f16ce8c186001e6b8c41"},
+    {file = "coverage-7.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:0646599e9b139988b63704d704af8e8df7fa4cbc4a1f33df69d97f36cb0a38de"},
+    {file = "coverage-7.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4cc37def103a2725bc672f84bd939a6fe4522310503207aae4d56351644682f1"},
+    {file = "coverage-7.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fc0b4d8bfeabd25ea75e94632f5b6e047eef8adaed0c2161ada1e922e7f7cece"},
+    {file = "coverage-7.5.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d0a0f5e06881ecedfe6f3dd2f56dcb057b6dbeb3327fd32d4b12854df36bf26"},
+    {file = "coverage-7.5.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9735317685ba6ec7e3754798c8871c2f49aa5e687cc794a0b1d284b2389d1bd5"},
+    {file = "coverage-7.5.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d21918e9ef11edf36764b93101e2ae8cc82aa5efdc7c5a4e9c6c35a48496d601"},
+    {file = "coverage-7.5.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c3e757949f268364b96ca894b4c342b41dc6f8f8b66c37878aacef5930db61be"},
+    {file = "coverage-7.5.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:79afb6197e2f7f60c4824dd4b2d4c2ec5801ceb6ba9ce5d2c3080e5660d51a4f"},
+    {file = "coverage-7.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1d0d98d95dd18fe29dc66808e1accf59f037d5716f86a501fc0256455219668"},
+    {file = "coverage-7.5.1-cp39-cp39-win32.whl", hash = "sha256:1cc0fe9b0b3a8364093c53b0b4c0c2dd4bb23acbec4c9240b5f284095ccf7981"},
+    {file = "coverage-7.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:dde0070c40ea8bb3641e811c1cfbf18e265d024deff6de52c5950677a8fb1e0f"},
+    {file = "coverage-7.5.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:6537e7c10cc47c595828b8a8be04c72144725c383c4702703ff4e42e44577312"},
+    {file = "coverage-7.5.1.tar.gz", hash = "sha256:54de9ef3a9da981f7af93eafde4ede199e0846cd819eb27c88e2b712aae9708c"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cryptography"
 version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -1588,6 +1652,17 @@ numpy = {version = ">=1.26.0", markers = "python_version < \"3.13\""}
 types-pytz = ">=2022.1.1"
 
 [[package]]
+name = "pastel"
+version = "0.2.1"
+description = "Bring colors to your terminal."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
+    {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+
+[[package]]
 name = "pdoc"
 version = "14.4.0"
 description = "API Documentation for Python Projects"
@@ -1669,6 +1744,24 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "poethepoet"
+version = "0.26.1"
+description = "A task runner that works well with poetry."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "poethepoet-0.26.1-py3-none-any.whl", hash = "sha256:aa43b443fec5d17d7e76771cccd484e5285805301721a74f059c483ad3276edd"},
+    {file = "poethepoet-0.26.1.tar.gz", hash = "sha256:aaad8541f6072617a60bcff2562d00779b58b353bd0f1847b06d8d0f2b6dc192"},
+]
+
+[package.dependencies]
+pastel = ">=0.2.1,<0.3.0"
+tomli = ">=1.2.2"
+
+[package.extras]
+poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
 name = "proto-plus"
@@ -2945,4 +3038,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "c6f0f078a6532632205962a569dd5ef8cb092e3ac1e90dfbc4626f98d44ddb04"
+content-hash = "d9c23bf8b4490d79cdd76ef80d2f0b2f4ab1e48bdef283cfeb66653a43aa2155"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,9 +288,17 @@ airbyte-lib-validate-source = "airbyte.validate:run"
 
 [tool.poe.tasks]
 test = { shell = "pytest" }
+
 coverage = { shell = "coverage run -m pytest && coverage report" }
 coverage-report = { shell = "coverage report" }
 coverage-html = { shell = "coverage html -d htmlcov && open htmlcov/index.html" }
+coverage-reset = { shell = "coverage erase" }
+
+check = { shell = "ruff check ." }
+
+fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
+fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe . && ruff format ." }
+fix-and-check = { shell = "poe fix && poe check" }
 
 [tool.airbyte_ci]
 extra_poetry_groups = ["dev"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,7 @@ coverage-report = { shell = "coverage report" }
 coverage-html = { shell = "coverage html -d htmlcov && open htmlcov/index.html" }
 coverage-reset = { shell = "coverage erase" }
 
-check = { shell = "ruff check ." }
+check = { shell = "ruff check . && mypy ." }
 
 fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
 fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe-fixes . && ruff format ." }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,8 @@ airbyte-lib-validate-source = "airbyte.validate:run"
 [tool.poe.tasks]
 test = { shell = "pytest" }
 coverage = { shell = "coverage run -m pytest && coverage report" }
+coverage-report = { shell = "coverage report" }
+coverage-html = { shell = "coverage html -d htmlcov && open htmlcov/index.html" }
 
 [tool.airbyte_ci]
 extra_poetry_groups = ["dev"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,7 +297,7 @@ coverage-reset = { shell = "coverage erase" }
 check = { shell = "ruff check ." }
 
 fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
-fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe . && ruff format ." }
+fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe-fixes . && ruff format ." }
 fix-and-check = { shell = "poe fix && poe check" }
 
 [tool.airbyte_ci]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ tomli = "^2.0"
 responses = "^0.25.0"
 airbyte-source-pokeapi = "^0.2.0"
 pytest-mock = "^3.14.0"
+poethepoet = "^0.26.1"
+coverage = "^7.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
@@ -285,7 +287,8 @@ generate-docs = "docs.generate:run"
 airbyte-lib-validate-source = "airbyte.validate:run"
 
 [tool.poe.tasks]
-test = "pytest tests"
+test = { shell = "pytest" }
+coverage = { shell = "coverage run -m pytest && coverage report" }
 
 [tool.airbyte_ci]
 extra_poetry_groups = ["dev"]


### PR DESCRIPTION
## Poe Task Runner Support

This adds support for the following `Poe` tasks:

```bash
poe test

poe coverage
poe coverage-report
poe coverage-html

poe check

poe fix
poe fix-and-check
poe fix-unsafe
```

All of the above can be run via `poetry run poe` if you don't have the poetry environment activated and/or if you don't want to pre-install Poe.

The recommendation is to install poe on your local workstation like this:

```bash
pipx install poe
```

and then you will always be able to just write `poe ...` without having to type `poetry run`.

## Coverage Reporting

As noted above, you can quickly see coverate reports by running the following locally:

```bash
poe coverage-html
```

You can also find coverage reports uploaded as artifacts on each CI test run.

Coverage reports are under the [Summary tab](https://github.com/airbytehq/PyAirbyte/actions/runs/9085483353?pr=231):

> ![image](https://github.com/airbytehq/PyAirbyte/assets/18150651/23f9c85b-e3a8-4a92-8f1c-c64f7364eff1)

## Personal Usage

FWIW, I find I'm most-often using `poe fix-and-check` as a way to quick fix everything that can be fixed lint-wise and format-wise, and then point me to any remaining issues in the same step.
