### PR TITLE
Chore: Add PyAirbyte performance profiling option without caching

### DIFF
--- a/examples/run_perf_test_reads.py
+++ b/examples/run_perf_test_reads.py
@@ -40,6 +40,15 @@ You can also use this script to test destination load performance:
 poetry run python ./examples/run_perf_test_reads.py -e=5 --destination=e2e
 ```
 
+Testing raw PyAirbyte throughput with and without caching:
+
+```bash
+# Test raw PyAirbyte throughput with caching (Source->Cache):
+poetry run python ./examples/run_perf_test_reads.py -e=5
+# Test raw PyAirbyte throughput without caching (Source->Destination):
+poetry run python ./examples/run_perf_test_reads.py -e=5 --destination=e2e --no-cache
+```
+
 Note:
 - The Faker stream ('purchases') is assumed to be 220 bytes, meaning 4_500 records is
   approximately 1 MB. Based on this: 25K records/second is approximately 5.5 MB/s.
@@ -188,7 +197,8 @@ def main(
         num_records=num_records,
     )
     source.check()
-    destination = get_destination(destination_type=destination_type)
+    if destination_type:
+        destination = get_destination(destination_type=destination_type)
     if cache is not False:
         read_result = source.read(cache)
         if destination_type:

--- a/examples/run_perf_test_reads.py
+++ b/examples/run_perf_test_reads.py
@@ -189,7 +189,7 @@ def main(
     num_records: int = n or 5 * (10 ** (e or 3))
     cache_type = "duckdb" if cache_type is None else cache_type
 
-    cache: CacheBase | False = get_cache(
+    cache: CacheBase | Literal[False] = get_cache(
         cache_type=cache_type,
     )
     source: Source = get_source(


### PR DESCRIPTION
Adds ability to quickly profile performance using the helper script in the `examples` directory.

This previous version (with cache) tests our max throughput from Source to Cache (approx. 50K records/second or ~10 MB/s):

`poetry run python ./examples/run_perf_test_reads.py -e=5`

<img width="809" alt="image" src="https://github.com/user-attachments/assets/bf7f15d8-6af4-4ddc-9c04-6c02ac9b2d18">

And this new version with `--no-cache` flag can test the max throughput from Source to (No-Op) Destination (approx. 115K records/second, or ~21 MB/s):

`poetry run python ./examples/run_perf_test_reads.py -e=5 --destination=e2e --no-cache`

<img width="806" alt="image" src="https://github.com/user-attachments/assets/d133b558-4c11-4f66-9ae3-944977ef4e25">

Caveats/notes:

- The tracked "records per second" speeds of the above are isolated to the source and destination, respectively, and do not include approximately 1-2 seconds spin-up time.
- It's odd that the no-cache version is faster than even the isolated load from cache to destination - 62K records per second vs 110K+ records per second. We may want to look more into this.
- We can use this method in the future to test arbitrary destinations or sources, connecting them in either side of this pipeline to see what their max speeds are.
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `--no-cache` command-line argument, allowing users to disable caching during throughput tests.
  - Enhanced caching functionality to provide clearer handling of cache types (duckdb, snowflake, bigquery, or no cache).

- **Bug Fixes**
  - Minor documentation updates for clarity on throughput metrics based on record sizes.

These changes improve the flexibility and usability of performance testing scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->