### PR TITLE
ci: Use GitHub App token for CI workflow

### DIFF
--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -65,7 +65,7 @@ jobs:
       commit-sha: ${{ fromJSON(steps.pr-info.outputs.json).head.sha }}
       pr-number: ${{ steps.pr-info.outputs.number }}
       pr-title: ${{ steps.pr-info.outputs.title }}
-      gh-app-token: ${{ needs.get-app-token.outputs.token }}
+      gh-app-token: ${{ steps.get-app-token.outputs.token }}
 
   # This is copied from the `python_pytest.yml` file.
   # Only the first two steps of the job are different, and they check out the PR's branch.

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -31,6 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - uses: actions/create-github-app-token@v1
+      id: get-app-token
+      with:
+        owner: "airbytehq"
+        repositories: "PyAirbyte"
+        app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+        private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
     - name: Create URL to the run output
       id: vars
       run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
@@ -51,14 +59,6 @@ jobs:
       uses: cloudposse-github-actions/get-pr@v2.0.0
       with:
         id: ${{ inputs.pr }}
-
-    - uses: actions/create-github-app-token@v1
-      id: get-app-token
-      with:
-        owner: "airbytehq"
-        repositories: "PyAirbyte"
-        app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-        private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
     outputs:
       source-repo: ${{ fromJSON(steps.pr-info.outputs.json).head.repo.full_name }}

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -11,6 +11,8 @@ on:
         description: 'Comment ID (Optional)'
         type: string
         required: false
+  # Temporary: for testing:
+  push:
 
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
@@ -53,8 +55,10 @@ jobs:
     - uses: actions/create-github-app-token@v1
       id: get-app-token
       with:
-        app-id: ${{ vars.OCTAVIA_GITHUB_APP_ID }}
-        private-key: ${{ secrets.OCTAVIA_GITHUB_APP_PRIVATE_KEY }}
+        owner: "airbytehq"
+        repositories: "PyAirbyte"
+        app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+        private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
     outputs:
       source-repo: ${{ fromJSON(steps.pr-info.outputs.json).head.repo.full_name }}

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -11,8 +11,6 @@ on:
         description: 'Comment ID (Optional)'
         type: string
         required: false
-  # Temporary: for testing:
-  push:
 
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   start-workflow:
-    name: Append 'Starting' Comment
+    name: Start Workflow
     runs-on: ubuntu-latest
     steps:
 
@@ -49,12 +49,20 @@ jobs:
       uses: cloudposse-github-actions/get-pr@v2.0.0
       with:
         id: ${{ inputs.pr }}
+
+    - uses: actions/create-github-app-token@v1
+      id: get-app-token
+      with:
+        app-id: ${{ vars.OCTAVIA_GITHUB_APP_ID }}
+        private-key: ${{ secrets.OCTAVIA_GITHUB_APP_PRIVATE_KEY }}
+
     outputs:
       source-repo: ${{ fromJSON(steps.pr-info.outputs.json).head.repo.full_name }}
       source-branch: ${{ fromJSON(steps.pr-info.outputs.json).head.ref }}
       commit-sha: ${{ fromJSON(steps.pr-info.outputs.json).head.sha }}
       pr-number: ${{ steps.pr-info.outputs.number }}
       pr-title: ${{ steps.pr-info.outputs.title }}
+      gh-app-token: ${{ needs.get-app-token.outputs.token }}
 
   # This is copied from the `python_pytest.yml` file.
   # Only the first two steps of the job are different, and they check out the PR's branch.
@@ -98,7 +106,7 @@ jobs:
         repo: "airbytehq/airbyte"  # Post to the Airbyte repo, not the fork
         sha: ${{ needs.start-workflow.outputs.commit-sha }}
         status: in_progress
-        token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+        token: ${{ needs.start-workflow.outputs.gh-app-token }}
 
     # Same as the `python_pytest.yml` file:
 
@@ -147,7 +155,7 @@ jobs:
         sha: ${{ needs.start-workflow.outputs.commit-sha }}
         status: completed
         conclusion: ${{ job.status }}
-        token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+        token: ${{ needs.start-workflow.outputs.gh-app-token }}
 
   log-success-comment:
     name: Append 'Success' Comment

--- a/.github/workflows/test-pr-command.yml
+++ b/.github/workflows/test-pr-command.yml
@@ -31,7 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/create-github-app-token@v1
+    - name: Authenticate as GitHub App
+      uses: actions/create-github-app-token@v1
       id: get-app-token
       with:
         owner: "airbytehq"


### PR DESCRIPTION
Replace the personal access token with a GitHub App token for improved security and explicitly define the repository owner in the CI configuration.