### PR TITLE
Fix: Default to docker-based destination executors

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -31,7 +31,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too complex
     version: str | None = None,
     pip_url: str | None = None,
     local_executable: Path | str | None = None,
-    docker_image: bool | str = False,
+    docker_image: bool | str | None = False,
     use_host_network: bool = False,
     source_manifest: bool | dict | Path | str = False,
     install_if_missing: bool = True,

--- a/airbyte/destinations/util.py
+++ b/airbyte/destinations/util.py
@@ -23,7 +23,7 @@ def get_destination(
     version: str | None = None,
     pip_url: str | None = None,
     local_executable: Path | str | None = None,
-    docker_image: str | bool = False,
+    docker_image: str | bool | None = None,
     install_if_missing: bool = True,
 ) -> Destination:
     """Get a connector by name and version.
@@ -50,6 +50,11 @@ def get_destination(
         install_if_missing: Whether to install the connector if it is not available locally. This
             parameter is ignored when local_executable is set.
     """
+    if not pip_url and not local_executable:
+        # Destination connectors are not yet published to PyPI.
+        # Default to Docker-based execution if no other method is explicitly requested.
+        docker_image = docker_image or True
+
     return Destination(
         name=name,
         config=config,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in handling the `docker_image` parameter for connector and destination functions, now accepting `None` as a valid input.
	- Introduced improved default behavior for the `docker_image` parameter when both `pip_url` and `local_executable` are not provided, favoring Docker-based execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->