### PR TITLE
Feat: Promote `get_source()` args for `docker_image` and `source_manifest` out of experimental status

### DIFF
--- a/airbyte/experimental/__init__.py
+++ b/airbyte/experimental/__init__.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 """Experimental features which may change.
 
+> **NOTE:**
+> The below "experimental" features are now "stable" and can be accessed directly from the
+`airbyte.get_source()` method.
+
 The experimental `get_source` implementation allows you to run sources
 using Docker containers. This feature is still in development and may
 change in the future.
@@ -34,7 +38,7 @@ You can help improve this product by reporting issues and providing feedback for
 
 from __future__ import annotations
 
-from airbyte.sources.util import _get_source as get_source
+from airbyte.sources.util import get_source
 
 
 __all__ = [

--- a/examples/run_declarative_manifest_source.py
+++ b/examples/run_declarative_manifest_source.py
@@ -12,7 +12,7 @@ from typing import cast
 
 import yaml
 
-from airbyte.experimental import get_source
+from airbyte import get_source
 
 
 # Copy-pasted from the Builder "Yaml" view:

--- a/examples/run_downloadable_yaml_source.py
+++ b/examples/run_downloadable_yaml_source.py
@@ -9,7 +9,7 @@ Usage (from PyAirbyte root directory):
 from __future__ import annotations
 
 import airbyte as ab
-from airbyte.experimental import get_source
+from airbyte import get_source
 
 
 yaml_connectors: list[str] = ab.get_available_connectors(install_type="yaml")

--- a/examples/run_pokeapi.py
+++ b/examples/run_pokeapi.py
@@ -11,7 +11,7 @@ if your installation gets interrupted or corrupted.
 from __future__ import annotations
 
 import airbyte as ab
-from airbyte.experimental import get_source
+from airbyte import get_source
 
 
 source = get_source(

--- a/tests/integration_tests/test_all_cache_types.py
+++ b/tests/integration_tests/test_all_cache_types.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 import airbyte as ab
 import pytest
+from airbyte import get_source
 from airbyte._executor import _get_bin_dir
-from airbyte.experimental import get_source
 from airbyte.progress import ReadProgress, progress
 
 # Product count is always the same, regardless of faker scale.

--- a/tests/integration_tests/test_lowcode_connectors.py
+++ b/tests/integration_tests/test_lowcode_connectors.py
@@ -7,7 +7,7 @@ import airbyte
 import jsonschema
 import pytest
 from airbyte import exceptions as exc
-from airbyte.experimental import get_source
+from airbyte import get_source
 from airbyte.sources.registry import (
     _LOWCODE_CONNECTORS_404,
     _LOWCODE_CONNECTORS_FAILING_VALIDATION,

--- a/tests/unit_tests/test_lowcode_connectors.py
+++ b/tests/unit_tests/test_lowcode_connectors.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from airbyte import get_source
 from airbyte._util.meta import is_windows
-from airbyte.experimental import get_source
 
 UNIT_TEST_DB_PATH: Path = Path(".cache") / "unit_tests" / "test_db.duckdb"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `get_source` functionality is now stable and accessible directly from `airbyte`.

- **Refactor**
  - Unified `get_source` imports across various modules to use the stable `airbyte` namespace.

- **Bug Fixes**
  - Improved handling and flexibility of `source_manifest` inputs in `get_source`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->