### PR TITLE
feat: Add get_stream_previews MCP tool

### DIFF
--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
@@ -235,6 +235,84 @@ def read_source_stream_records(
 
 
 # @app.tool()  # << deferred
+def get_stream_previews(
+    source_connector_name: Annotated[
+        str,
+        Field(description="The name of the source connector."),
+    ],
+    config: Annotated[
+        dict | Path | None,
+        Field(description="The configuration for the source connector."),
+    ] = None,
+    config_secret_name: Annotated[
+        str | None,
+        Field(description="The name of the secret containing the configuration."),
+    ] = None,
+    streams: Annotated[
+        list[str] | str | None,
+        Field(
+            description="The streams to get previews for. Use '*' for all streams, "
+            "or None for selected streams."
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(description="The maximum number of sample records to return per stream."),
+    ] = 5,
+) -> dict[str, list[dict[str, Any]] | str]:
+    """Get sample records (previews) from streams in a source connector.
+
+    This operation requires a valid configuration, including any required secrets.
+    Returns a dictionary mapping stream names to lists of sample records, or an error
+    message string if an error occurred for that stream.
+    """
+    try:
+        source: Source = get_source(
+            source_connector_name,
+            docker_image=is_docker_installed() or False,
+        )
+        config_dict = resolve_config(
+            config=config,
+            config_secret_name=config_secret_name,
+            config_spec_jsonschema=source.config_spec,
+        )
+        source.set_config(config_dict)
+
+        streams_param: list[str] | Literal["*"] | None
+        if streams == "*":
+            streams_param = "*"
+        elif isinstance(streams, str) and streams != "*":
+            streams_param = [streams]
+        elif isinstance(streams, list):
+            streams_param = streams
+        else:
+            streams_param = None
+
+        samples_result = source.get_samples(
+            streams=streams_param,
+            limit=limit,
+            on_error="ignore",
+        )
+
+        result: dict[str, list[dict[str, Any]] | str] = {}
+        for stream_name, dataset in samples_result.items():
+            if dataset is None:
+                result[stream_name] = (
+                    f"Could not retrieve stream samples for stream '{stream_name}'"
+                )
+            else:
+                result[stream_name] = list(dataset)
+    except Exception as ex:
+        tb_str = traceback.format_exc()
+        return {
+            "ERROR": f"Error getting stream previews from source '{source_connector_name}': "
+            f"{ex!r}, {ex!s}\n{tb_str}"
+        }
+    else:
+        return result
+
+
+# @app.tool()  # << deferred
 def sync_source_to_cache(
     source_connector_name: Annotated[
         str,
@@ -418,6 +496,7 @@ def register_local_ops_tools(app: FastMCP) -> None:
     for tool in (
         describe_default_cache,
         get_source_stream_json_schema,
+        get_stream_previews,
         list_cached_streams,
         list_source_streams,
         read_source_stream_records,


### PR DESCRIPTION
# feat: Add get_stream_previews MCP tool

## Summary

Adds a new `get_stream_previews` MCP tool to PyAirbyte that wraps the recently added `get_samples()` functionality from the Source class. This tool provides stream preview capabilities through the MCP interface, allowing users to retrieve sample records from source connectors.

**Key features:**
- Forces `on_error="ignore"` for clean MCP responses as requested
- Passes through `limit` and `streams` parameters from `get_samples()`
- Returns descriptive error messages for failed streams instead of None
- Follows existing MCP tool patterns with proper type annotations
- Converts `InMemoryDataset` objects to serializable lists of dictionaries

## Review & Testing Checklist for Human

- [ ] **Test with actual connectors**: Verify the tool works end-to-end with real source connectors and configurations
- [ ] **Validate error handling**: Test both stream-level errors (should return descriptive error messages) and function-level errors (should return structured error info)
- [ ] **Check MCP integration**: Confirm the tool is properly registered and accessible through the MCP interface
- [ ] **Verify return format**: Ensure the returned dictionary structure is suitable for MCP clients and matches expectations
- [ ] **Test parameter passthrough**: Verify that `streams` (including "*", lists, and single strings) and `limit` parameters work correctly

**Recommended test plan**: Test with a simple connector like `source-faker`, try different streams parameter values ("*", specific stream names, lists), and verify both success and error scenarios.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    subgraph "airbyte/mcp/"
        LocalOps["_local_ops.py"]:::major-edit
    end
    
    subgraph "airbyte/sources/"
        SourceBase["base.py (Source class)"]:::context
    end
    
    subgraph "MCP Framework"
        FastMCP["FastMCP"]:::context
    end
    
    LocalOps -->|"wraps get_samples()"| SourceBase
    LocalOps -->|"registers with"| FastMCP
    
    LocalOps -.- NewTool["get_stream_previews():<br/>- Forces on_error='ignore'<br/>- Returns descriptive errors<br/>- Converts InMemoryDataset to lists"]:::major-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Type checking**: Required several iterations to resolve mypy type compatibility issues with the `streams` parameter handling
- **Environment limitations**: Unable to fully test implementation locally due to dependency issues, so thorough testing with actual connectors is especially important
- **User requirements**: Implemented specific guidance from AJ Steers to force `on_error="ignore"` and return descriptive error messages instead of None values

**Session details**: Requested by AJ Steers (@aaronsteers) - [Devin session](https://app.devin.ai/sessions/2669d04d45b54d419bceaee6e535c113)