### PR TITLE
Docs: Improve docstrings and automated API ref docs

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -188,9 +188,9 @@ class ConnectorBase(abc.ABC):
         """Print the configuration spec for this connector.
 
         Args:
-        - format: The format to print the spec in. Must be "yaml" or "json".
-        - output_file: Optional. If set, the spec will be written to the given file path. Otherwise,
-          it will be printed to the console.
+            format: The format to print the spec in. Must be "yaml" or "json".
+            output_file: Optional. If set, the spec will be written to the given file path.
+                Otherwise, it will be printed to the console.
         """
         if format not in {"yaml", "json"}:
             raise exc.PyAirbyteInputError(

--- a/airbyte/_future_cdk/sql_processor.py
+++ b/airbyte/_future_cdk/sql_processor.py
@@ -431,10 +431,8 @@ class SqlProcessorBase(RecordProcessorBase):
 
         Raises an exception if the table schema is not compatible with the schema of the
         input stream.
-
-        TODO:
-        - Expand this to check for column types and sizes.
         """
+        # TODO: Expand this to check for column types and sizes.
         self._add_missing_columns_to_table(
             stream_name=stream_name,
             table_name=table_name,

--- a/airbyte/_message_iterators.py
+++ b/airbyte/_message_iterators.py
@@ -59,7 +59,6 @@ class AirbyteMessageIterator:
     @classmethod
     def from_read_result(cls, read_result: ReadResult) -> AirbyteMessageIterator:
         """Create a iterator from a `ReadResult` object."""
-
         state_provider = read_result.cache.get_state_provider(
             source_name=read_result.source_name,
             refresh=True,

--- a/airbyte/_processors/sql/snowflakecortex.py
+++ b/airbyte/_processors/sql/snowflakecortex.py
@@ -164,7 +164,7 @@ class SnowflakeCortexSqlProcessor(SnowflakeSqlProcessor):
         stream_name: str,
         table_name: str,
     ) -> None:
-        """Use Snowflake Python connector to add new columns to the table"""
+        """Use Snowflake Python connector to add new columns to the table."""
         columns = self._get_sql_column_definitions(stream_name)
         existing_columns = self._get_column_list_from_table(table_name)
         for column_name, column_type in columns.items():

--- a/airbyte/caches/_catalog_backend.py
+++ b/airbyte/caches/_catalog_backend.py
@@ -49,10 +49,11 @@ class CachedStream(SqlAlchemyModel):  # type: ignore[valid-type,misc]
 
 
 class CatalogBackendBase(abc.ABC):
-    """
-    A class to manage the stream catalog of data synced to a cache:
-    * What streams exist and to what tables they map
-    * The JSON schema for each stream
+    """A class to manage the stream catalog of data synced to a cache.
+
+    This includes:
+    - What streams exist and to what tables they map
+    - The JSON schema for each stream
     """
 
     # Abstract implementations
@@ -101,10 +102,11 @@ class CatalogBackendBase(abc.ABC):
 
 
 class SqlCatalogBackend(CatalogBackendBase):
-    """
-    A class to manage the stream catalog of data synced to a cache:
+    """A class to manage the stream catalog of data synced to a cache.
+
+    This includes:
     - What streams exist and to what tables they map
-    - The JSON schema for each stream
+    - The JSON schema for each stream.
     """
 
     def __init__(

--- a/airbyte/caches/_state_backend.py
+++ b/airbyte/caches/_state_backend.py
@@ -179,9 +179,9 @@ class SqlStateWriter(StateWriterBase):
 
 
 class SqlStateBackend(StateBackendBase):
-    """
-    A class to manage the stream catalog of data synced to a cache:
+    """A class to manage the stream catalog of data synced to a cache.
 
+    This includes:
     - What streams exist and to what tables they map
     - The JSON schema for each stream
     """

--- a/airbyte/caches/bigquery.py
+++ b/airbyte/caches/bigquery.py
@@ -40,7 +40,8 @@ class BigQueryCache(BigQueryConfig, CacheBase):
         max_chunk_size: int = DEFAULT_ARROW_MAX_CHUNK_SIZE,
     ) -> NoReturn:
         """Raises NotImplementedError; BigQuery doesn't support `pd.read_sql_table`.
-        https://github.com/airbytehq/PyAirbyte/issues/165
+
+        See: https://github.com/airbytehq/PyAirbyte/issues/165
         """
         raise NotImplementedError(
             "BigQuery doesn't currently support to_arrow"

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -97,10 +97,12 @@ class CloudConnection:
 
     @property
     def connection_url(self) -> str | None:
+        """The URL to the connection."""
         return f"{self.workspace.workspace_url}/connections/{self.connection_id}"
 
     @property
     def job_history_url(self) -> str | None:
+        """The URL to the job history for the connection."""
         return f"{self.connection_url}/job-history"
 
     # Run Sync

--- a/airbyte/cloud/experimental.py
+++ b/airbyte/cloud/experimental.py
@@ -41,7 +41,7 @@ warnings.warn(
 )
 
 
-class CloudWorkspace(Stable_CloudWorkspace):
+class CloudWorkspace(Stable_CloudWorkspace):  # noqa: D101  # Docstring inherited from parent.
     __doc__ = (
         f"Experimental implementation of `.CloudWorkspace`.\n\n{Stable_CloudConnection.__doc__}"
     )
@@ -53,7 +53,7 @@ class CloudWorkspace(Stable_CloudWorkspace):
     permanently_delete_destination = Stable_CloudWorkspace._permanently_delete_destination
 
 
-class CloudConnection(Stable_CloudConnection):
+class CloudConnection(Stable_CloudConnection):  # noqa: D101  # Docstring inherited from parent.
     __doc__ = (
         f"Experimental implementation of `.CloudConnection`.\n\n{Stable_CloudConnection.__doc__}"
     )

--- a/airbyte/cloud/sync_results.py
+++ b/airbyte/cloud/sync_results.py
@@ -346,7 +346,6 @@ class SyncResult:
             return self.parent.get_dataset(stream_name=key)
 
         def __iter__(self) -> Iterator[str]:
-            """TODO"""
             return iter(self.parent.stream_names)
 
         def __len__(self) -> int:

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -46,6 +46,7 @@ class CloudWorkspace:
 
     @property
     def workspace_url(self) -> str | None:
+        """The URL of the workspace."""
         return f"{self.api_root}/workspaces/{self.workspace_id}"
 
     # Test connection and creds
@@ -202,6 +203,10 @@ class CloudWorkspace:
                 `cache` or `destination`, but not both.
             destination (str, optional): The destination ID to use. You can provide
                 `cache` or `destination`, but not both.
+            table_prefix (str, optional): The table prefix to use for the cache. If not provided,
+                the cache's table prefix will be used.
+            selected_streams (list[str], optional): The selected stream names to use for the
+                connection. If not provided, the source's selected streams will be used.
         """
         # Resolve source ID
         source_id: str

--- a/airbyte/documents.py
+++ b/airbyte/documents.py
@@ -44,6 +44,7 @@ class Document(BaseModel):
     last_modified: Optional[datetime.datetime] = Field(default=None)
 
     def __str__(self) -> str:
+        """Return a string representation of the document."""
         return self.content
 
     @property

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -80,6 +80,7 @@ class PyAirbyteError(Exception):
         return self.__doc__.split("\n")[0] if self.__doc__ else ""
 
     def __str__(self) -> str:
+        """Return a string representation of the exception."""
         special_properties = ["message", "guidance", "help_url", "log_text", "context"]
         display_properties = {
             k: v
@@ -109,6 +110,7 @@ class PyAirbyteError(Exception):
         return exception_str
 
     def __repr__(self) -> str:
+        """Return a string representation of the exception."""
         class_name = self.__class__.__name__
         properties_str = ", ".join(
             f"{k}={v!r}" for k, v in self.__dict__.items() if not k.startswith("_")
@@ -383,6 +385,7 @@ class AirbyteError(PyAirbyteError):
 
     @property
     def workspace_url(self) -> str | None:
+        """The URL to the workspace where the error occurred."""
         if self.workspace:
             return self.workspace.workspace_url
 
@@ -404,6 +407,7 @@ class AirbyteConnectionError(AirbyteError):
 
     @property
     def connection_url(self) -> str | None:
+        """The URL to the connection where the error occurred."""
         if self.workspace_url and self.connection_id:
             return f"{self.workspace_url}/connections/{self.connection_id}"
 
@@ -411,6 +415,7 @@ class AirbyteConnectionError(AirbyteError):
 
     @property
     def job_history_url(self) -> str | None:
+        """The URL to the job history where the error occurred."""
         if self.connection_url:
             return f"{self.connection_url}/job-history"
 
@@ -418,6 +423,7 @@ class AirbyteConnectionError(AirbyteError):
 
     @property
     def job_url(self) -> str | None:
+        """The URL to the job where the error occurred."""
         if self.job_history_url and self.job_id:
             return f"{self.job_history_url}#{self.job_id}::0"
 

--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -208,6 +208,9 @@ class StreamRecord(dict[str, Any]):
         Args:
             from_dict: The dictionary to initialize the StreamRecord with.
             stream_record_handler: The StreamRecordHandler to use for processing the record.
+            with_internal_columns: If `True`, the internal columns will be added to the record.
+            extracted_at: The time the record was extracted. If not provided, the current time will
+                be used.
         """
         self._stream_handler: StreamRecordHandler = stream_record_handler
 
@@ -252,12 +255,14 @@ class StreamRecord(dict[str, Any]):
         )
 
     def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        """Return the item with the given key."""
         try:
             return super().__getitem__(key)
         except KeyError:
             return super().__getitem__(self._stream_handler.to_index_case(key))
 
     def __setitem__(self, key: str, value: Any) -> None:  # noqa: ANN401
