### PR TITLE
Chore: Only import submodules at type checking level

### DIFF
--- a/airbyte/__init__.py
+++ b/airbyte/__init__.py
@@ -123,23 +123,8 @@ has its own documentation and code samples related to effectively using the rela
 
 from __future__ import annotations
 
-from airbyte import (
-    caches,
-    callbacks,
-    # cli,  # Causes circular import if included
-    cloud,
-    constants,
-    datasets,
-    destinations,
-    documents,
-    exceptions,  # noqa: ICN001  # No 'exc' alias for top-level module
-    experimental,
-    logs,
-    records,
-    results,
-    secrets,
-    sources,
-)
+from typing import TYPE_CHECKING
+
 from airbyte.caches.bigquery import BigQueryCache
 from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import get_colab_cache, get_default_cache, new_local_cache
@@ -153,6 +138,28 @@ from airbyte.sources import registry
 from airbyte.sources.base import Source
 from airbyte.sources.registry import get_available_connectors
 from airbyte.sources.util import get_source
+
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004  # imports used for more than type checking
+    from airbyte import (
+        caches,
+        callbacks,
+        # cli,  # Causes circular import if included
+        cloud,
+        constants,
+        datasets,
+        destinations,
+        documents,
+        exceptions,  # noqa: ICN001  # No 'exc' alias for top-level module
+        experimental,
+        logs,
+        records,
+        results,
+        secrets,
+        sources,
+    )
 
 
 __all__ = [

--- a/airbyte/caches/__init__.py
+++ b/airbyte/caches/__init__.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from airbyte.caches import base, bigquery, duckdb, motherduck, postgres, snowflake, util
+from typing import TYPE_CHECKING
+
 from airbyte.caches.base import CacheBase
 from airbyte.caches.bigquery import BigQueryCache
 from airbyte.caches.duckdb import DuckDBCache
@@ -12,6 +13,11 @@ from airbyte.caches.postgres import PostgresCache
 from airbyte.caches.snowflake import SnowflakeCache
 from airbyte.caches.util import get_default_cache, new_local_cache
 
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004
+    from airbyte.caches import base, bigquery, duckdb, motherduck, postgres, snowflake, util
 
 # We export these classes for easy access: `airbyte.caches...`
 __all__ = [

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -56,11 +56,18 @@ These additional features are subject to change and may not be available in all 
 
 from __future__ import annotations
 
-from airbyte.cloud import connections, constants, sync_results, workspaces
+from typing import TYPE_CHECKING
+
 from airbyte.cloud.connections import CloudConnection
 from airbyte.cloud.constants import JobStatusEnum
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.cloud.workspaces import CloudWorkspace
+
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004
+    from airbyte.cloud import connections, constants, sync_results, workspaces
 
 
 __all__ = [

--- a/airbyte/destinations/__init__.py
+++ b/airbyte/destinations/__init__.py
@@ -75,12 +75,19 @@ to PyAirbyte so they can run anywhere that PyAirbyte can run.
 
 from __future__ import annotations
 
-from airbyte.destinations import util
+from typing import TYPE_CHECKING
+
 from airbyte.destinations.base import Destination
 from airbyte.destinations.util import (
     get_destination,
     get_noop_destination,
 )
+
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004  # imports used for more than type checking
+    from airbyte.destinations import util
 
 
 __all__ = [

--- a/airbyte/secrets/__init__.py
+++ b/airbyte/secrets/__init__.py
@@ -64,16 +64,8 @@ _Below are the classes and functions available in the `airbyte.secrets` module._
 
 from __future__ import annotations
 
-from airbyte.secrets import (
-    base,
-    config,
-    custom,
-    env_vars,
-    google_colab,
-    google_gsm,
-    prompt,
-    util,
-)
+from typing import TYPE_CHECKING
+
 from airbyte.secrets.base import SecretHandle, SecretManager, SecretSourceEnum, SecretString
 from airbyte.secrets.config import disable_secret_source, register_secret_manager
 from airbyte.secrets.custom import CustomSecretManager
@@ -82,6 +74,21 @@ from airbyte.secrets.google_colab import ColabSecretManager
 from airbyte.secrets.google_gsm import GoogleGSMSecretManager
 from airbyte.secrets.prompt import SecretsPrompt
 from airbyte.secrets.util import get_secret
+
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004  # imports used for more than type checking
+    from airbyte.secrets import (
+        base,
+        config,
+        custom,
+        env_vars,
+        google_colab,
+        google_gsm,
+        prompt,
+        util,
+    )
 
 
 __all__ = [

--- a/airbyte/sources/__init__.py
+++ b/airbyte/sources/__init__.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from airbyte.sources import base, util
+from typing import TYPE_CHECKING
+
 from airbyte.sources.base import Source
 from airbyte.sources.registry import (
     ConnectorMetadata,
@@ -15,6 +16,14 @@ from airbyte.sources.util import (
     get_source,
 )
 
+
+# Submodules imported here for documentation reasons: https://github.com/mitmproxy/pdoc/issues/757
+if TYPE_CHECKING:
+    # ruff: noqa: TCH004  # imports used for more than type checking
+    from airbyte.sources import (
+        base,
+        util,
+    )
 
 __all__ = [
     # Submodules

--- a/tests/integration_tests/test_install.py
+++ b/tests/integration_tests/test_install.py
@@ -20,4 +20,8 @@ def test_install_failure_log_pypi():
         )
 
     # Check that the stderr log contains the expected content from a failed pip install
-    assert "Could not install requirement" in str(exc_info.value.__cause__.log_text)
+    err_msg = str(exc_info.value.__cause__.log_text)
+    assert any([
+        "Cannot unpack file" in err_msg,
+        "Could not install requirement" in err_msg,
+    ])


### PR DESCRIPTION
Related to:

- https://github.com/mitmproxy/pdoc/issues/757

This PR moves all imports of submodules to their parent modules under `if TYPE_CHECKING: ...` conditional blocks. This seems to satisfy `pdoc` while not having the runtime implications or risk of circular dependency issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced import structure across various modules to improve performance and reduce circular dependencies by implementing conditional imports for type checking.
  
- **Documentation**
	- Maintained and clarified documentation comments to provide context for users regarding the usage of the PyAirbyte library. 

- **Bug Fixes**
	- Improved compatibility with type checkers by restructuring imports without affecting runtime performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->