### PR TITLE
Feat: Add performance metrics and mb/s tracking

### DIFF
--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import importlib
+import json
 import math
 import os
 import sys
@@ -207,6 +208,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         self.stream_read_counts: dict[str, int] = defaultdict(int)
         self.stream_read_start_times: dict[str, float] = {}
         self.stream_read_end_times: dict[str, float] = {}
+        self.stream_bytes_read: dict[str, int] = defaultdict(int)
 
         # Cache Writes
         self.total_records_written = 0
@@ -237,6 +239,33 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         """Print a message to the console and the file logger."""
         if self._file_logger:
             self._file_logger.info(message)
+
+    @property
+    def bytes_tracking_enabled(self) -> bool:
+        """Return True if bytes are being tracked."""
+        return bool(self.stream_bytes_read)
+
+    @property
+    def total_bytes_read(self) -> int | None:
+        """Return the total number of bytes read.
+
+        Return None if bytes are not being tracked.
+        """
+        if not self.bytes_tracking_enabled:
+            return None
+
+        return sum(self.stream_bytes_read.values())
+
+    @property
+    def total_megabytes_read(self) -> float | None:
+        """Return the total number of bytes read.
+
+        Return None if no bytes have been read, as this is generally due to bytes not being tracked.
+        """
+        if not self.bytes_tracking_enabled:
+            return None
+
+        return sum(self.stream_bytes_read.values()) / 1_000_000
 
     def tally_records_read(
         self,
@@ -351,6 +380,13 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
 
         self._update_display(force_refresh=True)
 
+    def tally_bytes_read(self, bytes_read: int, stream_name: str) -> None:
+        """Tally the number of bytes read.
+
+        Unlike the other tally methods, this method does not yield messages.
+        """
+        self.stream_bytes_read[stream_name] += bytes_read
+
     # Logging methods
 
     @property
@@ -393,6 +429,65 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         )
         self.stream_read_end_times[stream_name] = time.time()
 
+    def _log_read_metrics(self) -> None:
+        """Log read performance metrics."""
+        # Source performance metrics
+        if not self.total_records_read:
+            return
+
+        perf_metrics = {
+            "job_description": {
+                "description": self.job_description,
+            }
+        }
+        if self._source:
+            perf_metrics["job_description"]["source"] = self._source.name
+        if self._cache:
+            perf_metrics["job_description"]["cache"] = type(self._cache).__name__
+        if self._destination:
+            perf_metrics["job_description"]["destination"] = self._destination.name
+
+        perf_metrics["total_records_read"] = self.total_records_read
+        perf_metrics["read_start_time"] = self.read_start_time
+        perf_metrics["read_end_time"] = self.read_end_time
+        if self.elapsed_read_seconds > 0:
+            perf_metrics["records_per_second"] = self.total_records_read / self.elapsed_read_seconds
+            if self.bytes_tracking_enabled:
+                mb_read = self.total_megabytes_read
+                perf_metrics["mb_read"] = mb_read
+                perf_metrics["mb_per_second"] = round(mb_read / self.bytes_tracking_enabled, 4)
+
+        stream_metrics = {}
+        for stream_name, count in self.stream_read_counts.items():
+            stream_metrics[stream_name] = {
+                "records_read": count,
+                "read_start_time": self.stream_read_start_times.get(stream_name),
+                "read_end_time": self.stream_read_end_times.get(stream_name),
+            }
+            if (
+                stream_name in self.stream_read_end_times
+                and stream_name in self.stream_read_start_times
+                and count > 0
+            ):
+                duration: float = (
+                    self.stream_read_end_times[stream_name]
+                    - self.stream_read_start_times[stream_name]
+                )
+                stream_metrics[stream_name]["read_time_seconds"] = duration
+                if duration > 0:
+                    stream_metrics[stream_name]["records_per_second"] = count / (
+                        self.stream_read_end_times[stream_name]
+                        - self.stream_read_start_times[stream_name]
+                    )
+                    if self.bytes_tracking_enabled:
+                        mb_read = self.stream_bytes_read[stream_name] / 1_000_000
+                        stream_metrics[stream_name]["mb_read"] = mb_read
+                        stream_metrics[stream_name]["mb_per_second"] = round(mb_read / duration, 4)
+
+        perf_metrics["stream_metrics"] = stream_metrics
+
+        self._file_logger.info(json.dumps({"read_performance_metrics": perf_metrics}))
+
     @property
     def _unclosed_stream_names(self) -> list[str]:
         """Return a list of streams that have not yet been fully read."""
