### PR TITLE
feat: replace pip with uv and add use_python parameter

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -166,6 +166,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
     source_manifest: bool | dict | Path | str | None = None,
     install_if_missing: bool = True,
     install_root: Path | None = None,
+    use_python: bool | Path | str | None = None,
 ) -> Executor:
     """This factory function creates an executor for a connector.
 
@@ -179,6 +180,9 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             bool(source_manifest),
         ]
     )
+
+    if use_python is False:
+        docker_image = True
 
     if version and pip_url:
         raise exc.PyAirbyteInputError(
@@ -341,6 +345,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             target_version=version,
             pip_url=pip_url,
             install_root=install_root,
+            use_python=use_python,
         )
         if install_if_missing:
             executor.ensure_installation()

--- a/airbyte/cli.py
+++ b/airbyte/cli.py
@@ -174,12 +174,26 @@ def _get_connector_name(connector: str) -> str:
     return connector
 
 
+def _parse_use_python(use_python_str: str | None) -> bool | Path | str | None:
+    """Parse the use_python CLI parameter."""
+    if use_python_str is None:
+        return None
+    if use_python_str.lower() == "true":
+        return True
+    if use_python_str.lower() == "false":
+        return False
+    if "/" in use_python_str or use_python_str.startswith("."):
+        return Path(use_python_str)
+    return use_python_str
+
+
 def _resolve_source_job(
     *,
     source: str | None = None,
     config: str | None = None,
     streams: str | None = None,
     pip_url: str | None = None,
+    use_python: str | None = None,
 ) -> Source:
     """Resolve the source job into a configured Source object.
 
