### PR TITLE
feat: add new mcp tools for working with cached data

### DIFF
--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 """SQL Cache implementation."""
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -10,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 from pydantic import Field, PrivateAttr
+from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy import text
 
 from airbyte_protocol.models import ConfiguredAirbyteCatalog
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from airbyte.strategies import WriteStrategy
 
 
-class CacheBase(SqlConfig, AirbyteWriterInterface):
+class CacheBase(SqlConfig, AirbyteWriterInterface):  # noqa: PLR0904 (too many methods)
     """Base configuration for a cache.
 
     Caches inherit from the matching `SqlConfig` class, which provides the SQL config settings
@@ -144,6 +144,62 @@ class CacheBase(SqlConfig, AirbyteWriterInterface):
     def processor(self) -> SqlProcessorBase:
         """Return the SQL processor instance."""
         return self._read_processor
+
+    def close(self) -> None:
+        """Close the cache connection.
+
+        This method closes the underlying SQL connection and disposes of the engine.
+        It's a convenience method that delegates to the processor's close method.
+        """
+        return self.processor.close()
+
+    def run_sql_query(
+        self,
+        sql_query: str,
+        *,
+        max_records: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run a SQL query against the cache and return results as a list of dictionaries.
+
+        This method is designed for single DML statements like SELECT, SHOW, or DESCRIBE.
+        For DDL statements or multiple statements, use the processor directly.
+
+        Args:
+            sql_query: The SQL query to execute
+            max_records: Maximum number of records to return. If None, returns all records.
+
+        Returns:
+            List of dictionaries representing the query results
+        """
+        # Execute the SQL within a connection context to ensure the connection stays open
+        # while we fetch the results
+        sql_text = text(sql_query) if isinstance(sql_query, str) else sql_query
+
+        with self.processor.get_sql_connection() as conn:
+            try:
+                result = conn.execute(sql_text)
+            except (
+                sqlalchemy_exc.ProgrammingError,
+                sqlalchemy_exc.SQLAlchemyError,
+            ) as ex:
+                msg = f"Error when executing SQL:\n{sql_query}\n{type(ex).__name__}{ex!s}"
+                raise RuntimeError(msg) from ex
+
+            # Convert the result to a list of dictionaries while connection is still open
+            if result.returns_rows:
+                # Get column names
+                columns = list(result.keys()) if result.keys() else []
+
+                # Fetch rows efficiently based on limit
+                if max_records is not None:
+                    rows = result.fetchmany(max_records)
+                else:
+                    rows = result.fetchall()
+
+                return [dict(zip(columns, row, strict=True)) for row in rows]
+
+            # For non-SELECT queries (INSERT, UPDATE, DELETE, etc.)
+            return []
 
     def get_record_processor(
         self,

--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 """SQL Cache implementation."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
     from airbyte.strategies import WriteStrategy
 
 
-class CacheBase(SqlConfig, AirbyteWriterInterface):  # noqa: PLR0904 (too many methods)
+class CacheBase(SqlConfig, AirbyteWriterInterface):
     """Base configuration for a cache.
 
     Caches inherit from the matching `SqlConfig` class, which provides the SQL config settings

--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -145,14 +145,6 @@ class CacheBase(SqlConfig, AirbyteWriterInterface):  # noqa: PLR0904 (too many m
         """Return the SQL processor instance."""
         return self._read_processor
 
-    def close(self) -> None:
-        """Close the cache connection.
-
-        This method closes the underlying SQL connection and disposes of the engine.
-        It's a convenience method that delegates to the processor's close method.
-        """
-        return self.processor.close()
-
     def run_sql_query(
         self,
         sql_query: str,

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -11,7 +11,6 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from airbyte import get_source
-from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import get_default_cache
 from airbyte.mcp._util import resolve_config
 from airbyte.secrets.config import _get_secret_sources
@@ -20,6 +19,7 @@ from airbyte.sources.registry import get_connector_metadata
 
 
 if TYPE_CHECKING:
+    from airbyte.caches.duckdb import DuckDBCache
     from airbyte.sources.base import Source
 
 

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
 from fastmcp import FastMCP
-from pydantic import Field
-from pydantic.main import BaseModel
+from pydantic import Field, BaseModel
 
 from airbyte import get_source
 from airbyte.caches.duckdb import DuckDBCache

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -271,7 +271,6 @@ def sync_source_to_cache(
         cache=cache,
         streams=streams,
     )
-    cache.close()
     del cache  # Ensure the cache is closed properly
 
     summary: str = f"Sync completed for '{source_connector_name}'!\n\n"
@@ -294,7 +293,6 @@ def list_cached_datasets() -> list[CachedDatasetInfo]:
     """List all streams available in the default DuckDB cache."""
     cache: DuckDBCache = get_default_cache()
     result = [CachedDatasetInfo(stream_name=stream_name) for stream_name in cache.streams]
-    cache.close()
     del cache  # Ensure the cache is closed properly
     return result
 
@@ -392,7 +390,6 @@ def run_sql_query(
             }
         ]
     finally:
-        cache.close()
         del cache  # Ensure the cache is closed properly
 
 

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
 from fastmcp import FastMCP
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
 
 from airbyte import get_source
 from airbyte.caches.duckdb import DuckDBCache

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -283,16 +283,21 @@ class CachedDatasetInfo(BaseModel):
 
     stream_name: str
     """The name of the stream in the cache."""
-    # TODO: add later:
-    # table_name: str
-    # schema_name: str | None = None
-    # source_name: str | None = None
+    table_name: str
+    schema_name: str | None = None
 
 
-def list_cached_datasets() -> list[CachedDatasetInfo]:
+def list_cached_streams() -> list[CachedDatasetInfo]:
     """List all streams available in the default DuckDB cache."""
     cache: DuckDBCache = get_default_cache()
-    result = [CachedDatasetInfo(stream_name=stream_name) for stream_name in cache.streams]
+    result = [
+        CachedDatasetInfo(
+            stream_name=stream_name,
+            table_name=(cache.table_prefix or "") + stream_name,
+            schema_name=cache.schema_name,
+        )
+        for stream_name in cache.streams
+    ]
     del cache  # Ensure the cache is closed properly
     return result
 
@@ -399,7 +404,7 @@ def register_local_ops_tools(app: FastMCP) -> None:
     for tool in (
         describe_default_cache,
         get_source_stream_json_schema,
-        list_cached_datasets,
+        list_cached_streams,
         list_source_streams,
         read_source_stream_records,
         run_sql_query,

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -775,6 +775,19 @@ class SqlProcessorBase(abc.ABC):
         """Clean resources."""
         self.file_writer.cleanup_all()
 
+    def close(self) -> None:
+        """Close the connection and dispose of the engine.
+
+        This method performs a final checkpoint to ensure all data is flushed to disk,
+        then disposes of the SQLAlchemy engine to close all connections.
+        """
+        # Perform a final checkpoint to flush any remaining WAL data
+        self._do_checkpoint()
+
+        # Get the engine and dispose of it to close all connections
+        engine = self.get_sql_engine()
+        engine.dispose()
+
     # Finalizing context manager
 
     @final

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -775,19 +775,6 @@ class SqlProcessorBase(abc.ABC):
         """Clean resources."""
         self.file_writer.cleanup_all()
 
-    def close(self) -> None:
-        """Close the connection and dispose of the engine.
-
-        This method performs a final checkpoint to ensure all data is flushed to disk,
-        then disposes of the SQLAlchemy engine to close all connections.
-        """
-        # Perform a final checkpoint to flush any remaining WAL data
-        self._do_checkpoint()
-
-        # Get the engine and dispose of it to close all connections
-        engine = self.get_sql_engine()
-        engine.dispose()
-
     # Finalizing context manager
 
     @final

--- a/tests/integration_tests/test_duckdb_cache.py
+++ b/tests/integration_tests/test_duckdb_cache.py
@@ -13,11 +13,13 @@ import sys
 from collections.abc import Generator
 from pathlib import Path
 
-import airbyte as ab
 import pytest
+
+import airbyte as ab
 from airbyte._util.venv_util import get_bin_dir
 from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import new_local_cache
+
 
 # Product count is always the same, regardless of faker scale.
 NUM_PRODUCTS = 100
@@ -79,3 +81,15 @@ def duckdb_cache() -> Generator[DuckDBCache, None, None]:
     yield cache
     # TODO: Delete cache DB file after test is complete.
     return
+
+
+def test_duckdb_cache_close(duckdb_cache: DuckDBCache) -> None:
+    """Test that the DuckDB cache can be closed without errors."""
+    # Verify that we can call close() without errors
+    duckdb_cache.close()
+
+    # Verify that we can also call the processor close method directly
+    duckdb_cache.processor.close()
+
+    # Should be able to call close multiple times without errors
+    duckdb_cache.close()

--- a/tests/integration_tests/test_duckdb_cache.py
+++ b/tests/integration_tests/test_duckdb_cache.py
@@ -13,6 +13,7 @@ import sys
 from collections.abc import Generator
 from pathlib import Path
 
+import airbyte as ab
 import pytest
 from airbyte._util.venv_util import get_bin_dir
 from airbyte.caches.duckdb import DuckDBCache

--- a/tests/integration_tests/test_duckdb_cache.py
+++ b/tests/integration_tests/test_duckdb_cache.py
@@ -14,8 +14,6 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-
-import airbyte as ab
 from airbyte._util.venv_util import get_bin_dir
 from airbyte.caches.duckdb import DuckDBCache
 from airbyte.caches.util import new_local_cache
@@ -81,15 +79,3 @@ def duckdb_cache() -> Generator[DuckDBCache, None, None]:
     yield cache
     # TODO: Delete cache DB file after test is complete.
     return
-
-
-def test_duckdb_cache_close(duckdb_cache: DuckDBCache) -> None:
-    """Test that the DuckDB cache can be closed without errors."""
-    # Verify that we can call close() without errors
-    duckdb_cache.close()
-
-    # Verify that we can also call the processor close method directly
-    duckdb_cache.processor.close()
-
-    # Should be able to call close multiple times without errors
-    duckdb_cache.close()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to list cached datasets and view metadata about the default cache.
  * Introduced support for running safe, read-only SQL queries against the default cache, with detailed error reporting.
  * Enabled running SQL queries with record limits directly on caches.

* **Bug Fixes**
  * Improved resource management to ensure caches are properly closed after use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._