### PR TITLE
fix: Replace pendulum with ab_datetime_now() and fix linting issues (do not merge)

### DIFF
--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -422,14 +422,19 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         )
 
     def _log_sync_cancel(self) -> None:
-        print(f"Canceled `{self.job_description}` sync at `{pendulum.now().format('HH:mm:ss')}`.")
+        print(
+            f"Canceled `{self.job_description}` sync at `{ab_datetime_now().strftime('%H:%M:%S')}`."
+        )
         self._send_telemetry(
             state=EventState.CANCELED,
             event_type=EventType.SYNC,
         )
 
     def _log_stream_read_start(self, stream_name: str) -> None:
-        print(f"Read started on stream `{stream_name}` at `{pendulum.now().format('HH:mm:ss')}`...")
+        print(
+            f"Read started on stream `{stream_name}` at "
+            f"`{ab_datetime_now().strftime('%H:%M:%S')}`..."
+        )
         self.stream_read_start_times[stream_name] = time.time()
 
     def log_stream_start(self, stream_name: str) -> None:
@@ -559,7 +564,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
 
         print(
             f"Completed `{self.job_description}` sync at "
-            f"`{pendulum.now().format('HH:mm:ss')}`{streams_str}."
+            f"`{ab_datetime_now().strftime('%H:%M:%S')}`{streams_str}."
         )
         self._log_read_metrics()
         self._send_telemetry(

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -208,9 +208,9 @@ class Source(ConnectorBase):  # noqa: PLR0904
         - Stream names are not validated by PyAirbyte. If the stream name
           does not exist in the catalog, the override may be ignored.
         """
-        self._primary_key_overrides.update({
-            k.lower(): v if isinstance(v, list) else [v] for k, v in kwargs.items()
-        })
+        self._primary_key_overrides.update(
+            {k.lower(): v if isinstance(v, list) else [v] for k, v in kwargs.items()}
+        )
 
     def _log_warning_preselected_stream(self, streams: str | list[str]) -> None:
         """Logs a warning message indicating stream selection which are not selected yet."""
@@ -701,12 +701,14 @@ class Source(ConnectorBase):  # noqa: PLR0904
                     )
 
                 for record in dataset:
-                    table.add_row(*[
-                        escape(str(val))
-                        for key, val in record.items()
-                        # Exclude internal Airbyte columns.
-                        if key not in internal_cols
-                    ])
+                    table.add_row(
+                        *[
+                            escape(str(val))
+                            for key, val in record.items()
+                            # Exclude internal Airbyte columns.
+                            if key not in internal_cols
+                        ]
+                    )
 
             console.print(table)
 
@@ -746,11 +748,13 @@ class Source(ConnectorBase):  # noqa: PLR0904
         * Send out telemetry on the performed sync (with information about which source was used and
           the type of the cache)
         """
-        with as_temp_files([
-            self._hydrated_config,
-            catalog.model_dump_json(),
-            state.to_state_input_file_text() if state else "[]",
-        ]) as [
+        with as_temp_files(
+            [
+                self._hydrated_config,
+                catalog.model_dump_json(),
+                state.to_state_input_file_text() if state else "[]",
+            ]
+        ) as [
             config_file,
             catalog_file,
             state_file,
@@ -769,7 +773,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
             )
             for message in progress_tracker.tally_records_read(message_generator):
                 if stop_event and stop_event.is_set():
-                    progress_tracker._log_sync_cancel()
+                    progress_tracker._log_sync_cancel()  # noqa: SLF001
                     return
 
                 yield message


### PR DESCRIPTION
# fix: Replace pendulum with ab_datetime_now() and fix linting issues

This PR targets the following PR:
- #725

---

## Summary

Fixes CI failures in PR #725 that were blocking the stream preview functionality. The failures were caused by:
1. **Missing pendulum imports** - Three locations in `airbyte/progress.py` used `pendulum.now().format()` without importing pendulum
2. **Linting violations** - Private member access warning and code formatting issues
3. **Line length violation** - One line exceeded the 100 character limit

**Key Changes:**
- Replaced `pendulum.now().format('HH:mm:ss')` with `ab_datetime_now().strftime('%H:%M:%S')` in 3 locations (following existing codebase pattern)
- Added `# noqa: SLF001` comment to suppress intentional private member access warning
- Fixed line length violation by splitting long f-string
- Applied ruff formatting to both modified files

## Review & Testing Checklist for Human

- [ ] **Verify datetime format equivalence**: Confirm that `ab_datetime_now().strftime('%H:%M:%S')` produces identical output to `pendulum.now().format('HH:mm:ss')` 
- [ ] **Test stream preview functionality end-to-end**: Run the actual source preview features to ensure no functional regressions
- [ ] **Validate replacement pattern**: Confirm that using `ab_datetime_now()` aligns with the intended "whenever" replacement mentioned in the original context
- [ ] **Run broader test suite**: Execute additional test suites beyond the single failing test to check for edge cases

**Recommended Test Plan:**
1. Run the specific failing test: `poetry run pytest tests/unit_tests/test_lowcode_connectors.py::test_nocode_execution -v`
2. Test a real source with preview functionality to verify timestamps display correctly
3. Run the full unit test suite to check for regressions: `poetry run pytest tests/unit_tests/ -v`

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    source["airbyte/sources/base.py<br/>(Minor Edit)"]:::minor-edit
    progress["airbyte/progress.py<br/>(Major Edit)"]:::major-edit  
    test["tests/unit_tests/test_lowcode_connectors.py<br/>(Context)"]:::context
    datetime["airbyte_cdk.utils.datetime_helpers<br/>(Context)"]:::context
    
    source -->|"calls _log_sync_cancel()"| progress
    progress -->|"imports ab_datetime_now"| datetime
    test -->|"executes source.read()"| source
    progress -->|"formats timestamps"| progress
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Local verification passed**: All ruff formatting, linting, mypy type checking, and the specific failing test now pass locally
- **Assumption made**: Used `ab_datetime_now()` pattern based on existing codebase usage, though original context mentioned "whenever" replacement
- **Scope limitation**: Only tested the specific failing test case locally, not the full test suite
- **Session context**: Requested by AJ Steers (@aaronsteers) - Session: https://app.devin.ai/sessions/6e24d9fe30ab470187ca5eb06f13ebfe

The changes are mechanical replacements following established patterns in the codebase, but human verification of the datetime format equivalence and broader testing is recommended to ensure no subtle regressions.