### PR TITLE
migrate to uuid6 for generating uuid7 values

### DIFF
--- a/airbyte/records.py
+++ b/airbyte/records.py
@@ -72,7 +72,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import pytz
-from uuid_extensions import uuid7str
+from uuid6 import uuid7
 
 from airbyte._util.name_normalizers import LowerCaseNormalizer, NameNormalizerBase
 from airbyte.constants import (
@@ -232,7 +232,7 @@ class StreamRecord(dict[str, Any]):
         if with_internal_columns:
             self.update(
                 {
-                    AB_RAW_ID_COLUMN: uuid7str(),
+                    AB_RAW_ID_COLUMN: str(uuid7()),
                     AB_EXTRACTED_AT_COLUMN: extracted_at or datetime.now(pytz.utc),
                     AB_META_COLUMN: {},
                 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1334,8 +1334,8 @@ files = [
 [package.dependencies]
 orjson = ">=3.9.14,<4.0.0"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 requests = ">=2,<3"
 
@@ -1747,8 +1747,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -2127,8 +2127,8 @@ files = [
 annotated-types = ">=0.4.0"
 pydantic-core = "2.20.1"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -3335,14 +3335,14 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "uuid7"
-version = "0.1.0"
-description = "UUID version 7, generating time-sorted UUIDs with 200ns time resolution and 48 bits of randomness"
+name = "uuid6"
+version = "2024.7.10"
+description = "New time-based UUID formats which are suited for use as a database key"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61"},
-    {file = "uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c"},
+    {file = "uuid6-2024.7.10-py3-none-any.whl", hash = "sha256:93432c00ba403751f722829ad21759ff9db051dea140bf81493271e8e4dd18b7"},
+    {file = "uuid6-2024.7.10.tar.gz", hash = "sha256:2d29d7f63f593caaeea0e0d0dd0ad8129c9c663b29e19bdf882e864bedf18fb0"},
 ]
 
 [[package]]
@@ -3490,4 +3490,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ff078465575d9db425a09b760fc3768d496ea291cb050206afcac62820d55a56"
+content-hash = "c53d60201431897c8cb47d857e9c0c5d661a54f44304e7fd5176545cb0489321"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ sqlalchemy-bigquery = { version = "1.9.0", python = "<3.13" }
 airbyte-api = "^0.49.2"
 google-cloud-bigquery-storage = "^2.25.0"
 pyiceberg = "^0.6.1"
-uuid7 = "^0.1.0"
+uuid6 = "^2024.7.10"
 
 [tool.poetry.group.dev.dependencies]
 docker = "^7.0.0"


### PR DESCRIPTION
No clear perf benefit... both implementations appear to be between 2-3 us per generation (as string).

Before:

<img width="727" alt="image" src="https://github.com/user-attachments/assets/d3207216-5de5-44e1-9863-ba457e7f2c2a">

After:

<img width="632" alt="image" src="https://github.com/user-attachments/assets/ff7db7cb-6371-4fa9-8037-e360142acbe1">
