### PR TITLE
fix: specifying a target version for a source does not actually install that version

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -157,7 +157,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
                 "pip_url": pip_url,
             },
         )
-    
+
     if install_method_count > 1:
         raise exc.PyAirbyteInputError(
             message=(

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -151,7 +151,10 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
 
     if version and pip_url:
         raise exc.PyAirbyteInputError(
-            message="Cannot specify both version and pip_url. Make sure to specify the connector version directly in the pip_url.",
+            message=(
+                "Cannot specify both version and pip_url. "
+                "Make sure to specify the connector version directly in the pip_url."
+            ),
             context={
                 "version": version,
                 "pip_url": pip_url,

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -148,6 +148,16 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
             bool(source_manifest),
         ]
     )
+
+    if version and pip_url:
+        raise exc.PyAirbyteInputError(
+            message="Cannot specify both version and pip_url. Make sure to specify the connector version directly in the pip_url.",
+            context={
+                "version": version,
+                "pip_url": pip_url,
+            },
+        )
+    
     if install_method_count > 1:
         raise exc.PyAirbyteInputError(
             message=(
@@ -198,6 +208,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branch
                     source_manifest = True
                 case InstallType.PYTHON:
                     pip_url = metadata.pypi_package_name
+                    pip_url = f"{pip_url}=={version}" if version else pip_url
                 case _:
                     docker_image = True
 

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -124,7 +124,7 @@ def _get_local_executor(
     )
 
 
-def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915 # Too many branches/arguments/statements
+def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0915, C901 # Too many branches/arguments/statements
     name: str,
     *,
     version: str | None = None,


### PR DESCRIPTION
Fixes https://github.com/airbytehq/PyAirbyte/issues/622

Example:
```python
source = ab.get_source(
    name="source-faker",
    version="6.2.17",
    config={"count": SCALE / 2},
    install_if_missing=True,
)
```

PyAirbyte logs:
```
Installing 'source-faker' into virtual environment '/Users/m.marx/Code/playground/pyab/.venv-source-faker'.
Running 'pip install airbyte-source-faker==6.2.23'...

Collecting airbyte-source-faker==6.2.23
-----
AirbyteConnectorInstallationError: Connector's reported version does not match the target version.
    Connector Name: 'source-faker'
    Venv Name: '.venv-source-faker'
    Target Version: '6.2.17'
    Original Installed Version: None
    Version After Reinstall: '6.2.23'
```

With this change we make sure the `pip_url` uses the target `version`. 
Also fix a possible bug in case users specify `pip_url` and `version` where it will install the static value of `pip_url`
```python
source = ab.get_source(
    name="source-faker",
    pip_url="airbyte-source-faker",
    version="6.2.17",
    config={"count": SCALE / 2},
    install_if_missing=True,
)
```
Now it will throws an error alerting users to use pip_url OR version.
---
My initial idea was to change the following code:
https://github.com/airbytehq/PyAirbyte/blob/ee5cb2d20c001f52dc192dd2aff3d39aba5953c9/airbyte/_executors/python.py#L56-L60

But you'll always receive the `pip_url` and the executor doesn't have knowledge if it was the user or the (current code block) created the pip_url variable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation for installation configuration to prevent conflicting inputs.
  - Updated the handling of package reference inputs so that version information is automatically integrated when provided.
  - Added error handling to prevent both `version` and `pip_url` from being specified simultaneously.
  - Updated function documentation to include a warning regarding cyclomatic complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->