### PR TITLE
feat: prefer Docker images in MCP server when Docker is available

### DIFF
--- a/airbyte/mcp/_connector_registry.py
+++ b/airbyte/mcp/_connector_registry.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any, Literal
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
+from airbyte._util.meta import is_docker_installed
 from airbyte.sources import get_available_connectors
 from airbyte.sources.registry import ConnectorMetadata, get_connector_metadata
 from airbyte.sources.util import get_source
@@ -102,6 +103,7 @@ def get_connector_info(
 
     connector = get_source(
         connector_name,
+        docker_image=is_docker_installed(),
         install_if_missing=False,  # Defer to avoid failing entirely if it can't be installed.
     )
 

--- a/airbyte/mcp/_connector_registry.py
+++ b/airbyte/mcp/_connector_registry.py
@@ -103,7 +103,7 @@ def get_connector_info(
 
     connector = get_source(
         connector_name,
-        docker_image=is_docker_installed(),
+        docker_image=is_docker_installed() or False,
         install_if_missing=False,  # Defer to avoid failing entirely if it can't be installed.
     )
 

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from airbyte import get_source
+from airbyte._util.meta import is_docker_installed
 from airbyte.caches.util import get_default_cache
 from airbyte.mcp._util import resolve_config
 from airbyte.secrets.config import _get_secret_sources
@@ -63,7 +64,7 @@ def validate_connector_config(
     Returns a tuple of (is_valid: bool, message: str).
     """
     try:
-        source = get_source(connector_name)
+        source = get_source(connector_name, docker_image=is_docker_installed())
     except Exception as ex:
         return False, f"Failed to get connector '{connector_name}': {ex}"
 
@@ -132,6 +133,7 @@ def list_source_streams(
     """
     source: Source = get_source(
         source_connector_name,
+        docker_image=is_docker_installed(),
     )
     config_dict = resolve_config(
         config=config,
@@ -162,7 +164,7 @@ def get_source_stream_json_schema(
     ],
 ) -> dict[str, Any]:
     """List all properties for a specific stream in a source connector."""
-    source: Source = get_source(source_connector_name)
+    source: Source = get_source(source_connector_name, docker_image=is_docker_installed())
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,
@@ -198,7 +200,7 @@ def read_source_stream_records(
 ) -> list[dict[str, Any]] | str:
     """Get records from a source connector."""
     try:
-        source = get_source(source_connector_name)
+        source = get_source(source_connector_name, docker_image=is_docker_installed())
         config_dict = resolve_config(
             config=config,
             config_secret_name=config_secret_name,
@@ -243,7 +245,7 @@ def sync_source_to_cache(
     ] = "suggested",
 ) -> str:
     """Run a sync from a source connector to the default DuckDB cache."""
-    source = get_source(source_connector_name)
+    source = get_source(source_connector_name, docker_image=is_docker_installed())
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -167,7 +167,10 @@ def get_source_stream_json_schema(
     ],
 ) -> dict[str, Any]:
     """List all properties for a specific stream in a source connector."""
-    source: Source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
+    source: Source = get_source(
+        source_connector_name,
+        docker_image=is_docker_installed() or False,
+    )
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,
@@ -203,7 +206,10 @@ def read_source_stream_records(
 ) -> list[dict[str, Any]] | str:
     """Get records from a source connector."""
     try:
-        source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
+        source = get_source(
+            source_connector_name,
+            docker_image=is_docker_installed() or False,
+        )
         config_dict = resolve_config(
             config=config,
             config_secret_name=config_secret_name,
@@ -248,7 +254,10 @@ def sync_source_to_cache(
     ] = "suggested",
 ) -> str:
     """Run a sync from a source connector to the default DuckDB cache."""
-    source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
+    source = get_source(
+        source_connector_name,
+        docker_image=is_docker_installed() or False,
+    )
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -136,7 +136,7 @@ def list_source_streams(
     """
     source: Source = get_source(
         source_connector_name,
-        docker_image=is_docker_installed(),
+        docker_image=is_docker_installed() or False,
     )
     config_dict = resolve_config(
         config=config,
@@ -167,7 +167,7 @@ def get_source_stream_json_schema(
     ],
 ) -> dict[str, Any]:
     """List all properties for a specific stream in a source connector."""
-    source: Source = get_source(source_connector_name, docker_image=is_docker_installed())
+    source: Source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,
@@ -203,7 +203,7 @@ def read_source_stream_records(
 ) -> list[dict[str, Any]] | str:
     """Get records from a source connector."""
     try:
-        source = get_source(source_connector_name, docker_image=is_docker_installed())
+        source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
         config_dict = resolve_config(
             config=config,
             config_secret_name=config_secret_name,
@@ -248,7 +248,7 @@ def sync_source_to_cache(
     ] = "suggested",
 ) -> str:
     """Run a sync from a source connector to the default DuckDB cache."""
-    source = get_source(source_connector_name, docker_image=is_docker_installed())
+    source = get_source(source_connector_name, docker_image=is_docker_installed() or False)
     config_dict = resolve_config(
         config=config,
         config_secret_name=config_secret_name,

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -64,7 +64,10 @@ def validate_connector_config(
     Returns a tuple of (is_valid: bool, message: str).
     """
     try:
-        source = get_source(connector_name, docker_image=is_docker_installed())
+        source = get_source(
+            connector_name,
+            docker_image=is_docker_installed() or False,
+        )
     except Exception as ex:
         return False, f"Failed to get connector '{connector_name}': {ex}"
 


### PR DESCRIPTION
# feat: prefer Docker images in MCP server when Docker is available

## Summary

This PR implements Docker preference functionality in the PyAirbyte MCP server by updating all `get_source()` calls to pass `docker_image=is_docker_installed()` when Docker is detected on the system. This change leverages the existing cached Docker detection utility and maintains backward compatibility with graceful fallback to other installation methods.

**Key Changes:**
- Added `is_docker_installed()` import to MCP server modules
- Updated 6 `get_source()` calls across MCP local operations and connector registry
- Leverages existing `@lru_cache` decorator for performance optimization
- Maintains existing fallback logic for cases where Docker images aren't available

**Files Modified:**
- `airbyte/mcp/_local_ops.py` - 5 get_source() calls updated
- `airbyte/mcp/_connector_registry.py` - 1 get_source() call updated

## Review & Testing Checklist for Human

- [ ] **Test Docker preference end-to-end**: Verify MCP server actually uses Docker images for connectors when Docker is available (test with a known connector like source-pokeapi)
- [ ] **Test fallback behavior**: Confirm graceful fallback when Docker is detected but specific connector images aren't available 
- [ ] **Verify non-Docker environments**: Test that MCP server still works correctly in environments without Docker installed
- [ ] **Performance validation**: Confirm the Docker detection caching works correctly and doesn't introduce performance regressions
- [ ] **Integration testing**: Test core MCP operations (validate_config, sync_source_to_cache, etc.) work with Docker preference enabled


**Recommended Test Plan:**
1. Run MCP server in Docker-enabled environment and verify connector operations use Docker images
2. Test in Docker-disabled environment to ensure fallback works
3. Test with connectors that have/don't have Docker images available
4. Monitor performance of repeated MCP operations to verify caching effectiveness

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    MCP["MCP Server<br/>airbyte/mcp/server.py"]:::context
    LocalOps["Local Operations<br/>airbyte/mcp/_local_ops.py"]:::major-edit
    Registry["Connector Registry<br/>airbyte/mcp/_connector_registry.py"]:::major-edit
    Meta["Docker Detection<br/>airbyte/_util/meta.py"]:::context
    GetSource["get_source()<br/>airbyte/sources/util.py"]:::context
    Executor["get_connector_executor()<br/>airbyte/_executors/util.py"]:::context
    
    MCP --> LocalOps
    MCP --> Registry
    LocalOps --> GetSource
    Registry --> GetSource
    LocalOps --> Meta
    Registry --> Meta
    GetSource --> Executor
    
    LocalOps -.->|"docker_image=is_docker_installed()"| GetSource
    Registry -.->|"docker_image=is_docker_installed()"| GetSource
    Meta -.->|"@lru_cache cached result"| LocalOps
    Meta -.->|"@lru_cache cached result"| Registry
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This implementation reuses the existing `is_docker_installed()` function which already has proper caching via `@lru_cache`
- The `get_source()` function already supports the `docker_image` parameter, so this change integrates cleanly with existing architecture
- Executor selection logic already handles graceful fallback when Docker images aren't available for specific connectors
- All linting, formatting, and type checking passed successfully

**Session Info:** Requested by AJ Steers (@aaronsteers) in Devin session: https://app.devin.ai/sessions/5aa5c0fa6cd347808bab340f53cc603d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of Docker installation status, enhancing connector source selection and related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._