### PR TITLE
Feat: Buffered jsonl writes (draft)

### DIFF
--- a/airbyte/_processors/file/jsonl.py
+++ b/airbyte/_processors/file/jsonl.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import json
 from typing import IO, TYPE_CHECKING, cast
 
@@ -33,14 +34,16 @@ class JsonlWriter(FileWriterBase):
         file_path: Path,
     ) -> IO[str]:
         """Open a new file for writing."""
-        return cast(
-            IO[str],
-            gzip.open(
-                file_path,
-                mode="wt",
-                encoding="utf-8",
-            ),
+        gzip_file: gzip.GzipFile = gzip.open(
+            file_path,
+            mode="wb",
+            # encoding="utf-8",
         )
+        return io.TextIOWrapper(
+            io.BufferedWriter(cast(io.RawIOBase, gzip_file)),
+            encoding="utf-8",
+        )
+
 
     @overrides
     def _write_record_dict(

--- a/airbyte/_processors/file/jsonl.py
+++ b/airbyte/_processors/file/jsonl.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import gzip
 import io
 import json
-from typing import IO, TYPE_CHECKING, cast
+import queue
+import threading
+from typing import IO, TYPE_CHECKING, Any, cast
 
 import orjson
 from overrides import overrides
@@ -28,22 +30,52 @@ class JsonlWriter(FileWriterBase):
     default_cache_file_suffix = ".jsonl.gz"
     prune_extra_fields = True
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        self._current_file_writer: IO[str] | None = None
+        self._queue: queue.Queue[str] = queue.Queue()
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._write_worker)
+        self._thread.start()
+        super().__init__(*args, **kwargs)
+
     @overrides
     def _open_new_file(
         self,
         file_path: Path,
     ) -> IO[str]:
         """Open a new file for writing."""
+        # buffer_size = 1024 * 1024  # 1 MB
+
         gzip_file: gzip.GzipFile = gzip.open(
             file_path,
             mode="wb",
-            # encoding="utf-8",
         )
-        return io.TextIOWrapper(
-            io.BufferedWriter(cast(io.RawIOBase, gzip_file)),
+        self._current_file_writer = io.TextIOWrapper(
+            io.BufferedWriter(
+                cast(io.RawIOBase, gzip_file),
+                # buffer_size=buffer_size,
+            ),
             encoding="utf-8",
         )
+        return self._current_file_writer
 
+    def _write_worker(self) -> None:
+        while not self._stop_event.is_set() or not self._queue.empty():
+            try:
+                record = self._queue.get(timeout=1)
+                assert self._current_file_writer is not None
+                self._current_file_writer.write(record)
+                self._queue.task_done()
+            except queue.Empty:
+                continue
+
+    def close(self) -> None:
+        """Close the writer and wait for the worker thread to finish."""
+        self._queue.join()
+        self._stop_event.set()
+        self._thread.join()
+        assert self._current_file_writer is not None
+        self._current_file_writer.close()
 
     @overrides
     def _write_record_dict(
@@ -54,9 +86,13 @@ class JsonlWriter(FileWriterBase):
         # If the record is too nested, `orjson` will fail with error `TypeError: Recursion
         # limit reached`. If so, fall back to the slower `json.dumps`.
         try:
-            open_file_writer.write(orjson.dumps(record_dict).decode(encoding="utf-8") + "\n")
+            line = orjson.dumps(record_dict).decode(encoding="utf-8") + "\n"
         except TypeError:
             # Using isoformat method for datetime serialization
-            open_file_writer.write(
-                json.dumps(record_dict, default=lambda _: _.isoformat()) + "\n",
-            )
+            line = json.dumps(record_dict, default=lambda _: _.isoformat()) + "\n"
+        else:
+            # No exception occurred, so write the line to the file
+            if open_file_writer is not self._current_file_writer:
+                self._current_file_writer = open_file_writer
+
+            self._queue.put(line)


### PR DESCRIPTION
After some testing, the perf difference from using a buffered writer is not as significant as moving the write operation to a different thread. This change is further inline with the philosophy that writes should try not to block reads.

Still todo:

- [ ] Proper thread hygiene and cleanup.
- [ ] Proper handling of closed files.
- [ ] Tests are hanging as of now, probably because of the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced asynchronous file writing for more efficient handling of JSONL records.
	- Enhanced file handling for writing JSONL files with gzip compression, ensuring better consistency and formatting.

- **Bug Fixes**
	- Improved robustness of file operations by separating concerns of compression and text encoding, reducing potential encoding issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->