### PR TITLE
Fix: Corrects the source name in the _airbyte_state table for cache reading

### DIFF
--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -741,13 +741,20 @@ class Source(ConnectorBase):
                 progress_tracker=progress_tracker,
             )
         )
-        cache._write_airbyte_message_stream(  # noqa: SLF001  # Non-public API
-            stdin=airbyte_message_iterator,
+
+        cache_record_processor = cache.get_record_processor(
+            source_name=self.name,
             catalog_provider=catalog_provider,
-            write_strategy=write_strategy,
             state_writer=state_writer,
+        )
+
+        cache_record_processor.process_airbyte_messages(
+            messages=airbyte_message_iterator,
+            write_strategy=write_strategy,
             progress_tracker=progress_tracker,
         )
+
+        progress_tracker.log_cache_processing_complete()
 
         # Flush the WAL, if applicable
         cache.processor._do_checkpoint()  # noqa: SLF001  # Non-public API


### PR DESCRIPTION
**Bug**

The `source-name` column was being populated incorrectly when reading directly to the cache. We were using the `_write_airbyte_message_stream` [function](https://github.com/airbytehq/PyAirbyte/blob/7c703ac0e4e72ca2587eb00a9e51067b95bb10e6/airbyte/caches/base.py#L291) in the cache base to write data. However, this uses the `name` of the [cache](https://github.com/airbytehq/PyAirbyte/blob/7c703ac0e4e72ca2587eb00a9e51067b95bb10e6/airbyte/caches/base.py#L302) class as the source name which is incorrect for syncs that read directly to the cache.

**Bug Fixes**

- Source name is now the correct value when reading directly to the cache