@@ -416,6 +511,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         self._print_info_message(
             f"Completed `{self.job_description}` sync at `{pendulum.now().format('HH:mm:ss')}`."
         )
+        self._log_read_metrics()
         send_telemetry(
             source=self._source,
             cache=self._cache,
@@ -663,8 +759,12 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         # Format start time as a friendly string in local timezone:
         start_time_str = _to_time_str(self.read_start_time)
         records_per_second: float = 0.0
+        mb_per_second_str = ""
         if self.elapsed_read_seconds > 0:
             records_per_second = self.total_records_read / self.elapsed_read_seconds
+            if self.bytes_tracking_enabled:
+                mb_per_second = self.total_megabytes_read / self.elapsed_read_seconds
+                mb_per_second_str = f", {mb_per_second:,.2f} MB/s"
 
         status_message = HORIZONTAL_LINE + f"\n### Sync Progress: `{self.job_description}`\n\n"
 
@@ -680,7 +780,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
                 f"**Started reading from source at `{start_time_str}`:**\n\n"
                 f"- Read **{self.total_records_read:,}** records "
                 f"over **{self.elapsed_read_time_string}** "
-                f"({records_per_second:,.1f} records / second).\n\n"
+                f"({records_per_second:,.1f} records/s{mb_per_second_str}).\n\n"
             )
 
         if self.stream_read_counts:
