### PR TITLE
Fix: Wrap is_interactive checks in an exception handler 

### DIFF
--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -63,7 +63,7 @@ def is_interactive() -> bool:
         if is_ci():
             return False
 
-        return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())    
+        return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())
     except Exception:
         return False
 

--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -63,8 +63,7 @@ def is_interactive() -> bool:
         if is_ci():
             return False
 
-        return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())
-    
+        return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())    
     except Exception:
         return False
 

--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -56,13 +56,17 @@ def is_colab() -> bool:
 
 @lru_cache
 def is_interactive() -> bool:
-    if is_colab() or is_jupyter():
-        return True
+    try:
+        if is_colab() or is_jupyter():
+            return True
 
-    if is_ci():
+        if is_ci():
+            return False
+
+        return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())
+    
+    except Exception:
         return False
-
-    return bool(sys.__stdin__.isatty() and sys.__stdout__.isatty())
 
 
 @lru_cache


### PR DESCRIPTION
Catch exceptions and return False to better support ASGI runtimes