### PR TITLE
Chore: Replace `generate-docs` CLI command with Poe tasks `docs-generate` and `docs-preview`

### DIFF
--- a/.github/workflows/pydoc_preview.yml
+++ b/.github/workflows/pydoc_preview.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Generate documentation
       run: |
-        poetry run generate-docs
+        poetry run poe docs-generate
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pydoc_publish.yml
+++ b/.github/workflows/pydoc_publish.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Generate documentation
       run: |
-        poetry run generate-docs
+        poetry run poe docs-generate
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,12 +16,20 @@ Regular documentation lives in the `/docs` folder. Based on the doc strings of p
 To generate the documentation, run:
 
 ```console
-poe generate-docs
+poe docs-generate
 ```
 
-or `poetry run poe generate-docs` if you don't have [Poe](https://poethepoet.natn.io/index.html) installed.
+Or to build and open in one step:
 
-The `generate-docs` CLI command is mapped to the `run()` function of `docs/generate.py`.
+
+```console
+poe docs-preview
+```
+
+
+or `poetry run poe docs-preview` if you don't have [Poe](https://poethepoet.natn.io/index.html) installed.
+
+The `docs-generate` Poe task is mapped to the `run()` function of `docs/generate.py`.
 
 Documentation pages will be generated in the `docs/generated` folder. The `test_docs.py` test in pytest will automatically update generated content. This updates must be manually committed before docs tests will pass.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,6 @@ venvPath = "./"       # Assuming .venv is at the root of your project
 venv = ".venv"
 
 [tool.poetry.scripts]
-generate-docs = "docs.generate:run"
 airbyte-lib-validate-source = "airbyte.validate:run"
 
 [tool.poe.tasks]
@@ -321,7 +320,8 @@ coverage-reset = { shell = "coverage erase" }
 
 check = { shell = "ruff check . && mypy . && pytest --collect-only -qq" }
 
-docs-generate = {env = {PDOC_ALLOW_EXEC = "1"}, shell = "generate-docs && open docs/generated/index.html" }
+docs-generate = {env = {PDOC_ALLOW_EXEC = "1"}, cmd = "python -m docs.generate run"}
+docs-preview = {shell = "poe docs-generate && open docs/generated/index.html"}
 
 fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
 fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe-fixes . && ruff format ." }

--- a/tests/docs_tests/test_docs_checked_in.py
+++ b/tests/docs_tests/test_docs_checked_in.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.filterwarnings("ignore")
 def test_docs_generation():
     """
-    Docs need to be able to be generated via `poetry run generate-docs`.
+    Docs need to be able to be generated via `poetry run poe docs-generate`.
 
     This test runs the docs generation and ensures that it can complete successfully.
 
@@ -24,4 +24,4 @@ def test_docs_generation():
     # if there is a diff, fail the test
     assert (
         diff == 0
-    ), "Docs are out of date. Please run `poetry run generate-docs` and commit the changes."
+    ), "Docs are out of date. Please run `poetry run poe docs-generate` and commit the changes."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command `docs-preview` for building and opening documentation in one step.
	- Updated command for generating documentation to `docs-generate`, enhancing clarity and usability.
  
- **Bug Fixes**
	- Adjusted documentation generation tests to reflect the new command structure.

- **Documentation**
	- Clarified command-line interface instructions in `CONTRIBUTING.md` for generating and previewing documentation. 

- **Chores**
	- Updated GitHub Actions workflows to utilize the new documentation generation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->