### PR TITLE
Feat: Faster per-record processing

### DIFF
--- a/airbyte/_future_cdk/record_processor.py
+++ b/airbyte/_future_cdk/record_processor.py
@@ -194,6 +194,7 @@ class RecordProcessorBase(abc.ABC):
                         json_schema=self.catalog_provider.get_stream_json_schema(
                             stream_name=stream_name,
                         ),
+                        normalize_keys=True,
                         prune_extra_fields=False,
                     )
 

--- a/airbyte/_future_cdk/record_processor.py
+++ b/airbyte/_future_cdk/record_processor.py
@@ -157,7 +157,7 @@ class RecordProcessorBase(abc.ABC):
     def process_record_message(
         self,
         record_msg: AirbyteRecordMessage,
-        stream_schema: dict,
+        stream_record_handler: StreamRecordHandler,
     ) -> None:
         """Write a record.
 
@@ -199,7 +199,7 @@ class RecordProcessorBase(abc.ABC):
 
                 self.process_record_message(
                     record_msg,
-                    stream_schema=stream_schemas[stream_name],
+                    stream_record_handler=stream_record_handlers[stream_name],
                 )
 
             elif message.type is Type.STATE:

--- a/airbyte/_future_cdk/sql_processor.py
+++ b/airbyte/_future_cdk/sql_processor.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from airbyte._future_cdk.catalog_providers import CatalogProvider
     from airbyte._future_cdk.state_writers import StateWriterBase
     from airbyte._processors.file.base import FileWriterBase
+    from airbyte.records import StreamRecordHandler
     from airbyte.secrets.base import SecretString
 
 
@@ -227,7 +228,7 @@ class SqlProcessorBase(RecordProcessorBase):
     def process_record_message(
         self,
         record_msg: AirbyteRecordMessage,
-        stream_schema: dict,
+        stream_record_handler: StreamRecordHandler,
     ) -> None:
         """Write a record to the cache.
 
@@ -238,7 +239,7 @@ class SqlProcessorBase(RecordProcessorBase):
         """
         self.file_writer.process_record_message(
             record_msg,
-            stream_schema=stream_schema,
+            stream_record_handler=stream_record_handler,
         )
 
     # Protected members (non-public interface):

--- a/airbyte/_processors/file/base.py
+++ b/airbyte/_processors/file/base.py
@@ -12,9 +12,8 @@ import ulid
 
 from airbyte import exceptions as exc
 from airbyte._batch_handles import BatchHandle
-from airbyte._util.name_normalizers import LowerCaseNormalizer
 from airbyte.progress import progress
-from airbyte.records import StreamRecord
+from airbyte.records import StreamRecord, StreamRecordHandler
 
 
 if TYPE_CHECKING:
@@ -142,7 +141,7 @@ class FileWriterBase(abc.ABC):
     def process_record_message(
         self,
         record_msg: AirbyteRecordMessage,
-        stream_schema: dict,
+        stream_record_handler: StreamRecordHandler,
     ) -> None:
         """Write a record to the cache.
 
@@ -167,9 +166,7 @@ class FileWriterBase(abc.ABC):
         self._write_record_dict(
             record_dict=StreamRecord.from_record_message(
                 record_message=record_msg,
-                expected_keys=stream_schema["properties"].keys(),
-                normalizer=LowerCaseNormalizer,
-                prune_extra_fields=self.prune_extra_fields,
+                stream_record_handler=stream_record_handler,
             ),
             open_file_writer=batch_handle.open_file_writer,
         )

--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -89,6 +89,80 @@ if TYPE_CHECKING:
     )
 
 
