### PR TITLE
Feat: Replace ULID raw record ID with UUID v7

### DIFF
--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -72,7 +72,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import pytz
-import ulid
+from uuid_extensions import uuid7str
 
 from airbyte._util.name_normalizers import LowerCaseNormalizer, NameNormalizerBase
 from airbyte.constants import (
@@ -142,7 +142,7 @@ class StreamRecord(dict[str, Any]):
     ) -> StreamRecord:
         """Return a StreamRecord from a RecordMessage."""
         data_dict: dict[str, Any] = record_message.data.copy()
-        data_dict[AB_RAW_ID_COLUMN] = str(ulid.ULID())
+        data_dict[AB_RAW_ID_COLUMN] = uuid7str()
         data_dict[AB_EXTRACTED_AT_COLUMN] = datetime.fromtimestamp(
             record_message.emitted_at / 1000, tz=pytz.utc
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3096,16 +3096,6 @@ files = [
 ]
 
 [[package]]
-name = "ulid"
-version = "1.1"
-description = "Pyhton version of this: https://github.com/alizain/ulid"
-optional = false
-python-versions = "*"
-files = [
-    {file = "ulid-1.1.tar.gz", hash = "sha256:0943e8a751ec10dfcdb4df2758f96dffbbfbc055d0b49288caf2f92125900d49"},
-]
-
-[[package]]
 name = "url-normalize"
 version = "1.4.3"
 description = "URL normalization for Python"
@@ -3291,4 +3281,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ae4cadb85bebf085efcce7f803ec1819533f6152ef8593e7c70df2d743d1b149"
+content-hash = "7e9aaffa809364bd2505f706b2e8edc654a19c796ef4f727c880ac24411e432b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1285,8 +1285,8 @@ files = [
 [package.dependencies]
 orjson = ">=3.9.14,<4.0.0"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 requests = ">=2,<3"
 
@@ -1655,8 +1655,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -2035,8 +2035,8 @@ files = [
 annotated-types = ">=0.4.0"
 pydantic-core = "2.20.1"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -3136,6 +3136,17 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "uuid7"
+version = "0.1.0"
+description = "UUID version 7, generating time-sorted UUIDs with 200ns time resolution and 48 bits of randomness"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61"},
+    {file = "uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c"},
+]
+
+[[package]]
 name = "viztracer"
 version = "0.16.3"
 description = "A debugging and profiling tool that can trace and visualize python code execution"
@@ -3280,4 +3291,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "e1fe01b809eaef2971032ef7e1777bcbfcc24a58746d2e7d12c7e82f44a6fede"
+content-hash = "ae4cadb85bebf085efcce7f803ec1819533f6152ef8593e7c70df2d743d1b149"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ snowflake-connector-python = "^3.10.0"
 snowflake-sqlalchemy = "^1.5.1"
 sqlalchemy = "1.4.51"
 types-pyyaml = "^6.0.12.12"
-ulid = "^1.1"
 
 # TODO: Remove this arbitrary python constraint once `sqlalchemy-bigquery` has done so.
 sqlalchemy-bigquery = { version = "1.9.0", python = "<3.13" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ ulid = "^1.1"
 sqlalchemy-bigquery = { version = "1.9.0", python = "<3.13" }
 airbyte-api = "^0.49.2"
 google-cloud-bigquery-storage = "^2.25.0"
+uuid7 = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
 docker = "^7.0.0"


### PR DESCRIPTION
## Summary

- Improved unique ID generation by switching from ULID to a custom UUID method, ensuring more robust and unique identifier creation.
Chores

- Updated dependencies in pyproject.toml, including the addition of the uuid7 and types-pyyaml packages, while removing ulid.

In the previous flamegraph, the ULID creation was taking approx. 4us, plus up to 5us to convert to `str` type. The `UUID v7` implementation generates a UUID in one step in approx 2us. This cuts off approximately 7us out of ~26us processing time per record, or up to 30% of the per-record processing time.

Now (2us of 19us total):

<img width="436" alt="image" src="https://github.com/user-attachments/assets/ce8101d8-b5cc-427a-849e-a89e26bbcd56">

Previous (4+5us, combined 9us of 27us total):

<img width="377" alt="image" src="https://github.com/user-attachments/assets/8cc4f873-e155-4cfc-9346-5f8b8ebeb931">



Notes:

- ULIDs are still used for batch IDs, file name suffixes, and table name suffixes. This change only affects unique record IDs.
- In working this PR, I found that there was an unused dependency on `ulid` library, where we are/were actually using `python-ulid`.
- A nice added benefit is that the row IDs are now compatible with the UUID column type.

New benchmark (41K records / sec using the `e2e` source):

`poetry run python ./examples/run_perf_test_reads.py -e=6 --source=e2e`

<img width="641" alt="image" src="https://github.com/user-attachments/assets/e32a4e24-2a45-4e5c-9e62-a52a6530c0c4">
