### PR TITLE
Chore: Compile pytest tests as part of `poe check`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,7 @@ coverage-report = { shell = "coverage report" }
 coverage-html = { shell = "coverage html -d htmlcov && open htmlcov/index.html" }
 coverage-reset = { shell = "coverage erase" }
 
-check = { shell = "ruff check . && mypy ." }
+check = { shell = "ruff check . && mypy . && pytest --collect-only" }
 
 fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
 fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe-fixes . && ruff format ." }


### PR DESCRIPTION
Modified the `check` script in `pyproject.toml` to include `pytest --collect-only` in addition to `ruff check` and `mypy`. This ensures that pytest can collect tests without running them, helping catch collection errors early.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `check` command to include test case collection, improving the testing workflow.
  
- **Bug Fixes**
	- Ensured that test discovery is integrated into the checking process, enhancing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->