### PR TITLE
Chore: Rename override constant to `TEMP_DIR_OVERRIDE`

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -17,7 +17,7 @@ from airbyte._executors.local import PathExecutor
 from airbyte._executors.python import VenvExecutor
 from airbyte._util.meta import which
 from airbyte._util.telemetry import EventState, log_install_state  # Non-public API
-from airbyte.constants import OVERRIDE_TEMP_DIR
+from airbyte.constants import TEMP_DIR_OVERRIDE
 from airbyte.sources.registry import ConnectorMetadata, InstallType, get_connector_metadata
 
 
@@ -204,7 +204,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913 # Too complex
         if ":" not in docker_image:
             docker_image = f"{docker_image}:{version or 'latest'}"
 
-        temp_dir = OVERRIDE_TEMP_DIR or Path(tempfile.gettempdir())
+        temp_dir = TEMP_DIR_OVERRIDE or Path(tempfile.gettempdir())
 
         local_mount_dir = Path().absolute() / name
         local_mount_dir.mkdir(exist_ok=True)

--- a/airbyte/_util/temp_files.py
+++ b/airbyte/_util/temp_files.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from airbyte.constants import OVERRIDE_TEMP_DIR
+from airbyte.constants import TEMP_DIR_OVERRIDE
 
 
 if TYPE_CHECKING:
@@ -23,15 +23,13 @@ def as_temp_files(files_contents: list[dict | str]) -> Generator[list[str], Any,
     """Write the given contents to temporary files and yield the file paths as strings."""
     temp_files: list[Any] = []
     try:
-        temp_dir = OVERRIDE_TEMP_DIR
-
         for content in files_contents:
             use_json = isinstance(content, dict)
             temp_file = tempfile.NamedTemporaryFile(  # noqa: SIM115  # Avoiding context manager
                 mode="w+t",
                 delete=False,
                 encoding="utf-8",
-                dir=temp_dir,
+                dir=TEMP_DIR_OVERRIDE or None,
                 suffix=".json" if use_json else ".txt",
             )
             temp_file.write(

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -65,7 +65,7 @@ def _str_to_bool(value: str) -> bool:
     return bool(value) and value.lower() not in {"", "0", "false", "f", "no", "n", "off"}
 
 
-OVERRIDE_TEMP_DIR: Path | None = (
+TEMP_DIR_OVERRIDE: Path | None = (
     Path(os.environ["AIRBYTE_TEMP_DIR"]) if os.getenv("AIRBYTE_TEMP_DIR") else None
 )
 """The directory to use for temporary files.


### PR DESCRIPTION
A follow-on from:

- #368 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Renamed the constant for temporary directory overrides to enhance clarity and consistency.

- **Chores**
	- Updated variable names across multiple files for improved clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->