+class StreamRecordHandler:
+    """A class to handle processing of StreamRecords.
+
+    This is a long-lived object that can be used to process multiple StreamRecords, which
+    saves on memory and processing time by reusing the same object for all records of the same type.
+    """
+
+    def __init__(
+        self,
+        *,
+        json_schema: dict,
+        normalizer: type[NameNormalizerBase] = NameNormalizerBase,
+        normalize_keys: bool = True,
+        prune_extra_fields: bool,
+    ) -> None:
+        """Initialize the dictionary with the given data.
+
+        Args:
+            json_schema: The JSON Schema definition for this stream.
+            normalizer: The normalizer to use when normalizing keys. If not provided, the
+                LowerCaseNormalizer will be used.
+            normalize_keys: If `True`, the keys will be normalized using the given normalizer.
+            prune_extra_fields: If `True`, unexpected fields will be removed.
+        """
+        self._expected_keys: list[str] = list(json_schema.get("properties", {}).keys())
+        self._normalizer: type[NameNormalizerBase] = normalizer
+        self._normalize_keys: bool = normalize_keys
+        self.prune_extra_fields: bool = prune_extra_fields
+
+        self.index_keys: list[str] = [
+            self._normalizer.normalize(key) if self._normalize_keys else key
+            for key in self._expected_keys
+        ]
+        self.normalized_keys: list[str] = [
+            self._normalizer.normalize(key) for key in self._expected_keys
+        ]
+        self.quick_lookup: dict[str, str]
+
+        for internal_col in AB_INTERNAL_COLUMNS:
+            if internal_col not in self._expected_keys:
+                self._expected_keys.append(internal_col)
+
+        # Store a lookup from normalized keys to pretty cased (originally cased) keys.
+        self._pretty_case_lookup: dict[str, str] = {
+            self._normalizer.normalize(pretty_case.lower()): pretty_case
+            for pretty_case in self._expected_keys
+        }
+        # Store a map from all key versions (normalized and pretty-cased) to their normalized
+        # version.
+        self.quick_lookup = {
+            key: self._normalizer.normalize(key)
+            for key in set(self._expected_keys) | set(self._pretty_case_lookup.values())
+        }
+
+    def to_display_case(self, key: str) -> str:
+        """Return the original case of the key."""
+        return self._pretty_case_lookup[self._normalizer.normalize(key)]
+
+    def to_index_case(self, key: str) -> str:
+        """Return the internal case of the key.
+
+        If `normalize_keys` is True, returns the normalized key.
+        Otherwise, return the original case ("pretty case") of the key.
+        """
+        try:
+            return self.quick_lookup[key]
+        except KeyError:
+            result = (
+                self._normalizer.normalize(key) if self._normalize_keys else self._display_case(key)
+            )
+            self.quick_lookup[key] = result
+            return result
+
+
 class StreamRecord(dict[str, Any]):
     """The StreamRecord class is a case-aware, case-insensitive dictionary implementation.
 
@@ -115,30 +189,41 @@ class StreamRecord(dict[str, Any]):
     determine the original case of the keys.
     """
 
