### PR TITLE
Fix: Postgres can't handle dict type (WIP) in source schema columns

### DIFF
--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -156,7 +156,7 @@ class SQLTypeConverter:
 
         if json_schema_type == "object":
             return sqlalchemy.types.JSON()
-        
+
         if json_schema_type == "dict":
             return sqlalchemy.types.JSON()
 

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -157,6 +157,8 @@ class SQLTypeConverter:
         if json_schema_type == "object":
             return sqlalchemy.types.JSON()
 
+        print("json_schema_type:::::::::::::::::::::::: ", json_schema_type)
+
         if json_schema_type == "dict":
             return sqlalchemy.types.JSON()
 

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -156,5 +156,8 @@ class SQLTypeConverter:
 
         if json_schema_type == "object":
             return sqlalchemy.types.JSON()
+        
+        if json_schema_type == "dict":
+            return sqlalchemy.types.JSON()
 
         return self.get_failover_type()


### PR DESCRIPTION
Related to https://github.com/airbytehq/PyAirbyte/issues/210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved database compatibility by adding support for JSON data types when `json_schema_type` is "dict."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->