### PR TITLE
fix: use stderr for log and progress prints

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import jsonschema
 import rich
 import yaml
-from numpy import std
 from rich.syntax import Syntax
 
 from airbyte_protocol.models import (

--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import abc
 import json
+import sys
 from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any, Literal
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import jsonschema
 import rich
 import yaml
+from numpy import std
 from rich.syntax import Syntax
 
 from airbyte_protocol.models import (
@@ -106,7 +108,7 @@ class ConnectorBase(abc.ABC):
         message: str,
     ) -> None:
         """Print a message to the console and the logger."""
-        rich.print(f"ERROR: {message}")
+        rich.print(f"ERROR: {message}", file=sys.stderr)
         if self._file_logger:
             self._file_logger.error(message)
 
@@ -248,6 +250,7 @@ class ConnectorBase(abc.ABC):
         format: Literal["yaml", "json"] = "yaml",  # noqa: A002
         *,
         output_file: Path | str | None = None,
+        stderr: bool = False,
     ) -> None:
         """Print the configuration spec for this connector.
 
@@ -255,7 +258,18 @@ class ConnectorBase(abc.ABC):
             format: The format to print the spec in. Must be "yaml" or "json".
             output_file: Optional. If set, the spec will be written to the given file path.
                 Otherwise, it will be printed to the console.
+            stderr: If True, print to stderr instead of stdout. This is useful when we
+                want to print the spec to the console but not interfere with other output.
         """
