### PR TITLE
Feat: Introducing `AIRBYTE_OFFLINE_MODE` for air-gapped environments

### DIFF
--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -50,6 +50,7 @@ from airbyte._util.connector_info import (
     WriterRuntimeInfo,
 )
 from airbyte._util.hashing import one_way_hash
+from airbyte.constants import AIRBYTE_OFFLINE_MODE
 from airbyte.version import get_version
 
 
@@ -89,7 +90,7 @@ def _setup_analytics() -> str | bool:
     anonymous_user_id: str | None = None
     issues: list[str] = []
 
-    if os.environ.get(DO_NOT_TRACK):
+    if os.environ.get(DO_NOT_TRACK) or AIRBYTE_OFFLINE_MODE:
         # User has opted out of tracking.
         return False
 
@@ -207,7 +208,7 @@ def send_telemetry(
     exception: Exception | None = None,
 ) -> None:
     # If DO_NOT_TRACK is set, we don't send any telemetry
-    if os.environ.get(DO_NOT_TRACK):
+    if os.environ.get(DO_NOT_TRACK) or AIRBYTE_OFFLINE_MODE:
         return
 
     payload_props: dict[str, str | int | dict] = {

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -89,3 +89,23 @@ TEMP_FILE_CLEANUP = _str_to_bool(
 This value is read from the `AIRBYTE_TEMP_FILE_CLEANUP` environment variable. If the variable is
 not set, the default value is `True`.
 """
+
+AIRBYTE_OFFLINE_MODE = _str_to_bool(
+    os.getenv(
+        key="AIRBYTE_OFFLINE_MODE",
+        default="false",
+    )
+)
+"""Enable or disable offline mode.
+
+When offline mode is enabled, PyAirbyte will attempt to fetch metadata for connectors from the
+Airbyte registry but will not raise an error if the registry is unavailable. This can be useful in
+environments without internet access or with air-gapped networks.
+
+Offline mode also disables telemetry, similar to a `DO_NOT_TRACK` setting, ensuring no usage data
+is sent from your environment. You may also specify a custom registry URL via the`_REGISTRY_ENV_VAR`
+environment variable if you prefer to use a different registry source for metadata.
+
+This setting helps you make informed choices about data privacy and operation in restricted and
+air-gapped environments.
+"""

--- a/airbyte/sources/registry.py
+++ b/airbyte/sources/registry.py
@@ -16,6 +16,8 @@ import requests
 
 from airbyte import exceptions as exc
 from airbyte._util.meta import is_docker_installed
+from airbyte.constants import AIRBYTE_OFFLINE_MODE
+from airbyte.logs import warn_once
 from airbyte.version import get_version
 
 
@@ -180,6 +182,10 @@ def _get_registry_url() -> str:
     return _REGISTRY_URL
 
 
+def _is_registry_disabled(url: str) -> bool:
+    return url.upper() in {"0", "F", "FALSE"} or AIRBYTE_OFFLINE_MODE
+
+
 def _registry_entry_to_connector_metadata(entry: dict) -> ConnectorMetadata:
     name = entry["dockerRepository"].replace("airbyte/", "")
     latest_version: str | None = entry.get("dockerImageTag")
@@ -233,6 +239,10 @@ def _get_registry_cache(*, force_refresh: bool = False) -> dict[str, ConnectorMe
         return __cache
 
     registry_url = _get_registry_url()
+
+    if _is_registry_disabled(registry_url):
+        return {}
+
     if registry_url.startswith("http"):
         response = requests.get(
             registry_url,
@@ -256,23 +266,29 @@ def _get_registry_cache(*, force_refresh: bool = False) -> dict[str, ConnectorMe
         new_cache[connector_metadata.name] = connector_metadata
 
     if len(new_cache) == 0:
-        raise exc.PyAirbyteInternalError(
-            message="Connector registry is empty.",
-            context={
-                "registry_url": _get_registry_url(),
-            },
+        # This isn't necessarily fatal, since users can bring their own
+        # connector definitions.
+        warn_once(
+            message=f"Connector registry is empty: {registry_url}",
+            with_stack=False,
         )
 
     __cache = new_cache
     return __cache
 
 
-def get_connector_metadata(name: str) -> ConnectorMetadata:
+def get_connector_metadata(name: str) -> None | ConnectorMetadata:
     """Check the cache for the connector.
 
     If the cache is empty, populate by calling update_cache.
     """
+    registry_url = _get_registry_url()
+
+    if _is_registry_disabled(registry_url):
+        return None
+
     cache = copy(_get_registry_cache())
+
     if not cache:
         raise exc.PyAirbyteInternalError(
             message="Connector registry could not be loaded.",


### PR DESCRIPTION
# Description
- Introduced a new constant, `AIRBYTE_OFFLINE_MODE`, for PyAirbyte to enable functionality in offline or air-gapped environments where external connectivity is unavailable.

- This issue was initially documented in [Issue #428](https://github.com/airbytehq/PyAirbyte/issues/428), where a user experienced difficulties using PyAirbyte due to unsuccessful requests to the Airbyte Connector Registry.

- The `AIRBYTE_OFFLINE_MODE` constant gracefully handles exceptions when attempting to connect to the registry. If this mode is disabled, the error handling includes a detailed explanation and guidance for users.

- Additionally, when `AIRBYTE_OFFLINE_MODE` is enabled, it acts likewise to the `DO_NOT_TRACK` environment variable, ensuring that no telemetry data is sent from the environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `AIRBYTE_OFFLINE_MODE` to enhance offline operation, allowing users to work without internet access while managing connector metadata.
	- Updated telemetry settings to disable tracking in offline mode.

- **Bug Fixes**
	- Improved error handling for connectivity issues, providing clearer guidance when the connector registry is unreachable.
	- Enhanced management of scenarios where the connector registry is disabled or offline, allowing for graceful handling without raising errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->