### PR TITLE
Fix: Handle missing config in CLI `validate` command for destinations

### DIFF
--- a/airbyte/cli.py
+++ b/airbyte/cli.py
@@ -262,12 +262,7 @@ def _resolve_destination_job(
         config: The path to a configuration file for the named source or destination.
         pip_url: Optional. A location from which to install the connector.
     """
-    if not config:
-        raise PyAirbyteInputError(
-            message="No configuration found.",
-        )
-
-    config_dict = _resolve_config(config)
+    config_dict = _resolve_config(config) if config else None
 
     if destination and (destination.startswith(".") or "/" in destination):
         # Treat the destination as a path.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for configuration inputs in CLI commands.
	- Simplified control flow for destination and source job resolution.

- **New Features**
	- Enhanced flexibility in handling cases where configuration may not be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->