### PR TITLE
Feat: Use GCS public bucket to get manifest yaml for connectors; adds support for pinning versions and getting prior versions

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -26,8 +26,7 @@ if TYPE_CHECKING:
 
 VERSION_LATEST = "latest"
 DEFAULT_MANIFEST_URL = (
-    "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/"
-    "metadata/airbyte/{source_name}/{version}/manifest.yaml"
+    "https://connectors.airbyte.com/files/metadata/airbyte/{source_name}/{version}/manifest.yaml"
 )
 
 

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import requests
 import yaml
-from requests import HTTPError
 from rich import print  # noqa: A004  # Allow shadowing the built-in
 
 from airbyte import exceptions as exc

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -38,7 +38,7 @@ def _try_get_source_manifest(
 ) -> dict:
     """Try to get a source manifest from a URL.
 
-    If the URL is not provided, we'll try the default URL in the public GCS bucket.
+    If the URL is not provided, we'll try the default URL in the Airbyte registry.
 
     Raises:
         - `PyAirbyteInputError`: If `source_name` is `None`.
@@ -50,7 +50,7 @@ def _try_get_source_manifest(
             message="Param 'source_name' is required.",
         )
 
-    # If manifest URL was provided, we'll use the default URL from the public GCS bucket.
+    # If manifest URL was provided, we'll use the default URL from the Airbyte registry.
 
     cleaned_version = (version or VERSION_LATEST).removeprefix("v")
     manifest_url = manifest_url or DEFAULT_MANIFEST_URL.format(

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -42,6 +42,7 @@ def _try_get_source_manifest(
     Raises:
         - `PyAirbyteInputError`: If `source_name` is `None`.
         - `HTTPError`: If fetching the URL was unsuccessful.
+        - `YAMLError`: If parsing the YAML failed.
     """
     if source_name is None:
         raise exc.PyAirbyteInputError(

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -25,56 +25,50 @@ if TYPE_CHECKING:
     from airbyte._executors.base import Executor
 
 
-def _try_get_source_manifest(source_name: str, manifest_url: str | None) -> dict:
+VERSION_LATEST = "latest"
+DEFAULT_MANIFEST_URL = (
+    "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/"
+    "metadata/airbyte/{source_name}/{version}/manifest.yaml"
+)
+
+
+def _try_get_source_manifest(
+    source_name: str,
+    manifest_url: str | None,
+    version: str | None = None,
+) -> dict:
     """Try to get a source manifest from a URL.
 
-    If the URL is not provided, we'll try a couple of default URLs.
-    We can remove/refactor this once manifests are available in GCS connector registry.
+    If the URL is not provided, we'll try the default URL in the public GCS bucket.
+
+    Raises:
+        - `PyAirbyteInputError`: If `source_name` is `None`.
+        - `HTTPError`: If fetching the URL was unsuccessful.
     """
-    if manifest_url:
-        response = requests.get(url=manifest_url)
-        response.raise_for_status()  # Raise HTTPError exception if the download failed
-        try:
-            return cast(dict, yaml.safe_load(response.text))
-        except yaml.YAMLError as ex:
-            raise exc.AirbyteConnectorInstallationError(
-                message="Failed to parse the connector manifest YAML.",
-                connector_name=source_name,
-                context={
-                    "manifest_url": manifest_url,
-                },
-            ) from ex
-
-    # No manifest URL was provided. We'll try a couple of default URLs.
-
-    try:
-        # First try the new URL format (language='manifest-only'):
-        result_1 = _try_get_source_manifest(
-            source_name=source_name,
-            manifest_url=(
-                f"https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations"
-                f"/connectors/{source_name}/manifest.yaml"
-            ),
+    if source_name is None:
+        raise exc.PyAirbyteInputError(
+            message="Param 'source_name' is required.",
         )
-    except HTTPError as ex_1:
-        # If the new URL path was not found, try the old URL format (language='low-code'):
-        try:
-            result_2 = _try_get_source_manifest(
-                source_name=source_name,
-                manifest_url=(
-                    f"https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations"
-                    f"/connectors/{source_name}/{source_name.replace('-', '_')}/manifest.yaml"
-                ),
-            )
-        except HTTPError:
-            # Raise the first exception, since that represents the new default URL
-            raise ex_1 from None
-        else:
-            # Old URL path was found (no exceptions raised).
-            return result_2
-    else:
-        # New URL path was found (no exceptions raised).
-        return result_1
+
+    # If manifest URL was provided, we'll use the default URL from the public GCS bucket.
+
+    manifest_url = manifest_url or DEFAULT_MANIFEST_URL.format(
+        source_name=source_name,
+        version=(version or VERSION_LATEST).removeprefix("v"),
+    )
+
+    response = requests.get(url=manifest_url)
+    response.raise_for_status()  # Raise HTTPError exception if the download failed
+    try:
+        return cast(dict, yaml.safe_load(response.text))
+    except yaml.YAMLError as ex:
+        raise exc.AirbyteConnectorInstallationError(
+            message="Failed to parse the connector manifest YAML.",
+            connector_name=source_name,
+            context={
+                "manifest_url": manifest_url,
+            },
+        ) from ex
 
 
 def _get_local_executor(

--- a/airbyte/sources/registry.py
+++ b/airbyte/sources/registry.py
@@ -235,7 +235,8 @@ def _get_registry_cache(*, force_refresh: bool = False) -> dict[str, ConnectorMe
     registry_url = _get_registry_url()
     if registry_url.startswith("http"):
         response = requests.get(
-            registry_url, headers={"User-Agent": f"airbyte-lib-{get_version()}"}
+            registry_url,
+            headers={"User-Agent": f"PyAirbyte/{get_version()}"},
         )
         response.raise_for_status()
         data = response.json()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced manifest URL construction with optional version handling for improved flexibility.
	- Introduced a default manifest URL format for easier access.

- **Bug Fixes**
	- Streamlined error handling to ensure `source_name` is always required, preventing potential errors.

- **Refactor**
	- Simplified logic for obtaining the manifest URL, removing unnecessary complexity.
  
- **Chores**
	- Updated User-Agent header in HTTP requests for improved identification to the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->