@@ -747,7 +847,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
                 status_message += (
                     f"- Sent **{self.total_destination_records_delivered:,} records** "
                     f"to destination over **{self.total_destination_write_time_str}** "
-                    f"({self.destination_records_delivered_per_second:,.1f} records per second)."
+                    f"({self.destination_records_delivered_per_second:,.1f} records/s)."
                     "\n\n"
                 )
                 status_message += (

--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -246,26 +246,20 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         return bool(self.stream_bytes_read)
 
     @property
-    def total_bytes_read(self) -> int | None:
+    def total_bytes_read(self) -> int:
         """Return the total number of bytes read.
 
         Return None if bytes are not being tracked.
         """
-        if not self.bytes_tracking_enabled:
-            return None
-
         return sum(self.stream_bytes_read.values())
 
     @property
-    def total_megabytes_read(self) -> float | None:
+    def total_megabytes_read(self) -> float:
         """Return the total number of bytes read.
 
         Return None if no bytes have been read, as this is generally due to bytes not being tracked.
         """
-        if not self.bytes_tracking_enabled:
-            return None
-
-        return sum(self.stream_bytes_read.values()) / 1_000_000
+        return self.total_bytes_read / 1_000_000
 
     def tally_records_read(
         self,
@@ -432,10 +426,10 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
     def _log_read_metrics(self) -> None:
         """Log read performance metrics."""
         # Source performance metrics
-        if not self.total_records_read:
+        if not self.total_records_read or not self._file_logger:
             return
 
-        perf_metrics = {
+        perf_metrics: dict[str, Any] = {
             "job_description": {
                 "description": self.job_description,
             }

--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -455,7 +455,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
             if self.bytes_tracking_enabled:
                 mb_read = self.total_megabytes_read
                 perf_metrics["mb_read"] = mb_read
-                perf_metrics["mb_per_second"] = round(mb_read / self.bytes_tracking_enabled, 4)
+                perf_metrics["mb_per_second"] = round(mb_read / self.elapsed_read_seconds, 4)
 
         stream_metrics = {}
         for stream_name, count in self.stream_read_counts.items():

--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -441,11 +441,14 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         if self._destination:
             perf_metrics["job_description"]["destination"] = self._destination.name
 
-        perf_metrics["total_records_read"] = self.total_records_read
+        perf_metrics["records_read"] = self.total_records_read
+        perf_metrics["read_time_seconds"] = self.elapsed_read_seconds
         perf_metrics["read_start_time"] = self.read_start_time
         perf_metrics["read_end_time"] = self.read_end_time
         if self.elapsed_read_seconds > 0:
-            perf_metrics["records_per_second"] = self.total_records_read / self.elapsed_read_seconds
+            perf_metrics["records_per_second"] = round(
+                self.total_records_read / self.elapsed_read_seconds, 4
+            )
             if self.bytes_tracking_enabled:
                 mb_read = self.total_megabytes_read
                 perf_metrics["mb_read"] = mb_read
@@ -469,9 +472,13 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
                 )
                 stream_metrics[stream_name]["read_time_seconds"] = duration
                 if duration > 0:
-                    stream_metrics[stream_name]["records_per_second"] = count / (
-                        self.stream_read_end_times[stream_name]
-                        - self.stream_read_start_times[stream_name]
+                    stream_metrics[stream_name]["records_per_second"] = round(
+                        count
+                        / (
+                            self.stream_read_end_times[stream_name]
+                            - self.stream_read_start_times[stream_name]
+                        ),
+                        4,
                     )
                     if self.bytes_tracking_enabled:
                         mb_read = self.stream_bytes_read[stream_name] / 1_000_000

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -552,6 +552,7 @@ class Source(ConnectorBase):
                     "--state",
                     state_file,
                 ],
+                progress_tracker=progress_tracker,
             )
             yield from progress_tracker.tally_records_read(message_generator)
         progress_tracker.log_read_complete()


### PR DESCRIPTION
Example output printed to log files:

Metrics from Faker to a local DuckDB cache:

```json
{
    "read_performance_metrics": {
        "job_description": {
            "description": "source-faker -> DuckDBCache",
            "source": "source-faker",
            "cache": "DuckDBCache"
        },
        "total_records_read": 200100,
        "read_start_time": 1725301258.959898,
        "read_end_time": 1725301282.203239,
        "records_per_second": 9252.684942052056,
        "mb_read": 92.544833,
        "mb_per_second": 4.2793,
        "stream_metrics": {
            "products": {
                "records_read": 100,
                "read_start_time": 1725301260.57727,
                "read_end_time": 1725301260.579796,
                "read_time_seconds": 0.0025260448455810547,
                "records_per_second": 39587.57904672015,
                "mb_read": 0.023553,
                "mb_per_second": 9.3241
            },
            "users": {
                "records_read": 100000,
                "read_start_time": 1725301261.9061,
                "read_end_time": 1725301273.219753,
                "read_time_seconds": 11.313652992248535,
                "records_per_second": 8838.878129682274,
                "mb_read": 60.902998,
                "mb_per_second": 5.3831
            },
            "purchases": {
                "records_read": 100000,
                "read_start_time": 1725301274.128414,
                "read_end_time": 1725301282.041147,
                "read_time_seconds": 7.91273307800293,
                "records_per_second": 12637.858375129052,
                "mb_read": 31.618282,
                "mb_per_second": 3.9959
            }
        }
    }
}

```

Metrics from e2e source to e2e destination, with caching disabled:

```json
{
    "read_performance_metrics": {
        "job_description": {
            "description": "source-e2e -> destination-e2e-test",
            "source": "source-e2e",
            "destination": "destination-e2e-test"
        },
        "total_records_read": 240000,
        "read_start_time": 1725301176.394967,
        "read_end_time": 1725301184.583842,
        "records_per_second": 36316.86986395221,
        "mb_read": 62.88,
        "mb_per_second": 9.515,
        "stream_metrics": {
            "stream1": {
                "records_read": 240000,
                "read_start_time": 1725301177.975788,
                "read_end_time": null
            }
        }
    }
}
```

We also print MB/s in live progress tracking:

![image](https://github.com/user-attachments/assets/bfdf2e24-7a5c-44d8-a6a0-413b94753232)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced progress tracking for data processing, allowing users to monitor bytes read during execution.
	- Added new metrics for byte-level performance, including total bytes and megabytes read.
	- Enhanced logging to include byte metrics upon successful sync operations.

- **Bug Fixes**
	- Improved the `_read_with_catalog` function to support progress tracking, enhancing usability during data reading processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->