### PR TITLE
Fix: Add back default schema name `'airbyte_raw'` for caches

### DIFF
--- a/airbyte/_future_cdk/sql_processor.py
+++ b/airbyte/_future_cdk/sql_processor.py
@@ -15,7 +15,7 @@ import pandas as pd
 import sqlalchemy
 import ulid
 from pandas import Index
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import (
     Column,
     Table,
@@ -77,7 +77,7 @@ class SQLRuntimeError(Exception):
 class SqlConfig(BaseModel, abc.ABC):
     """Common configuration for SQL connections."""
 
-    schema_name: str
+    schema_name: str = Field(default="airbyte_raw")
     """The name of the schema to write to."""
 
     table_prefix: Optional[str] = ""

--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -20,6 +20,7 @@ from airbyte import exceptions as exc
 from airbyte._future_cdk import SqlProcessorBase
 from airbyte._future_cdk.sql_processor import SqlConfig
 from airbyte._processors.file.jsonl import JsonlWriter
+from airbyte.constants import DEFAULT_CACHE_SCHEMA_NAME
 from airbyte.secrets.base import SecretString
 from airbyte.types import SQLTypeConverter
 
@@ -38,7 +39,7 @@ class BigQueryConfig(SqlConfig):
     database_name: str = Field(alias="project_name")
     """The name of the project to use. In BigQuery, this is equivalent to the database name."""
 
-    schema_name: str = Field(alias="dataset_name")
+    schema_name: str = Field(alias="dataset_name", default=DEFAULT_CACHE_SCHEMA_NAME)
     """The name of the dataset to use. In BigQuery, this is equivalent to the schema name."""
 
     credentials_path: Optional[str] = None

--- a/airbyte/_processors/sql/snowflake.py
+++ b/airbyte/_processors/sql/snowflake.py
@@ -15,6 +15,7 @@ from snowflake.sqlalchemy import URL, VARIANT
 from airbyte._future_cdk import SqlProcessorBase
 from airbyte._future_cdk.sql_processor import SqlConfig
 from airbyte._processors.file.jsonl import JsonlWriter
+from airbyte.constants import DEFAULT_CACHE_SCHEMA_NAME
 from airbyte.secrets.base import SecretString
 from airbyte.types import SQLTypeConverter
 
@@ -34,7 +35,7 @@ class SnowflakeConfig(SqlConfig):
     warehouse: str
     database: str
     role: str
-    schema_name: str = Field(default="PUBLIC")
+    schema_name: str = Field(default=DEFAULT_CACHE_SCHEMA_NAME)
 
     @overrides
     def get_database_name(self) -> str:

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -32,3 +32,9 @@ AB_INTERNAL_COLUMNS = {
     AB_META_COLUMN,
 }
 """A set of internal columns that are reserved for PyAirbyte's internal use."""
+
+DEFAULT_CACHE_SCHEMA_NAME = "airbyte_raw"
+"""The default schema name to use for caches.
+
+Specific caches may override this value with a different schema name.
+"""


### PR DESCRIPTION
This reverts back to `airbyte_raw` as the default schema name.

Some database types lost this default when we refactored in either `0.10.x` or `0.11.x`.

Anyone who is providing an explicit schema name will not be affected by this change.

⚠️ Set to auto-merge
