### PR TITLE
Feat: Introducing `AIRBYTE_TEMP_DIR` For Temporary File Mount Overrides

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -17,6 +17,7 @@ from airbyte._executors.local import PathExecutor
 from airbyte._executors.python import VenvExecutor
 from airbyte._util.meta import which
 from airbyte._util.telemetry import EventState, log_install_state  # Non-public API
+from airbyte.constants import OVERRIDE_TEMP_DIR
 from airbyte.sources.registry import ConnectorMetadata, InstallType, get_connector_metadata
 
 
@@ -203,7 +204,8 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913 # Too complex
         if ":" not in docker_image:
             docker_image = f"{docker_image}:{version or 'latest'}"
 
-        temp_dir = tempfile.gettempdir()
+        temp_dir = OVERRIDE_TEMP_DIR or Path(tempfile.gettempdir())
+
         local_mount_dir = Path().absolute() / name
         local_mount_dir.mkdir(exist_ok=True)
 

--- a/airbyte/_util/temp_files.py
+++ b/airbyte/_util/temp_files.py
@@ -11,6 +11,8 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from airbyte.constants import OVERRIDE_TEMP_DIR
+
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -21,12 +23,15 @@ def as_temp_files(files_contents: list[dict | str]) -> Generator[list[str], Any,
     """Write the given contents to temporary files and yield the file paths as strings."""
     temp_files: list[Any] = []
     try:
+        temp_dir = OVERRIDE_TEMP_DIR
+
         for content in files_contents:
             use_json = isinstance(content, dict)
             temp_file = tempfile.NamedTemporaryFile(  # noqa: SIM115  # Avoiding context manager
                 mode="w+t",
                 delete=False,
                 encoding="utf-8",
+                dir=temp_dir,
                 suffix=".json" if use_json else ".txt",
             )
             temp_file.write(

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -65,6 +65,19 @@ def _str_to_bool(value: str) -> bool:
     return bool(value) and value.lower() not in {"", "0", "false", "f", "no", "n", "off"}
 
 
+OVERRIDE_TEMP_DIR: Path | None = (
+    Path(os.environ["AIRBYTE_TEMP_DIR"]) if os.getenv("AIRBYTE_TEMP_DIR") else None
+)
+"""The directory to use for temporary files.
+
+This value is read from the `AIRBYTE_TEMP_DIR` environment variable. If the variable is not set,
+Tempfile will use the system's default temporary directory.
+
+This can be useful if you want to store temporary files in a specific location (or) when you
+need your temporary files to exist in user level directories, and not in system level
+directories for permissions reasons.
+"""
+
 TEMP_FILE_CLEANUP = _str_to_bool(
     os.getenv(
         key="AIRBYTE_TEMP_FILE_CLEANUP",


### PR DESCRIPTION
# Description

- The source-postgres connector failed to connect due to an error in accessing a system-level temporary directory, which is not accessible in the Colima setup. This caused the connector to be unable to find the required file, resulting in a failure.
- The update ensures compatibility with containerized environments like Colima by using user-specific paths instead of system-level paths. This change also improves consistency and reliability in accessing temporary files and mount points across different environments.
-  The issue was observed on MacOS 12.4 (M1, 2020) with Colima. The paths now correctly resolve in user-specific locations, ensuring compatibility and reliability.

- UPDATE: After gaining feedback from @aaronsteers , it was decided that the best solution to this problem would not be to change the default, but to introduce an override through ENV variables. i.e. described very well with the `constants.py` in the root level.

# Fixes/Implements #367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated temporary directory for Airbyte-related files, improving organization and management of temporary files.
	- Users can now specify a custom temporary directory via the `OVERRIDE_TEMP_DIR` variable, enhancing flexibility in file storage.
	- Temporary files are managed more effectively, allowing for easier cleanup and better organization by directing them to the specified location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->