+        if output_file and stderr:
+            raise exc.PyAirbyteInputError(
+                message="You can set output_file or stderr but not both.",
+                context={
+                    "output_file": output_file,
+                    "stderr": stderr,
+                },
+            )
+
         if format not in {"yaml", "json"}:
             raise exc.PyAirbyteInputError(
                 message="Invalid format. Expected 'yaml' or 'json'",
@@ -274,7 +288,7 @@ class ConnectorBase(abc.ABC):
             return
 
         syntax_highlighted = Syntax(content, format)
-        rich.print(syntax_highlighted)
+        rich.print(syntax_highlighted, file=sys.stderr if stderr else None)
 
     @property
     def _yaml_spec(self) -> str:
@@ -325,7 +339,10 @@ class ConnectorBase(abc.ABC):
                 for msg in self._execute(["check", "--config", config_file]):
                     if msg.type == Type.CONNECTION_STATUS and msg.connectionStatus:
                         if msg.connectionStatus.status != Status.FAILED:
-                            rich.print(f"Connection check succeeded for `{self.name}`.")
+                            rich.print(
+                                f"Connection check succeeded for `{self.name}`.",
+                                file=sys.stderr,
+                            )
                             log_connector_check_result(
                                 name=self.name,
                                 state=EventState.SUCCEEDED,
@@ -359,7 +376,10 @@ class ConnectorBase(abc.ABC):
     def install(self) -> None:
         """Install the connector if it is not yet installed."""
         self.executor.install()
-        rich.print("For configuration instructions, see: \n" f"{self.docs_url}#reference\n")
+        rich.print(
+            f"For configuration instructions, see: \n{self.docs_url}#reference\n",
+            file=sys.stderr,
+        )
 
     def uninstall(self) -> None:
         """Uninstall the connector if it is installed.

--- a/airbyte/_executors/python.py
+++ b/airbyte/_executors/python.py
@@ -113,7 +113,8 @@ class VenvExecutor(Executor):
         pip_path = str(get_bin_dir(self._get_venv_path()) / "pip")
         print(
             f"Installing '{self.name}' into virtual environment '{self._get_venv_path()!s}'.\n"
-            f"Running 'pip install {self.pip_url}'...\n"
+            f"Running 'pip install {self.pip_url}'...\n",
+            file=sys.stderr,
         )
         try:
             self._run_subprocess_and_raise_on_failure(
@@ -134,7 +135,8 @@ class VenvExecutor(Executor):
         print(
             f"Connector '{self.name}' installed successfully!\n"
             f"For more information, see the {self.name} documentation:\n"
-            f"{self.docs_url}#reference\n"
+            f"{self.docs_url}#reference\n",
+            file=sys.stderr,
         )
 
     @overrides
@@ -241,7 +243,8 @@ class VenvExecutor(Executor):
             # This is sometimes caused by a failed or partial installation.
             print(
                 "Connector executable not found within the virtual environment "
-                f"at {self._get_connector_path()!s}.\nReinstalling..."
+                f"at {self._get_connector_path()!s}.\nReinstalling...",
+                file=sys.stderr,
             )
             self.uninstall()
             self.install()

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
@@ -147,7 +148,7 @@ def _get_local_executor(
 
     # `local_executable` is now a Path object
 
-    print(f"Using local `{name}` executable: {local_executable!s}")
+    print(f"Using local `{name}` executable: {local_executable!s}", file=sys.stderr)
     return PathExecutor(
         name=name,
         path=local_executable,

--- a/airbyte/cli.py
+++ b/airbyte/cli.py
@@ -61,6 +61,7 @@ pyab validate --connector=source-hardcoded-records --config='{count: 400_000}'
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -339,8 +340,8 @@ def validate(
             pip_url=pip_url,
         )
 
-    print("Getting `spec` output from connector...")
-    connector_obj.print_config_spec()
+    print("Getting `spec` output from connector...", file=sys.stderr)
+    connector_obj.print_config_spec(stderr=True)
 
     if config:
         print("Running connector check...")

--- a/airbyte/cli.py
+++ b/airbyte/cli.py
@@ -436,7 +436,7 @@ def benchmark(
         else get_noop_destination()
     )
 
-    click.echo("Running benchmarks...")
+    click.echo("Running benchmarks...", sys.stderr)
     destination_obj.write(
         source_data=source_obj,
         cache=False,

--- a/airbyte/logs.py
+++ b/airbyte/logs.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import sys
 import tempfile
 import warnings
 from functools import lru_cache
@@ -153,7 +154,7 @@ def get_global_file_logger() -> logging.Logger | None:
         return None
 
     logfile_path = folder / f"airbyte-log-{str(ulid.ULID())[2:11]}.log"
-    print(f"Writing PyAirbyte logs to file: {logfile_path!s}")
+    print(f"Writing PyAirbyte logs to file: {logfile_path!s}", file=sys.stderr)
 
     file_handler = logging.FileHandler(
         filename=logfile_path,
@@ -242,7 +243,7 @@ def get_global_stats_logger() -> structlog.BoundLogger:
         # No temp directory available, so return no-op logger without handlers
         return structlog.get_logger("airbyte.stats")
 
-    print(f"Writing PyAirbyte performance stats to file: {logfile_path!s}")
+    print(f"Writing PyAirbyte performance stats to file: {logfile_path!s}", file=sys.stderr)
 
     # Remove any existing handlers
     for handler in logger.handlers:
@@ -299,7 +300,7 @@ def new_passthrough_file_logger(connector_name: str) -> logging.Logger:
     global_logger = get_global_file_logger()
     logfile_path = folder / f"{connector_name}-log-{str(ulid.ULID())[2:11]}.log"
     logfile_msg = f"Writing `{connector_name}` logs to file: {logfile_path!s}"
-    print(logfile_msg)
+    print(logfile_msg, file=sys.stderr)
     if global_logger:
         global_logger.info(logfile_msg)
 

--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -28,6 +28,7 @@ from contextlib import suppress
 from enum import Enum, auto
 from typing import IO, TYPE_CHECKING, Any, Literal, cast
 
+from rich.console import Console
 from rich.errors import LiveError
 from rich.live import Live as RichLive
 from rich.markdown import Markdown as RichMarkdown
@@ -211,6 +212,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
 
         # Progress bar properties
         self._last_update_time: float | None = None
+        self._stderr_console: Console | None = None
         self._rich_view: RichLive | None = None
 
         self.reset_progress_style(style)
@@ -622,9 +624,13 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         """
         if self.style == ProgressStyle.RICH and not self._rich_view:
             try:
+                if self._stderr_console is None:
+                    self._stderr_console = Console(stderr=True)
+
                 self._rich_view = RichLive(
                     auto_refresh=True,
                     refresh_per_second=DEFAULT_REFRESHES_PER_SECOND,
+                    console=self._stderr_console,
                 )
                 self._rich_view.start()
             except Exception:

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from airbyte.shared.state_writers import StateWriterBase
 
 
-class Source(ConnectorBase):  # noqa: PLR0904
+class Source(ConnectorBase):
     """A class representing a source that can be called."""
 
     connector_type = "source"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to print configuration specifications and informational messages directly to standard error (stderr) instead of standard output (stdout) across various commands and components.

* **Refactor**
  * Updated print statements in multiple areas to consistently use stderr for error and informational messages.
  * Removed the configuration specification printing method from sources, streamlining output handling.
  * Enhanced progress display to use a dedicated stderr console for live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._