### PR TITLE
CI: Add '/poetry-lock' slash command

### DIFF
--- a/.github/workflows/poetry-lock-command.yml
+++ b/.github/workflows/poetry-lock-command.yml
@@ -1,0 +1,139 @@
+name: On-Demand Poetry Lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR Number'
+        type: string
+        required: true
+      comment-id:
+        description: 'Comment ID (Optional)'
+        type: string
+        required: false
+
+env:
+  AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
+
+jobs:
+  poetry-lock-on-demand:
+    name: On-Demand Poetry Lock
+    strategy:
+      matrix:
+        python-version: [
+          '3.10',
+        ]
+        os: [
+          Ubuntu,
+        ]
+      fail-fast: false
+
+    runs-on: "${{ matrix.os }}-latest"
+    steps:
+
+    # Custom steps to fetch the PR and checkout the code:
+    - name: Checkout Airbyte
+      uses: actions/checkout@v4
+      with:
+        # Important that this is set so that CI checks are triggered again
+        # Without this we would be forever waiting on required checks to pass
+        token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+    - name: Checkout PR (${{ github.event.inputs.pr }})
+      uses: dawidd6/action-checkout-pr@v1
+      with:
+        pr: ${{ github.event.inputs.pr }}
+
+    - name: Get PR info
+      id: pr-info
+      run: |
+        PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+        echo "::set-output name=repo::$(echo "$PR_JSON" | jq -r .head.repo.full_name)"
+        echo "::set-output name=branch::$(echo "$PR_JSON" | jq -r .head.ref)"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+
+    - name: Create URL to the run output
+      id: vars
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+    - name: Append comment with job run link
+      id: first-comment-action
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ github.event.inputs.comment-id }}
+        issue-number: ${{ github.event.inputs.pr }}
+        body: |
+
+          > `poetry lock` job started... [Check job output.][1]
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Set up Poetry
+      uses: Gr1N/setup-poetry@v9
+      with:
+        poetry-version: "1.7.1"
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
+    - name: Install dependencies
+      run: poetry install
+
+    # Run `poetry lock`
+
+    - name: Run `poetry lock`
+      run: poetry lock
+
+    # Check for changes in git
+
+    - name: Check for changes
+      id: git-diff
+      run: |
+        git diff --quiet && echo "No changes to commit" || echo "::set-output name=changes::true"
+      shell: bash
+
+    # Commit changes (if any)
+
+    - name: Commit changes
+      if: steps.git-diff.outputs.changes == 'true'
+      run: |
+        git config --global user.name "octavia-squidington-iii"
+        git config --global user.email "contact@airbyte.com"
+        git add .
+        git commit -m "Auto-fix lint and format issues"
+
+    - name: Push changes to '(${{ steps.pr-info.outputs.repo }})'
+      if: steps.git-diff.outputs.changes == 'true'
+      run: |
+        git remote add contributor https://github.com/${{ steps.pr-info.outputs.repo }}.git
+        git push contributor HEAD:${{ steps.pr-info.outputs.branch }}
+
+    - name: Append success comment
+      uses: peter-evans/create-or-update-comment@v4
+      if: steps.git-diff.outputs.changes == 'true'
+      with:
+        comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+        reactions: hooray
+        body: |
+          > ✅ `poetry lock` applied successfully.
+
+    - name: Append success comment (no-op)
+      uses: peter-evans/create-or-update-comment@v4
+      if: steps.git-diff.outputs.changes != 'true' && steps.git-diff-2.outputs.changes != 'true'
+      with:
+        comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+        reactions: "+1"
+        body: |
+          > 🟦 Job completed successfully (no changes).
+
+    - name: Append failure comment
+      uses: peter-evans/create-or-update-comment@v4
+      if: failure()
+      with:
+        comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+        reactions: confused
+        body: |
+          > ❌ Job failed.

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -25,6 +25,7 @@ jobs:
           commands: |
             fix-pr
             test-pr
+            poetry-lock
           static-args: |
             pr=${{ github.event.issue.number }}
             comment-id=${{ github.event.comment.id }}


### PR DESCRIPTION
This adds a new `/poetry-lock` slash command. It copies all code from the `/fix-pr` slash command, and adapts it slightly for this use case.

> **[Note]**
> This is in auto-merge status, ready to merge on approval.