### PR TITLE
feat: add "runas_host_user" param to get_source()

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
@@ -123,6 +124,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
     local_executable: Path | str | None = None,
     docker_image: bool | str | None = None,
     use_host_network: bool = False,
+    runas_host_user: bool = False,
     source_manifest: bool | dict | Path | str | None = None,
     install_if_missing: bool = True,
     install_root: Path | None = None,
@@ -235,6 +237,9 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
 
         if use_host_network is True:
             docker_cmd.extend(["--network", "host"])
+
+        if runas_host_user is True:
+            docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
 
         docker_cmd.extend([docker_image])
 

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -21,6 +22,7 @@ from airbyte.constants import AIRBYTE_OFFLINE_MODE, TEMP_DIR_OVERRIDE
 from airbyte.sources.registry import ConnectorMetadata, InstallType, get_connector_metadata
 from airbyte.version import get_version
 
+logger = logging.getLogger("airbyte")
 
 if TYPE_CHECKING:
     from airbyte._executors.base import Executor
@@ -239,7 +241,10 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
             docker_cmd.extend(["--network", "host"])
 
         if runas_host_user is True:
-            docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+            try:
+                docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+            except:
+                logger.info("The 'runas_host_user' parameter is only supported on POSIX systems.")
 
         docker_cmd.extend([docker_image])
 

--- a/airbyte/destinations/util.py
+++ b/airbyte/destinations/util.py
@@ -28,6 +28,7 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
     local_executable: Path | str | None = None,
     docker_image: str | bool | None = None,
     use_host_network: bool = False,
+    runas_host_user: bool = False,
     install_if_missing: bool = True,
 ) -> Destination:
     """Get a connector by name and version.
@@ -56,6 +57,9 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
             the host network. This is useful for connectors that need to access resources on
             the host machine, such as a local database. This parameter is ignored when
             `docker_image` is not set.
+        runas_host_user: If set, along with docker_image, the connector will be executed using the
+            host's user UID/GID. This is useful to handle container privileges (such as files
+            permissions). This parameter is ignored when `docker_image` is not set.
         install_if_missing: Whether to install the connector if it is not available locally. This
             parameter is ignored when local_executable is set.
     """
@@ -70,6 +74,7 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
             local_executable=local_executable,
             docker_image=docker_image,
             use_host_network=use_host_network,
+            runas_host_user=runas_host_user,
             install_if_missing=install_if_missing,
         ),
     )

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -55,6 +55,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
     local_executable: Path | str | None = None,
     docker_image: bool | str | None = None,
     use_host_network: bool = False,
+    runas_host_user: bool = False,
     source_manifest: bool | dict | Path | str | None = None,
     install_if_missing: bool = True,
     install_root: Path | None = None,
@@ -95,6 +96,9 @@ def get_source(  # noqa: PLR0913 # Too many arguments
             the host network. This is useful for connectors that need to access resources on
             the host machine, such as a local database. This parameter is ignored when
             `docker_image` is not set.
+        runas_host_user: If set, along with docker_image, the connector will be executed using the
+            host's user UID/GID. This is useful to handle container privileges (such as files
+            permissions). This parameter is ignored when `docker_image` is not set.
         source_manifest: If set, the connector will be executed based on a declarative YAML
             source definition. This input can be `True` to attempt to auto-download a YAML spec,
             `dict` to accept a Python dictionary as the manifest, `Path` to pull a manifest from
@@ -116,6 +120,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
             local_executable=local_executable,
             docker_image=docker_image,
             use_host_network=use_host_network,
+            runas_host_user=runas_host_user,
             source_manifest=source_manifest,
             install_if_missing=install_if_missing,
             install_root=install_root,


### PR DESCRIPTION
Docker in Docker context.

I need to execute a containerized source with same UID as the  containerized host executing script in order to simplify file permissions management.
"config" and "catalog" files generated thanks to "tempfile" library have 600 POSIX perms and the "runas_host_user" approach helped me to allow source container to read this ones. 

It works like the `use_host_network` param, simply set `runas_host_user` to `True` while calling `get_source()` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connectors now offer an option to execute with host user privileges, improving file permission handling and resource access.
  
- **Deprecations**
  - An older connector method has been deprecated in favor of the updated implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->