-    def _display_case(self, key: str) -> str:
-        """Return the original case of the key."""
-        return self._pretty_case_keys[self._normalizer.normalize(key)]
+    def __init__(
+        self,
+        from_dict: dict,
+        *,
+        stream_record_handler: StreamRecordHandler,
+    ) -> None:
+        """Initialize the dictionary with the given data.
 
-    def _index_case(self, key: str) -> str:
-        """Return the internal case of the key.
-
-        If normalize_keys is True, return the normalized key.
-        Otherwise, return the original case of the key.
+        Args:
+            from_dict: The dictionary to initialize the StreamRecord with.
+            stream_record_handler: The StreamRecordHandler to use for processing the record.
         """
-        if self._normalize_keys:
-            return self._normalizer.normalize(key)
+        self._stream_handler: StreamRecordHandler = stream_record_handler
 
-        return self._display_case(key)
+        # Start by initializing all values to None
+        self.update(dict.fromkeys(stream_record_handler.normalized_keys))
+
+        # Update the dictionary with the given data
+        if self._stream_handler.prune_extra_fields:
+            self.update(
+                {
+                    self._stream_handler.to_index_case(k): v
+                    for k, v in from_dict.items()
+                    if self._stream_handler.to_index_case(k) in self._stream_handler.index_keys
+                }
+            )
+        else:
+            self.update({self._stream_handler.to_index_case(k): v for k, v in from_dict.items()})
 
     @classmethod
     def from_record_message(
         cls,
         record_message: AirbyteRecordMessage,
         *,
-        prune_extra_fields: bool,
-        normalize_keys: bool = True,
-        normalizer: type[NameNormalizerBase] | None = None,
-        expected_keys: list[str] | None = None,
+        stream_record_handler: StreamRecordHandler,
     ) -> StreamRecord:
         """Return a StreamRecord from a RecordMessage."""
         data_dict: dict[str, Any] = record_message.data.copy()
@@ -156,69 +241,11 @@ class StreamRecord(dict[str, Any]):
             expected_keys=expected_keys,
         )
 
-    def __init__(
-        self,
-        from_dict: dict,
-        *,
-        prune_extra_fields: bool,
-        normalize_keys: bool = True,
-        normalizer: type[NameNormalizerBase] | None = None,
-        expected_keys: list[str] | None = None,
-    ) -> None:
-        """Initialize the dictionary with the given data.
-
-        Args:
-            from_dict: The dictionary to initialize the StreamRecord with.
-            prune_extra_fields: If `True`, unexpected fields will be removed.
-            normalize_keys: If `True`, the keys will be normalized using the given normalizer.
-            normalizer: The normalizer to use when normalizing keys. If not provided, the
-                LowerCaseNormalizer will be used.
-            expected_keys: If provided and `prune_extra_fields` is True, then unexpected fields
-                will be removed. This option is ignored if `expected_keys` is not provided.
-        """
-        # If no normalizer is provided, use LowerCaseNormalizer.
-        self._normalize_keys = normalize_keys
-        self._normalizer: type[NameNormalizerBase] = normalizer or LowerCaseNormalizer
-
-        # If no expected keys are provided, use all keys from the input dictionary.
-        if not expected_keys:
-            expected_keys = list(from_dict.keys())
-            prune_extra_fields = False  # No expected keys provided.
-        else:
-            expected_keys = list(expected_keys)
-
-        for internal_col in AB_INTERNAL_COLUMNS:
-            if internal_col not in expected_keys:
-                expected_keys.append(internal_col)
-
-        # Store a lookup from normalized keys to pretty cased (originally cased) keys.
-        self._pretty_case_keys: dict[str, str] = {
-            self._normalizer.normalize(pretty_case.lower()): pretty_case
-            for pretty_case in expected_keys
-        }
-
-        if normalize_keys:
-            index_keys = [self._normalizer.normalize(key) for key in expected_keys]
-        else:
-            index_keys = expected_keys
-
-        self.update(dict.fromkeys(index_keys))  # Start by initializing all values to None
-        for k, v in from_dict.items():
-            index_cased_key = self._index_case(k)
-            if prune_extra_fields and index_cased_key not in index_keys:
-                # Dropping undeclared field
-                continue
-
-            self[index_cased_key] = v
-
     def __getitem__(self, key: str) -> Any:  # noqa: ANN401
-        if super().__contains__(key):
+        try:
             return super().__getitem__(key)
-
-        if super().__contains__(self._index_case(key)):
+        except KeyError:
             return super().__getitem__(self._index_case(key))
-
-        raise KeyError(key)
 
     def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
         if super().__contains__(key):
@@ -230,18 +257,20 @@ class StreamRecord(dict[str, Any]):
             return
 
         # Store the pretty cased (originally cased) key:
-        self._pretty_case_keys[self._normalizer.normalize(key)] = key
+        self._pretty_case_lookup[self._normalizer.normalize(key)] = key
 
         # Store the data with the normalized key:
         super().__setitem__(self._index_case(key), value)
 
     def __delitem__(self, key: str) -> None:
-        if super().__contains__(key):
+        try:
             super().__delitem__(key)
-            return
-
-        if super().__contains__(self._index_case(key)):
-            super().__delitem__(self._index_case(key))
+        except KeyError:
+            if super().__contains__(self._index_case(key)):
+                super().__delitem__(self._index_case(key))
+                return
+        else:
+            # No failure. Key was deleted.
             return
 
         raise KeyError(key)

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -455,8 +455,8 @@ class Source:  # noqa: PLR0904  # Ignore max publish methods
 
         stream_record_handler = StreamRecordHandler(
             json_schema=self.get_stream_json_schema(stream),
-            normalize_keys=False,
             prune_extra_fields=True,
+            normalize_keys=False,
         )
 
         iterator: Iterator[dict[str, Any]] = _with_logging(


### PR DESCRIPTION
This brings per-record parsing time down from approx. `20us` to roughly `10us`. We accomplish this by decoupling stream-level logic from record-level processing, meaning we build the logic handler for each stream at the start of the stream, and then reuse the handler's logic on those individual records.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/de5c6549-7fc9-4d08-ad08-c1279362defd">

Note:

- This doesn't modify the operation to write to gzip file, which now is about equal with the parsing logic - roughly another `10-13us` for each write to gzip file.
- Since the gzip `write` is entirely one step performed by the `gzip` module, the only options to speed up are: (a) write more records at once instead of one at a time, (b) use another library if there is a faster option, (c) do both a+b but also just migrate to something else entirely like parquet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `StreamRecordHandler` to enhance stream record processing capabilities.
  
- **Refactor**
  - Updated several functions to use `StreamRecordHandler` instead of dictionaries for stream schemas, improving schema handling and processing efficiency.

- **Tests**
  - Enhanced test cases to incorporate `StreamRecordHandler` with updated stream schema handling parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->