### PR TITLE
feat: Remove long standing connections on sql state and catalog backends

### DIFF
--- a/airbyte/caches/_catalog_backend.py
+++ b/airbyte/caches/_catalog_backend.py
@@ -27,7 +27,7 @@ from airbyte.shared.catalog_providers import CatalogProvider
 
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine import Engine
+    from airbyte.shared.sql_processor import SqlConfig
 
 
 STREAMS_TABLE_NAME = "_airbyte_streams"
@@ -110,10 +110,10 @@ class SqlCatalogBackend(CatalogBackendBase):
 
     def __init__(
         self,
-        engine: Engine,
+        sql_config: SqlConfig,
         table_prefix: str,
     ) -> None:
-        self._engine: Engine = engine
+        self._sql_config = sql_config
         self._table_prefix = table_prefix
         self._ensure_internal_tables()
         self._full_catalog: ConfiguredAirbyteCatalog = ConfiguredAirbyteCatalog(
@@ -125,7 +125,7 @@ class SqlCatalogBackend(CatalogBackendBase):
         self._source_catalogs: dict[str, ConfiguredAirbyteCatalog] = {}
 
     def _ensure_internal_tables(self) -> None:
-        engine = self._engine
+        engine = self._sql_config.get_sql_engine()
         SqlAlchemyModel.metadata.create_all(engine)  # type: ignore[attr-defined]
 
     def register_source(
@@ -181,7 +181,7 @@ class SqlCatalogBackend(CatalogBackendBase):
         incoming_stream_names: set[str],
     ) -> None:
         self._ensure_internal_tables()
-        engine = self._engine
+        engine = self._sql_config.get_sql_engine()
         with Session(engine) as session:
             # Delete and replace existing stream entries from the catalog cache
             table_name_entries_to_delete = [
@@ -217,7 +217,7 @@ class SqlCatalogBackend(CatalogBackendBase):
 
         The `source_name` and `table_prefix` args are optional filters.
         """
-        engine = self._engine
+        engine = self._sql_config.get_sql_engine()
         with Session(engine) as session:
             # load all the streams
             streams: list[CachedStream] = session.query(CachedStream).all()

--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -89,11 +89,11 @@ class CacheBase(SqlConfig, AirbyteWriterInterface):
 
         # Initialize the catalog and state backends
         self._catalog_backend = SqlCatalogBackend(
-            engine=self.get_sql_engine(),
+            sql_config=self,
             table_prefix=self.table_prefix or "",
         )
         self._state_backend = SqlStateBackend(
-            engine=self.get_sql_engine(),
+            sql_config=self,
             table_prefix=self.table_prefix or "",
         )
 


### PR DESCRIPTION
## What does this PR do?
This PR modifies how `SqlCatalogBackend` and `SqlStateBackend` connect to an sql engine to do so lazily and per query execution instead of eagerly and in a single connection. This allows long running syncs to complete without receiving the following error:
```
(snowflake.connector.errors.ProgrammingError) 390114 (08001): None: Authentication token has expired.  The user must authenticate again.
```

## Testing
- [ ] tbd (want an initial review of approach before testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated backend initialization to use a configuration object for SQL connections instead of a direct engine reference. This change affects how internal catalog and state management components are set up, with no impact on user-facing features or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->