### PR TITLE
feat(sources): Update sources with init errors

### DIFF
--- a/airbyte/sources/registry.py
+++ b/airbyte/sources/registry.py
@@ -40,7 +40,8 @@ _LOWCODE_CONNECTORS_FAILING_VALIDATION: list[str] = []
 # Connectors that return 404 or some other misc exception.
 _LOWCODE_CONNECTORS_UNEXPECTED_ERRORS: list[str] = [
     "source-adjust",
-    "source-amazon-ads",
+    "source-amazon-seller-partner",
+    "source-gitlab",
     "source-marketo",
 ]
 # (CDK) FileNotFoundError: Unable to find spec.yaml or spec.json in the package.


### PR DESCRIPTION
[amazon-seller-partner](https://docs.airbyte.com/integrations/sources/amazon-seller-partner) has just been migrated to manifest-only.
[gitlab](https://docs.airbyte.com/integrations/sources/gitlab) has just been migrated to manifest-only.

[amazon-ads](https://docs.airbyte.com/integrations/sources/amazon-ads) has been updated and is not failing anymore.

They make the CI fail, cf [this PR](https://github.com/airbytehq/PyAirbyte/pull/717) containing no changes.

So we are excluding them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the Amazon Seller Partner connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->