+        """Set the item with the given key to the given value."""
         index_case_key = self._stream_handler.to_index_case(key)
         if (
             self._stream_handler.prune_extra_fields
@@ -268,6 +273,7 @@ class StreamRecord(dict[str, Any]):
         super().__setitem__(index_case_key, value)
 
     def __delitem__(self, key: str) -> None:
+        """Delete the item with the given key."""
         try:
             super().__delitem__(key)
         except KeyError:
@@ -282,18 +288,22 @@ class StreamRecord(dict[str, Any]):
         raise KeyError(key)
 
     def __contains__(self, key: object) -> bool:
+        """Return whether the dictionary contains the given key."""
         assert isinstance(key, str), "Key must be a string."
         return super().__contains__(key) or super().__contains__(
             self._stream_handler.to_index_case(key)
         )
 
     def __iter__(self) -> Iterator[str]:
+        """Return an iterator over the keys of the dictionary."""
         return iter(super().__iter__())
 
     def __len__(self) -> int:
+        """Return the number of items in the dictionary."""
         return super().__len__()
 
     def __eq__(self, other: object) -> bool:
+        """Return whether the StreamRecord is equal to the given dict or StreamRecord object."""
         if isinstance(other, StreamRecord):
             return dict(self) == dict(other)
 

--- a/airbyte/secrets/base.py
+++ b/airbyte/secrets/base.py
@@ -55,7 +55,8 @@ class SecretString(str):
     def __bool__(self) -> bool:
         """Override the boolean value of the secret string.
 
-        Always returns `True` without inspecting contents."""
+        Always returns `True` without inspecting contents.
+        """
         return True
 
     def parse_json(self) -> dict:
@@ -102,8 +103,7 @@ class SecretString(str):
     def __get_pydantic_json_schema__(  # noqa: PLW3201  # Pydantic dunder method
         cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
-        """
-        Return a modified JSON schema for the secret string.
+        """Return a modified JSON schema for the secret string.
 
         - `writeOnly=True` is the official way to prevent secrets from being exposed inadvertently.
         - `Format=password` is a popular and readable convention to indicate the field is sensitive.

--- a/airbyte/secrets/base.py
+++ b/airbyte/secrets/base.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class SecretSourceEnum(str, Enum):
+    """Enumeration of secret sources supported by PyAirbyte."""
+
     ENV = "env"
     DOTENV = "dotenv"
     GOOGLE_COLAB = "google_colab"
@@ -31,12 +33,30 @@ class SecretString(str):
     """A string that represents a secret.
 
     This class is used to mark a string as a secret. When a secret is printed, it
-    will be masked to prevent accidental exposure of sensitive information.
+    will be masked to prevent accidental exposure of sensitive information when debugging
+    or when printing containing objects like dictionaries.
+
+    To create a secret string, simply instantiate the class with any string value:
+
+        ```python
+        secret = SecretString("my_secret_password")
+        ```
+
     """
 
     __slots__ = ()
 
     def __repr__(self) -> str:
+        """Override the representation of the secret string to return a masked value.
+
+        The secret string is always masked with `****` to prevent accidental exposure, unless
+        explicitly converted to a string. For instance, printing a config dictionary that contains
+        a secret will automatically mask the secret value instead of printing it in plain text.
+
+        However, if you explicitly convert the cast the secret as a string, such as when used
+        in an f-string, the secret will be exposed. This is the desired behavior to allow
+        secrets to be used in a controlled manner.
+        """
         return "<SecretString: ****>"
 
     def is_empty(self) -> bool:
@@ -95,6 +115,7 @@ class SecretString(str):
         source_type: Any,  # noqa: ANN401  # Must allow `Any` to match Pydantic signature
         handler: GetCoreSchemaHandler,
     ) -> CoreSchema:
+        """Return a modified core schema for the secret string."""
         return core_schema.with_info_after_validator_function(
             function=cls.validate, schema=handler(str), field_name=handler.field_name
         )
@@ -157,9 +178,11 @@ class SecretManager(ABC):
         ...
 
     def __str__(self) -> str:
+        """Return the name of the secret manager."""
         return self.name
 
     def __eq__(self, value: object) -> bool:
+        """Check if the secret manager is equal to another secret manager."""
         if isinstance(value, SecretManager):
             return self.name == value.name
 
@@ -172,6 +195,10 @@ class SecretManager(ABC):
         return super().__eq__(value)
 
     def __hash__(self) -> int:
+        """Return a hash of the secret manager name.
+
+        This allows the secret manager to be used in sets and dictionaries.
+        """
         return hash(self.name)
 
 

--- a/airbyte/secrets/custom.py
+++ b/airbyte/secrets/custom.py
@@ -22,6 +22,7 @@ class CustomSecretManager(SecretManager, ABC):
     as_backup = False
 
     def __init__(self) -> None:
+        """Initialize the custom secret manager."""
         super().__init__()
         if self.auto_register:
             self.register()

--- a/airbyte/secrets/google_colab.py
+++ b/airbyte/secrets/google_colab.py
@@ -12,6 +12,7 @@ class ColabSecretManager(SecretManager):
     name = SecretSourceEnum.GOOGLE_COLAB.value
 
     def __init__(self) -> None:
+        """Initialize the Google Colab secret manager."""
         try:
             from google.colab import (  # pyright: ignore[reportMissingImports]  # noqa: PLC0415
                 userdata as colab_userdata,

--- a/airbyte/secrets/prompt.py
+++ b/airbyte/secrets/prompt.py
@@ -18,6 +18,10 @@ class SecretsPrompt(SecretManager):
         self,
         secret_name: str,
     ) -> SecretString | None:
+        """Prompt the user to enter a secret.
+
+        As a security measure, the secret is not echoed to the terminal when typed.
+        """
         with contextlib.suppress(Exception):
             return SecretString(getpass(f"Enter the value for secret '{secret_name}': "))
 

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -98,7 +98,7 @@ class Source(ConnectorBase):
         self.select_streams(streams)
 
     def _log_warning_preselected_stream(self, streams: str | list[str]) -> None:
-        """Logs a warning message indicating stream selection which are not selected yet"""
+        """Logs a warning message indicating stream selection which are not selected yet."""
         if streams == "*":
             print(
                 "Warning: Config is not set yet. All streams will be selected after config is set."

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Base class implementation for sources."""
+
 from __future__ import annotations
 
 import json
@@ -126,7 +128,7 @@ class Source(ConnectorBase):
         """Select the stream names that should be read from the connector.
 
         Args:
-        - streams: A list of stream names to select. If set to "*", all streams will be selected.
+            streams: A list of stream names to select. If set to "*", all streams will be selected.
 
         Currently, if this is not set, all streams will be read.
         """
@@ -268,9 +270,9 @@ class Source(ConnectorBase):
         """Print the configuration spec for this connector.
 
         Args:
-        - format: The format to print the spec in. Must be "yaml" or "json".
-        - output_file: Optional. If set, the spec will be written to the given file path. Otherwise,
-          it will be printed to the console.
+            format: The format to print the spec in. Must be "yaml" or "json".
+            output_file: Optional. If set, the spec will be written to the given file path.
+                Otherwise, it will be printed to the console.
         """
         if format not in {"yaml", "json"}:
             raise exc.PyAirbyteInputError(
@@ -349,6 +351,13 @@ class Source(ConnectorBase):
         self,
         streams: Literal["*"] | list[str] | None = None,
     ) -> ConfiguredAirbyteCatalog:
+        """Get a configured catalog for the given streams.
+
+        If no streams are provided, the selected streams will be used. If no streams are selected,
+        all available streams will be used.
+
+        If '*' is provided, all available streams will be used.
+        """
         selected_streams: list[str] = []
         if streams is None:
             selected_streams = self._selected_stream_names or self.get_available_streams()

--- a/airbyte/sources/registry.py
+++ b/airbyte/sources/registry.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Connectivity to the connector catalog registry."""
+
 from __future__ import annotations
 
 import json
@@ -104,6 +106,8 @@ _LOWCODE_CONNECTORS_EXCLUDED: list[str] = [
 
 
 class InstallType(str, Enum):
+    """The type of installation for a connector."""
+
     YAML = "yaml"
     PYTHON = "python"
     DOCKER = "docker"
@@ -111,6 +115,8 @@ class InstallType(str, Enum):
 
 
 class Language(str, Enum):
+    """The language of a connector."""
+
     PYTHON = InstallType.PYTHON.value
     JAVA = InstallType.JAVA.value
 

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -102,6 +102,7 @@ class SQLTypeConverter:
         self,
         conversion_map: dict | None = None,
     ) -> None:
+        """Initialize the type converter."""
         self.conversion_map = conversion_map or CONVERSION_MAP
 
     @classmethod

--- a/airbyte/validate.py
+++ b/airbyte/validate.py
@@ -59,6 +59,7 @@ def _run_subprocess_and_raise_on_failure(args: list[str]) -> None:
 
 
 def full_tests(connector_name: str, sample_config: str) -> None:
+    """Run full tests on the connector."""
     print("Creating source and validating spec and version...")
     source = ab.get_source(
         # TODO: FIXME: noqa: SIM115, PTH123
@@ -91,6 +92,7 @@ def full_tests(connector_name: str, sample_config: str) -> None:
 
 
 def install_only_test(connector_name: str) -> None:
+    """Test that the connector can be installed and spec can be printed."""
     print("Creating source and validating spec is returned successfully...")
     source = ab.get_source(connector_name)
     source._get_spec(force_refresh=True)  # noqa: SLF001  # Member is private until we have a public API for it.
@@ -116,6 +118,7 @@ def run() -> None:
 
 
 def validate(connector_dir: str, sample_config: str, *, validate_install_only: bool) -> None:
+    """Validate a connector."""
     # read metadata.yaml
     metadata_path = Path(connector_dir) / "metadata.yaml"
     metadata = yaml.safe_load(Path(metadata_path).read_text(encoding="utf-8"))["data"]

--- a/airbyte/version.py
+++ b/airbyte/version.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Support for PyAirbyte version checks."""
+
 from __future__ import annotations
 
 import importlib.metadata
@@ -8,4 +10,5 @@ airbyte_version = importlib.metadata.version("airbyte")
 
 
 def get_version() -> str:
+    """Return the version of PyAirbyte."""
     return airbyte_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,40 +122,40 @@ select = [
     "C90",   # mccabe (complexity)
     "COM",   # flake8-commas
     "CPY",   # missing copyright notice
-    # "D", # pydocstyle # TODO: Re-enable when adding docstrings
-    "DTZ",  # flake8-datetimez
-    "E",    # pycodestyle (errors)
-    "ERA",  # flake8-eradicate (commented out code)
-    "EXE",  # flake8-executable
-    "F",    # Pyflakes
-    "FA",   # flake8-future-annotations
-    "FIX",  # flake8-fixme
-    "FLY",  # flynt
-    "FURB", # Refurb
-    "I",    # isort
-    "ICN",  # flake8-import-conventions
-    "INP",  # flake8-no-pep420
-    "INT",  # flake8-gettext
-    "ISC",  # flake8-implicit-str-concat
-    "ICN",  # flake8-import-conventions
-    "LOG",  # flake8-logging
-    "N",    # pep8-naming
-    "PD",   # pandas-vet
-    "PERF", # Perflint
-    "PIE",  # flake8-pie
-    "PGH",  # pygrep-hooks
-    "PL",   # Pylint
-    "PT",   # flake8-pytest-style
-    "PTH",  # flake8-use-pathlib
-    "PYI",  # flake8-pyi
-    "Q",    # flake8-quotes
-    "RET",  # flake8-return
-    "RSE",  # flake8-raise
-    "RUF",  # Ruff-specific rules
-    "SIM",  # flake8-simplify
-    "SLF",  # flake8-self
-    "SLOT", # flake8-slots
-    "T10",  # debugger calls
+    "D",     # pydocstyle (Docstring conventions)
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle (errors)
+    "ERA",   # flake8-eradicate (commented out code)
+    "EXE",   # flake8-executable
+    "F",     # Pyflakes
+    "FA",    # flake8-future-annotations
+    "FIX",   # flake8-fixme
+    "FLY",   # flynt
+    "FURB",  # Refurb
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "INT",   # flake8-gettext
+    "ISC",   # flake8-implicit-str-concat
+    "ICN",   # flake8-import-conventions
+    "LOG",   # flake8-logging
+    "N",     # pep8-naming
+    "PD",    # pandas-vet
+    "PERF",  # Perflint
+    "PIE",   # flake8-pie
+    "PGH",   # pygrep-hooks
+    "PL",    # Pylint
+    "PT",    # flake8-pytest-style
+    "PTH",   # flake8-use-pathlib
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "RSE",   # flake8-raise
+    "RUF",   # Ruff-specific rules
+    "SIM",   # flake8-simplify
+    "SLF",   # flake8-self
+    "SLOT",  # flake8-slots
+    "T10",   # debugger calls
     # "T20", # flake8-print # TODO: Re-enable once we have logging
     "TCH",    # flake8-type-checking
     "TD",     # flake8-todos


### PR DESCRIPTION
This PR enables the ruff lint rule category for docstring conventions, and then resolves all issues.

Method:

This was extremely fast to do using GitHub Copilot in VS Code. In most cases, I added the triple-quotes, waited for copilot to suggest something and then accepted it. I did review each suggestion and tweaked those that were not clear or accurate, but this was only about 10% of the total suggestions that I needed to tweak.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed docstrings across various classes and methods to enhance documentation clarity and usability.
	- Introduced new optional parameters to the `_deploy_connection` function for greater flexibility in connection deployments.

- **Bug Fixes**
	- Improved grammar and clarity of existing docstrings in multiple locations, ensuring consistent documentation standards.

- **Documentation**
	- Added module-level docstrings to several files, describing their overall purpose and functionality.
	- Enhanced individual function and class docstrings for better developer understanding and maintenance.

- **Chores**
	- Reformatted configuration settings in `pyproject.toml` for improved clarity regarding linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->