### PR TITLE
Chore: Add hardcoded-records source to profiling script

### DIFF
--- a/examples/run_perf_test_reads.py
+++ b/examples/run_perf_test_reads.py
@@ -161,7 +161,9 @@ def get_source(
         return ab.get_source(
             "source-hardcoded-records",
             streams="*",
-            config={},
+            config={
+                "count": 2_400_000,
+            },
         )
 
     raise ValueError(f"Unknown source alias: {source_alias}")  # noqa: TRY003

--- a/examples/run_perf_test_reads.py
+++ b/examples/run_perf_test_reads.py
@@ -49,6 +49,16 @@ poetry run python ./examples/run_perf_test_reads.py -e=5
 poetry run python ./examples/run_perf_test_reads.py -e=5 --destination=e2e --no-cache
 ```
 
+Testing Python CDK throughput:
+
+```bash
+# Test max throughput:
+poetry run python ./examples/run_perf_test_reads.py -n=2400000 --source=hardcoded --destination=e2e
+# Analyze tracing data:
+poetry run viztracer --open -- ./examples/run_perf_test_reads.py -e=3 --source=hardcoded --destination=e2e
+```
+
+
 Note:
 - The Faker stream ('purchases') is assumed to be 220 bytes, meaning 4_500 records is
   approximately 1 MB. Based on this: 25K records/second is approximately 5.5 MB/s.
@@ -160,9 +170,9 @@ def get_source(
     if source_alias == "hardcoded":
         return ab.get_source(
             "source-hardcoded-records",
-            streams="*",
+            streams=["dummy_fields"],
             config={
-                "count": 2_400_000,
+                "count": num_records,
             },
         )
 

--- a/examples/run_perf_test_reads.py
+++ b/examples/run_perf_test_reads.py
@@ -157,6 +157,13 @@ def get_source(
             },
         )
 
+    if source_alias == "hardcoded":
+        return ab.get_source(
+            "source-hardcoded-records",
+            streams="*",
+            config={},
+        )
+
     raise ValueError(f"Unknown source alias: {source_alias}")  # noqa: TRY003
 
 
@@ -244,10 +251,11 @@ if __name__ == "__main__":
         type=str,
         help=(
             "The cache type to use. The `e2e` source is recommended when Docker is available, "
-            "while the `faker` source runs natively in Python."
+            "while the `faker` source runs natively in Python. The 'hardcoded' source is "
+            "similar to the 'e2e' source, but written in Python."
         ),
-        choices=["faker", "e2e"],
-        default="e2e",
+        choices=["faker", "e2e", "hardcoded"],
+        default="hardcoded",
     )
     parser.add_argument(
         "--destination",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new data source option, "hardcoded," enhancing flexibility for data retrieval.
	- Updated command-line argument parsing to include the "hardcoded" source, changing the default cache type.

- **Improvements**
	- Modified help text for cache type to clarify the relationship between "hardcoded" and "e2e" sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->