### PR TITLE
fix: ConfiguredAirbyteCatalog schema violation (cursor_field)

### DIFF
--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -375,6 +375,7 @@ class Source(ConnectorBase):
                     destination_sync_mode=DestinationSyncMode.overwrite,
                     primary_key=stream.source_defined_primary_key,
                     sync_mode=SyncMode.incremental,
+                    cursor_field=stream.default_cursor_field,
                 )
                 for stream in self.discovered_catalog.streams
                 if stream.name in selected_streams


### PR DESCRIPTION
"cursor_field" property from an ConfiguredAirbyteCatalog is not properly set, leaving its value to Null while it's not allowed.
Fixes #567.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data stream configuration now supports incremental processing with a dedicated tracking field for efficient data synchronization. Existing record retrieval behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->