### PR TITLE
Chore: Add docs for callback, add type alias

### DIFF
--- a/airbyte/__init__.py
+++ b/airbyte/__init__.py
@@ -125,6 +125,7 @@ from __future__ import annotations
 
 from airbyte import (
     caches,
+    callbacks,
     # cli,  # Causes circular import if included
     cloud,
     constants,
@@ -157,6 +158,7 @@ from airbyte.sources.util import get_source
 __all__ = [
     # Modules
     "caches",
+    "callbacks",
     # "cli",  # Causes circular import if included
     "cloud",
     "constants",

--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -36,11 +36,12 @@ from airbyte.logs import new_passthrough_file_logger
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable, Generator
+    from collections.abc import Generator
     from typing import IO
 
     from airbyte._executors.base import Executor
     from airbyte._message_iterators import AirbyteMessageIterator
+    from airbyte.callbacks import ConfigChangeCallback
     from airbyte.progress import ProgressTracker
 
 
@@ -57,7 +58,7 @@ class ConnectorBase(abc.ABC):
         executor: Executor,
         name: str,
         config: dict[str, Any] | None = None,
-        config_change_callback: Callable[[dict[str, Any]], None] | None = None,
+        config_change_callback: ConfigChangeCallback | None = None,
         *,
         validate: bool = False,
     ) -> None:

--- a/airbyte/callbacks.py
+++ b/airbyte/callbacks.py
@@ -10,8 +10,8 @@ from typing import Any
 ConfigChangeCallback = Callable[[dict[str, Any]], None]
 """Callback for when the configuration changes while the connector is running.
 
-This callback can be passed to supporting functions like `airbyte.sources.util.get_source()` and
-`airbyte.destinations.util.get_destination()` to take action whenever configuration changes.
+This callback can be passed to supporting functions like `airbyte.get_source()` and
+`airbyte.get_destination()` to take action whenever configuration changes.
 The callback will be called with the new configuration as the only argument.
 
 The most common use case for this callback is for connectors with OAuth APIs to pass updated

--- a/airbyte/callbacks.py
+++ b/airbyte/callbacks.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Callbacks for working with PyAirbyte."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+ConfigChangeCallback = Callable[[dict[str, Any]], None]
+"""Callback for when the configuration changes while the connector is running.
+
+This callback can be passed to supporting functions like `airbyte.sources.util.get_source()` and
+`airbyte.destinations.util.get_destination()` to take action whenever configuration changes.
+The callback will be called with the new configuration as the only argument.
+
+The most common use case for this callback is for connectors with OAuth APIs to pass updated
+refresh tokens when the previous token is about to expire.
+
+Note that the dictionary passed will contain the entire configuration, not just the changed fields.
+
+Example Usage:
+
+```python
+import airbyte as ab
+import yaml
+from pathlib import Path
+
+config_file = Path("path/to/my/config.yaml")
+config_dict = yaml.safe_load(config_file.read_text())
+
+# Define the callback function:
+def config_callback(new_config: dict[str, Any]) -> None:
+    # Write new config back to config file
+    config_file.write_text(yaml.safe_dump(new_config))
+
+# Pass in the callback function when creating the source:
+source = get_source(
+    "source-faker",
+    config=config_dict,
+    config_change_callback=config_callback,
+)
+# Now read as usual. If config changes during sync, the callback will be called.
+source.read()
+```
+
+For more information on the underlying Airbyte protocol, please see documentation on
+the [`CONNECTOR_CONFIG` control messages]
+(https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#airbytecontrolconnectorconfigmessage).
+"""

--- a/airbyte/destinations/base.py
+++ b/airbyte/destinations/base.py
@@ -33,10 +33,9 @@ from airbyte.strategies import WriteStrategy
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from airbyte._executors.base import Executor
     from airbyte.caches.base import CacheBase
+    from airbyte.callbacks import ConfigChangeCallback
     from airbyte.shared.state_writers import StateWriterBase
 
 
@@ -50,8 +49,8 @@ class Destination(ConnectorBase, AirbyteWriterInterface):
         executor: Executor,
         name: str,
         config: dict[str, Any] | None = None,
-        config_change_callback: Callable[[dict[str, Any]], None] | None = None,
         *,
+        config_change_callback: ConfigChangeCallback | None = None,
         validate: bool = False,
     ) -> None:
         """Initialize the source.

--- a/airbyte/destinations/util.py
+++ b/airbyte/destinations/util.py
@@ -13,15 +13,16 @@ from airbyte.destinations.base import Destination
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
+
+    from airbyte.callbacks import ConfigChangeCallback
 
 
 def get_destination(  # noqa: PLR0913 # Too many arguments
     name: str,
     config: dict[str, Any] | None = None,
-    config_change_callback: Callable[[dict[str, Any]], None] | None = None,
     *,
+    config_change_callback: ConfigChangeCallback | None = None,
     version: str | None = None,
     pip_url: str | None = None,
     local_executable: Path | str | None = None,

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -36,13 +36,14 @@ from airbyte.strategies import WriteStrategy
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Iterator
+    from collections.abc import Generator, Iterable, Iterator
 
     from airbyte_cdk import ConnectorSpecification
     from airbyte_protocol.models import AirbyteStream
 
     from airbyte._executors.base import Executor
     from airbyte.caches import CacheBase
+    from airbyte.callbacks import ConfigChangeCallback
     from airbyte.documents import Document
     from airbyte.shared.state_providers import StateProviderBase
     from airbyte.shared.state_writers import StateWriterBase
@@ -58,9 +59,9 @@ class Source(ConnectorBase):
         executor: Executor,
         name: str,
         config: dict[str, Any] | None = None,
-        config_change_callback: Callable[[dict[str, Any]], None] | None = None,
-        streams: str | list[str] | None = None,
         *,
+        config_change_callback: ConfigChangeCallback | None = None,
+        streams: str | list[str] | None = None,
         validate: bool = False,
     ) -> None:
         """Initialize the source.

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -13,8 +13,9 @@ from airbyte.sources.base import Source
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
+
+    from airbyte.callbacks import ConfigChangeCallback
 
 
 def get_connector(
@@ -46,8 +47,8 @@ def get_connector(
 def get_source(  # noqa: PLR0913 # Too many arguments
     name: str,
     config: dict[str, Any] | None = None,
-    config_change_callback: Callable[[dict[str, Any]], None] | None = None,
     *,
+    config_change_callback: ConfigChangeCallback | None = None,
     streams: str | list[str] | None = None,
     version: str | None = None,
     pip_url: str | None = None,


### PR DESCRIPTION
Adds a new docs page for the config callback feature, and a new type alias for readability.

Pairs with:

- https://github.com/airbytehq/PyAirbyte/pull/440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a callback mechanism for handling configuration changes in connectors.
	- Added a new `ConfigChangeCallback` type for enhanced type safety.

- **Bug Fixes**
	- Improved error handling in the `get_configured_catalog` method to raise errors for invalid stream arguments.

- **Deprecations**
	- Marked the `set_streams` and `get_connector` methods as deprecated, recommending the use of `select_streams` and `get_source` instead.

- **Documentation**
	- Updated docstrings to reflect new parameter types and provide clearer guidance for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->