### PR TITLE
feat: Allow configuring dataset location in BigQueryCache

### DIFF
--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -210,10 +210,7 @@ class BigQuerySqlProcessor(SqlProcessorBase):
         project = self.sql_config.project_name
         schema = self.sql_config.schema_name
         location = self.sql_config.dataset_location
-        sql = (
-            f"CREATE SCHEMA IF NOT EXISTS `{project}.{schema}` "
-            f'OPTIONS(location="{location}")'
-        )
+        sql = f"CREATE SCHEMA IF NOT EXISTS `{project}.{schema}` " f'OPTIONS(location="{location}")'
         try:
             self._execute_sql(sql)
         except Exception as ex:

--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -207,9 +207,12 @@ class BigQuerySqlProcessor(SqlProcessorBase):
         if self._schema_exists:
             return
 
+        project = self.sql_config.project_name
+        schema = self.sql_config.schema_name
+        location = self.sql_config.dataset_location
         sql = (
-            f"CREATE SCHEMA IF NOT EXISTS `{self.sql_config.project_name}.{self.sql_config.schema_name}` "
-            f"OPTIONS(location=\"{self.sql_config.dataset_location}\")"
+            f"CREATE SCHEMA IF NOT EXISTS `{project}.{schema}` "
+            f'OPTIONS(location="{location}")'
         )
         try:
             self._execute_sql(sql)

--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -47,6 +47,10 @@ class BigQueryConfig(SqlConfig):
     """The path to the credentials file to use.
     If not passed, falls back to the default inferred from the environment."""
 
+    dataset_location: str = "US"
+    """The geographic location of the BigQuery dataset (e.g., 'US', 'EU', etc.).
+    Defaults to 'US'. See: https://cloud.google.com/bigquery/docs/locations"""
+
     @property
     def project_name(self) -> str:
         """Return the project name (alias of self.database_name)."""

--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -94,7 +94,7 @@ class BigQueryConfig(SqlConfig):
         else:
             credentials, _ = google.auth.default()
 
-        return bigquery.Client(credentials=credentials)
+        return bigquery.Client(credentials=credentials, location=self.dataset_location)
 
 
 class BigQueryTypeConverter(SQLTypeConverter):
@@ -207,7 +207,10 @@ class BigQuerySqlProcessor(SqlProcessorBase):
         if self._schema_exists:
             return
 
-        sql = f"CREATE SCHEMA IF NOT EXISTS {self.sql_config.schema_name}"
+        sql = (
+            f"CREATE SCHEMA IF NOT EXISTS `{self.sql_config.project_name}.{self.sql_config.schema_name}` "
+            f"OPTIONS(location=\"{self.sql_config.dataset_location}\")"
+        )
         try:
             self._execute_sql(sql)
         except Exception as ex:

--- a/airbyte/destinations/_translate_cache_to_dest.py
+++ b/airbyte/destinations/_translate_cache_to_dest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from airbyte_api.models import (
     BatchedStandardInserts,
+    DatasetLocation,
     DestinationBigquery,
     DestinationDuckdb,
     DestinationPostgres,
@@ -122,10 +123,11 @@ def bigquery_cache_to_destination_configuration(
         if cache.credentials_path
         else None
     )
+
     return DestinationBigquery(
         project_id=cache.project_name,
         dataset_id=cache.dataset_name,
-        dataset_location="US",
+        dataset_location=DatasetLocation(cache.dataset_location),
         credentials_json=credentials_json,
         loading_method=BatchedStandardInserts(),
     )

--- a/airbyte/destinations/_translate_dest_to_cache.py
+++ b/airbyte/destinations/_translate_dest_to_cache.py
@@ -90,6 +90,7 @@ def bigquery_destination_to_cache(
         project_name=destination_configuration.project_id,
         dataset_name=destination_configuration.dataset_id,
         credentials_path=credentials_path,
+        dataset_location=destination_configuration.dataset_location,
     )
 
 


### PR DESCRIPTION
Resolves #688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying the geographic location of BigQuery datasets through a new configuration option. The dataset location now defaults to "US" but can be customized as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->