### PR TITLE
Feat: Add 'execute_sql' command on caches, add DuckDB WAL cleanup step

### DIFF
--- a/airbyte/_processors/sql/duckdb.py
+++ b/airbyte/_processors/sql/duckdb.py
@@ -165,7 +165,7 @@ class DuckDBSqlProcessor(SqlProcessorBase):
 
     def _do_checkpoint(
         self,
-        connection: Connection | None,
+        connection: Connection | None = None,
     ) -> None:
         """Checkpoint the given connection.
 

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -391,6 +391,7 @@ class SqlProcessorBase(abc.ABC):
             self._init_connection_settings(connection)
             yield connection
 
+        connection.close()
         del connection
 
     def get_sql_table_name(

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -368,6 +368,17 @@ class SqlProcessorBase(abc.ABC):
         """Return a new SQL engine to use."""
         return self.sql_config.get_sql_engine()
 
+    def _close_connection(
+        self,
+        connection: Connection,
+    ) -> None:
+        """Close the given connection.
+
+        Subclasses can override this method to perform additional cleanup, such
+        as WAL checkpointing.
+        """
+        connection.close()
+
     @contextmanager
     def get_sql_connection(self) -> Generator[sqlalchemy.engine.Connection, None, None]:
         """A context manager which returns a new SQL connection for running queries.
@@ -378,7 +389,7 @@ class SqlProcessorBase(abc.ABC):
             self._init_connection_settings(connection)
             yield connection
 
-        connection.close()
+        self._close_connection(connection)
         del connection
 
     def get_sql_table_name(

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -348,7 +348,7 @@ class SqlProcessorBase(abc.ABC):
 
     def _do_checkpoint(  # noqa: B027  # Intentionally empty, not abstract
         self,
-        connection: Connection | None,
+        connection: Connection | None = None,
     ) -> None:
         """Checkpoint the given connection.
 

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -748,6 +748,10 @@ class Source(ConnectorBase):
             state_writer=state_writer,
             progress_tracker=progress_tracker,
         )
+
+        # Flush the WAL, if applicable
+        cache.processor._do_checkpoint()  # noqa: SLF001  # Non-public API
+
         return ReadResult(
             source_name=self.name,
             progress_tracker=progress_tracker,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method to execute SQL statements directly within the cache, enhancing SQL operations.
	- Added methods for explicit checkpointing and closing SQL connections, improving connection management.
  
- **Bug Fixes**
	- Ensured proper transaction handling during SQL execution to maintain data integrity.
	- Added checkpointing after writing to the cache to ensure buffered changes are persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->