### PR TITLE
Fix: Added regex to sub special characters

### DIFF
--- a/airbyte/_writers/file_writers.py
+++ b/airbyte/_writers/file_writers.py
@@ -65,7 +65,7 @@ class FileWriterBase(AirbyteWriterInterface):
         # If a stream contains a special Character, the temporary jsonl.gz
         # file can't be created, because of OS restrictions. Therefore, we
         # remove the special characters.
-        cleaned_stream_name = re.sub(r"[^a-zA-Z0-9\s]", "", stream_name)
+        cleaned_stream_name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', "", stream_name)
         return target_dir / f"{cleaned_stream_name}_{batch_id}{self.default_cache_file_suffix}"
 
     def _open_new_file(

--- a/airbyte/_writers/file_writers.py
+++ b/airbyte/_writers/file_writers.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import abc
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, final
@@ -61,7 +62,8 @@ class FileWriterBase(AirbyteWriterInterface):
         batch_id = batch_id or str(ulid.ULID())
         target_dir = Path(self._cache_dir)
         target_dir.mkdir(parents=True, exist_ok=True)
-        return target_dir / f"{stream_name}_{batch_id}{self.default_cache_file_suffix}"
+        cleaned_stream_name = re.sub(r"[^a-zA-Z0-9\s]", "", stream_name)
+        return target_dir / f"{cleaned_stream_name}_{batch_id}{self.default_cache_file_suffix}"
 
     def _open_new_file(
         self,

--- a/airbyte/_writers/file_writers.py
+++ b/airbyte/_writers/file_writers.py
@@ -62,6 +62,9 @@ class FileWriterBase(AirbyteWriterInterface):
         batch_id = batch_id or str(ulid.ULID())
         target_dir = Path(self._cache_dir)
         target_dir.mkdir(parents=True, exist_ok=True)
+        # If a stream contains a special Character, the temporary jsonl.gz
+        # file can't be created, because of OS restrictions. Therefore, we
+        # remove the special characters.
         cleaned_stream_name = re.sub(r"[^a-zA-Z0-9\s]", "", stream_name)
         return target_dir / f"{cleaned_stream_name}_{batch_id}{self.default_cache_file_suffix}"
 

--- a/airbyte/_writers/file_writers.py
+++ b/airbyte/_writers/file_writers.py
@@ -65,6 +65,8 @@ class FileWriterBase(AirbyteWriterInterface):
         # If a stream contains a special Character, the temporary jsonl.gz
         # file can't be created, because of OS restrictions. Therefore, we
         # remove the special characters.
+        # Specifically: we remove any of these characters: `<>:"/\|?*`
+        # and we remove characters in the ASCII range from 0 to 31.
         cleaned_stream_name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', "", stream_name)
         return target_dir / f"{cleaned_stream_name}_{batch_id}{self.default_cache_file_suffix}"
 


### PR DESCRIPTION
Fixes #544.

I've tested the fix with three different sources.

<details><summary>Source File</summary>

```python

import airbyte as ab

file_content = "col_1,col_2\nfoo,bar\n"
with open("test \ special chars.csv", "w") as f:
    f.write(file_content)

source: ab.Source = ab.get_source("source-file")
config = {
    "dataset_name": "test \ special chars",
    "format": "csv",
    "url": "test \ special chars.csv",
    "provider": {"storage": "local"}
}

source.set_config(config)
source.select_all_streams()
records = source.read()
records.streams.get("test \\ special chars").to_pandas()
```

</details>



<details><summary>PokeApi</summary>
<p>

```python

import airbyte as ab

source: ab.Source = ab.get_source(    "source-pokeapi",
    config={"pokemon_name": "bulbasaur"},
    source_manifest=True,
)

source.check()
source.get_available_streams()
source.select_all_streams()
records = source.read()

```

</p>
</details> 

It also worked on the custom Connector mentioned in the Bug Issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file path generation by cleaning stream names to remove special characters, ensuring compatibility with operating system restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->