@@ -191,11 +205,14 @@ def _resolve_source_job(
         streams: A comma-separated list of stream names to select for reading. If set to "*",
             all streams will be selected. If not provided, all streams will be selected.
         pip_url: Optional. A location from which to install the connector.
+        use_python: Optional. Python interpreter specification.
     """
     config_dict = _resolve_config(config) if config else None
     streams_list: str | list[str] = streams or "*"
     if isinstance(streams, str) and streams != "*":
         streams_list = [stream.strip() for stream in streams.split(",")]
+
+    use_python_parsed = _parse_use_python(use_python)
 
     source_obj: Source
     if source and _is_docker_image(source):
@@ -205,6 +222,7 @@ def _resolve_source_job(
             config=config_dict,
             streams=streams_list,
             pip_url=pip_url,
+            use_python=use_python_parsed,
         )
         return source_obj
 
@@ -224,6 +242,7 @@ def _resolve_source_job(
             config=config_dict,
             streams=streams_list,
             pip_url=pip_url,
+            use_python=use_python_parsed,
         )
         return source_obj
 
@@ -240,6 +259,7 @@ def _resolve_source_job(
         config=config_dict,
         streams=streams_list,
         pip_url=pip_url,
+        use_python=use_python_parsed,
     )
 
 
@@ -248,6 +268,7 @@ def _resolve_destination_job(
     destination: str,
     config: str | None = None,
     pip_url: str | None = None,
+    use_python: str | None = None,
 ) -> Destination:
     """Resolve the destination job into a configured Destination object.
 
@@ -258,8 +279,10 @@ def _resolve_destination_job(
             and tag.
         config: The path to a configuration file for the named source or destination.
         pip_url: Optional. A location from which to install the connector.
+        use_python: Optional. Python interpreter specification.
     """
     config_dict = _resolve_config(config) if config else None
+    use_python_parsed = _parse_use_python(use_python)
 
     if destination and (destination.startswith(".") or "/" in destination):
         # Treat the destination as a path.
@@ -276,6 +299,7 @@ def _resolve_destination_job(
             local_executable=destination_executable,
             config=config_dict,
             pip_url=pip_url,
+            use_python=use_python_parsed,
         )
 
     # else: # Treat the destination as a name.
@@ -284,6 +308,7 @@ def _resolve_destination_job(
         name=destination,
         config=config_dict,
         pip_url=pip_url,
+        use_python=use_python_parsed,
     )
 
 
@@ -314,10 +339,20 @@ def _resolve_destination_job(
     required=False,
     help=CONFIG_HELP,
 )
+@click.option(
+    "--use-python",
+    type=str,
+    help=(
+        "Python interpreter specification. Use 'true' for current Python, "
+        "'false' for Docker, a path for specific interpreter, or a version "
+        "string for uv-managed Python (e.g., '3.11', 'python3.12')."
+    ),
+)
 def validate(
     connector: str | None = None,
     config: str | None = None,
     pip_url: str | None = None,
+    use_python: str | None = None,
 ) -> None:
     """CLI command to run a `benchmark` operation."""
     if not connector:
@@ -332,12 +367,14 @@ def validate(
             config=None,
             streams=None,
             pip_url=pip_url,
+            use_python=use_python,
         )
     else:  # destination
         connector_obj = _resolve_destination_job(
             destination=connector,
             config=None,
             pip_url=pip_url,
+            use_python=use_python,
         )
 
     print("Getting `spec` output from connector...", file=sys.stderr)
@@ -393,12 +430,22 @@ def validate(
     type=str,
     help=CONFIG_HELP,
 )
+@click.option(
+    "--use-python",
+    type=str,
+    help=(
+        "Python interpreter specification. Use 'true' for current Python, "
+        "'false' for Docker, a path for specific interpreter, or a version "
+        "string for uv-managed Python (e.g., '3.11', 'python3.12')."
+    ),
+)
 def benchmark(
     source: str | None = None,
     streams: str = "*",
     num_records: int | str = "5e5",  # 500,000 records
     destination: str | None = None,
     config: str | None = None,
+    use_python: str | None = None,
 ) -> None:
     """CLI command to run a `benchmark` operation.
 
@@ -421,6 +468,7 @@ def benchmark(
             source=source,
             config=config,
             streams=streams,
+            use_python=use_python,
         )
         if source
         else get_benchmark_source(
@@ -431,6 +479,7 @@ def benchmark(
         _resolve_destination_job(
             destination=destination,
             config=config,
+            use_python=use_python,
         )
         if destination
         else get_noop_destination()
@@ -493,6 +542,15 @@ def benchmark(
     type=str,
     help="Optional pip URL for the destination (Python connectors only). " + PIP_URL_HELP,
 )
+@click.option(
+    "--use-python",
+    type=str,
+    help=(
+        "Python interpreter specification. Use 'true' for current Python, "
+        "'false' for Docker, a path for specific interpreter, or a version "
+        "string for uv-managed Python (e.g., '3.11', 'python3.12')."
+    ),
+)
 def sync(
     *,
     source: str,
@@ -502,6 +560,7 @@ def sync(
     destination_config: str | None = None,
     destination_pip_url: str | None = None,
     streams: str | None = None,
+    use_python: str | None = None,
 ) -> None:
     """CLI command to run a `sync` operation.
 
@@ -516,11 +575,13 @@ def sync(
         config=source_config,
         streams=streams,
         pip_url=source_pip_url,
+        use_python=use_python,
     )
     destination_obj = _resolve_destination_job(
         destination=destination,
         config=destination_config,
         pip_url=destination_pip_url,
+        use_python=use_python,
     )
 
     click.echo("Running sync...")

--- a/airbyte/destinations/util.py
+++ b/airbyte/destinations/util.py
@@ -29,6 +29,8 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
     docker_image: str | bool | None = None,
     use_host_network: bool = False,
     install_if_missing: bool = True,
+    install_root: Path | None = None,
+    use_python: bool | Path | str | None = None,
 ) -> Destination:
     """Get a connector by name and version.
 
@@ -58,6 +60,13 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
             `docker_image` is not set.
         install_if_missing: Whether to install the connector if it is not available locally. This
             parameter is ignored when local_executable is set.
+        install_root: (Optional.) The root directory where the virtual environment will be
+            created. If not provided, the current working directory will be used.
+        use_python: (Optional.) Python interpreter specification:
+            - True: Use current Python interpreter
+            - False: Use Docker instead
+            - Path: Use interpreter at this path
+            - str: Use uv-managed Python version
     """
     return Destination(
         name=name,
@@ -71,6 +80,8 @@ def get_destination(  # noqa: PLR0913 # Too many arguments
             docker_image=docker_image,
             use_host_network=use_host_network,
             install_if_missing=install_if_missing,
+            install_root=install_root,
+            use_python=use_python,
         ),
     )
 

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -58,6 +58,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
     source_manifest: bool | dict | Path | str | None = None,
     install_if_missing: bool = True,
     install_root: Path | None = None,
+    use_python: bool | Path | str | None = None,
 ) -> Source:
     """Get a connector by name and version.
 
@@ -103,6 +104,11 @@ def get_source(  # noqa: PLR0913 # Too many arguments
             parameter is ignored when `local_executable` or `source_manifest` are set.
         install_root: (Optional.) The root directory where the virtual environment will be
             created. If not provided, the current working directory will be used.
+        use_python: (Optional.) Python interpreter specification:
+            - True: Use current Python interpreter
+            - False: Use Docker instead
+            - Path: Use interpreter at this path
+            - str: Use uv-managed Python version
     """
     return Source(
         name=name,
@@ -119,6 +125,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
             source_manifest=source_manifest,
             install_if_missing=install_if_missing,
             install_root=install_root,
+            use_python=use_python,
         ),
     )
 

--- a/examples/run_spacex.py
+++ b/examples/run_spacex.py
@@ -9,7 +9,7 @@ import airbyte as ab
 # preparation (from PyAirbyte main folder):
 #   python -m venv .venv-source-spacex-api
 #   source .venv-source-spacex-api/bin/activate
-#   pip install -e ../airbyte-integrations/connectors/source-spacex-api
+#   uv pip install -e ../airbyte-integrations/connectors/source-spacex-api
 # In separate terminal:
 #   poetry run python examples/run_spacex.py
 

--- a/examples/run_test_source.py
+++ b/examples/run_test_source.py
@@ -8,7 +8,7 @@ import airbyte as ab
 # preparation (from PyAirbyte main folder):
 #   python -m venv .venv-source-test
 #   source .venv-source-test/bin/activate
-#   pip install -e ./tests/integration_tests/fixtures/source-test
+#   uv pip install -e ./tests/integration_tests/fixtures/source-test
 # In separate terminal:
 #   poetry run python examples/run_test_source.py
 

--- a/examples/run_test_source_single_stream.py
+++ b/examples/run_test_source_single_stream.py
@@ -9,7 +9,7 @@ import airbyte as ab
 # preparation (from PyAirbyte main folder):
 #   python -m venv .venv-source-test
 #   source .venv-source-test/bin/activate
-#   pip install -e ./tests/integration_tests/fixtures/source-test
+#   uv pip install -e ./tests/integration_tests/fixtures/source-test
 # In separate terminal:
 #   poetry run python examples/run_test_source.py
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import time
 import warnings
-from pathlib import Path
 
 import airbyte
 import docker
@@ -20,7 +19,6 @@ import pytest
 from _pytest.nodes import Item
 from airbyte._util import text_util
 from airbyte._util.meta import is_windows
-from airbyte._util.venv_util import get_bin_dir
 from airbyte.caches import PostgresCache
 from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import new_local_cache
@@ -289,10 +287,17 @@ def source_test_installation():
     if os.path.exists(venv_dir):
         shutil.rmtree(venv_dir)
 
-    subprocess.run(["python", "-m", "venv", venv_dir], check=True)
-    pip_path = str(get_bin_dir(Path(venv_dir)) / "pip")
+    subprocess.run(["uv", "venv", venv_dir], check=True)
     subprocess.run(
-        [pip_path, "install", "-e", "./tests/integration_tests/fixtures/source-test"],
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            venv_dir,
+            "-e",
+            "./tests/integration_tests/fixtures/source-test",
+        ],
         check=True,
     )
 


### PR DESCRIPTION
# feat: replace pip with uv and add use_python parameter

## Summary

This PR replaces all `pip` usage with `uv` for Python connector installations in PyAirbyte and adds a new optional `use_python` parameter that provides flexible Python interpreter selection.

**Key Changes:**
- **VenvExecutor**: Modified to use `uv venv` and `uv pip install` instead of `python -m venv` and `pip install`
- **New `use_python` parameter**: Added throughout the call chain from CLI → get_source/get_destination → get_connector_executor → VenvExecutor
- **CLI support**: Added `--use-python` option to validate, benchmark, and sync commands
- **Parameter types**: 
  - `True`/`None`: Use current Python interpreter (backward compatible)
  - `False`: Prefer Docker execution
  - `Path`: Use specific interpreter path
  - `str`: Use uv-managed Python version (e.g., "3.11", "python3.12")

## Review & Testing Checklist for Human

- [ ] **Test CLI parameter with different values**: Verify `--use-python` works with "true", "false", interpreter paths, and version strings
- [ ] **Verify uv availability**: Ensure `uv` is installed and accessible in target environments before merging
- [ ] **Test backward compatibility**: Confirm existing workflows still work without the new parameter
- [ ] **Test error handling**: Verify graceful failures when `uv` is not available or when invalid interpreter paths are provided
- [ ] **End-to-end testing**: Install a real connector using the new parameter types to ensure the full pipeline works

**Recommended test plan:**
```bash
# Test different parameter values
pyab validate source-faker --use-python true
pyab validate source-faker --use-python false    
pyab validate source-faker --use-python /usr/bin/python3
pyab validate source-faker --use-python 3.11

# Test backward compatibility
pyab validate source-faker  # Should work without new parameter
```

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CLI["airbyte/cli.py<br/>validate/benchmark/sync"]:::major-edit
    ParsePython["_parse_use_python()<br/>helper function"]:::major-edit
    SourceUtil["airbyte/sources/util.py<br/>get_source()"]:::major-edit
    DestUtil["airbyte/destinations/util.py<br/>get_destination()"]:::major-edit
    ExecutorUtil["airbyte/_executors/util.py<br/>get_connector_executor()"]:::major-edit
    VenvExecutor["airbyte/_executors/python.py<br/>VenvExecutor class"]:::major-edit
    Examples["examples/*.py<br/>comment updates"]:::minor-edit
    Tests["tests/conftest.py<br/>uv usage"]:::minor-edit

    CLI --> ParsePython
    CLI --> SourceUtil
    CLI --> DestUtil
    SourceUtil --> ExecutorUtil
    DestUtil --> ExecutorUtil
    ExecutorUtil --> VenvExecutor
    
    VenvExecutor --> UV["uv venv + uv pip install<br/>commands"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Environment dependency**: This PR introduces a dependency on `uv` being available in the system PATH when using the new parameter types
- **Backward compatibility**: Default behavior (use_python=None/True) maintains compatibility but now uses `uv pip install` instead of `pip install`
- **Parameter flow**: The `use_python` parameter flows through the entire call chain: CLI → utility functions → executor factory → VenvExecutor
- **Testing limitation**: While existing tests pass, the new parameter types haven't been comprehensively tested in all environments

**Session details:**
- Requested by: AJ Steers (@aaronsteers)
- Devin session: https://app.devin.ai/sessions/af9917a5648049f580c99c6387ea9fda