### PR TITLE
Feat: Added `use_host_network` param to `get_destination()`

### DIFF
--- a/airbyte/destinations/util.py
+++ b/airbyte/destinations/util.py
@@ -24,6 +24,7 @@ def get_destination(
     pip_url: str | None = None,
     local_executable: Path | str | None = None,
     docker_image: str | bool | None = None,
+    use_host_network: bool = False,
     install_if_missing: bool = True,
 ) -> Destination:
     """Get a connector by name and version.
@@ -47,6 +48,10 @@ def get_destination(
             to use the default image for the connector, or you can specify a custom image name.
             If `version` is specified and your image name does not already contain a tag
             (e.g. `my-image:latest`), the version will be appended as a tag (e.g. `my-image:0.1.0`).
+        use_host_network: If set, along with docker_image, the connector will be executed using
+            the host network. This is useful for connectors that need to access resources on
+            the host machine, such as a local database. This parameter is ignored when
+            `docker_image` is not set.
         install_if_missing: Whether to install the connector if it is not available locally. This
             parameter is ignored when local_executable is set.
     """
@@ -64,6 +69,7 @@ def get_destination(
             pip_url=pip_url,
             local_executable=local_executable,
             docker_image=docker_image,
+            use_host_network=use_host_network,
             install_if_missing=install_if_missing,
         ),
     )


### PR DESCRIPTION
## Description

- PR to implement `use_host_network`, a Docker based connectors option for destinations. This enables locally testable destinations, for example, a local Postgres DB instance.
- Reference PR for `get_source()` #277
- Due to this feature being in experiment mode for long, the destinations (new feature) did not persist these changes.
- Hence, including the `use_host_network` is necessary for destinations, if someone tried to use PyAirbyte locally.

## Fixes/Implements #363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter, `use_host_network`, for enhanced network access in connectors, allowing execution using the host network for specified Docker images.
- **Documentation**
	- Updated function documentation to clarify the purpose and usage of the new `use_host_network` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->