### PR TITLE
feat: add manifest_url to get_connector_info tool

### DIFF
--- a/airbyte/mcp/_connector_registry.py
+++ b/airbyte/mcp/_connector_registry.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any, Literal
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
+from airbyte._executors.util import DEFAULT_MANIFEST_URL
 from airbyte._util.meta import is_docker_installed
 from airbyte.sources import get_available_connectors
 from airbyte.sources.registry import ConnectorMetadata, get_connector_metadata
@@ -118,8 +119,9 @@ def get_connector_info(
         connector.install()
         config_spec_jsonschema = connector.config_spec
 
-    manifest_url = (
-        f"https://connectors.airbyte.com/metadata/airbyte/{connector_name}/latest/metadata.yaml"
+    manifest_url = DEFAULT_MANIFEST_URL.format(
+        source_name=connector_name,
+        version="latest",
     )
 
     return ConnectorInfo(

--- a/airbyte/mcp/_connector_registry.py
+++ b/airbyte/mcp/_connector_registry.py
@@ -89,6 +89,7 @@ class ConnectorInfo(BaseModel):
     connector_metadata: ConnectorMetadata | None = None
     documentation_url: str | None = None
     config_spec_jsonschema: dict | None = None
+    manifest_url: str | None = None
 
 
 def get_connector_info(
@@ -117,11 +118,16 @@ def get_connector_info(
         connector.install()
         config_spec_jsonschema = connector.config_spec
 
+    manifest_url = (
+        f"https://connectors.airbyte.com/metadata/airbyte/{connector_name}/latest/metadata.yaml"
+    )
+
     return ConnectorInfo(
         connector_name=connector.name,
         connector_metadata=connector_metadata,
         documentation_url=connector.docs_url,
         config_spec_jsonschema=config_spec_jsonschema,
+        manifest_url=manifest_url,
     )
 
 


### PR DESCRIPTION
# feat: add manifest_url to get_connector_info tool

## Summary

This PR adds a `manifest_url` field to the `ConnectorInfo` class returned by the `get_connector_info` MCP tool. This allows MCP clients to directly access the connector manifest URL without needing to make a separate call to the `get_connector_manifest` tool from connector-builder-mcp.

**Key Changes:**
- Added `manifest_url: str | None = None` field to `ConnectorInfo` class
- Updated `get_connector_info` function to populate the manifest URL using the pattern: `https://connectors.airbyte.com/metadata/airbyte/{connector_name}/latest/metadata.yaml`
- Follows the same URL pattern established in connector-builder-mcp for consistency

This complements the recently added `get_connector_manifest` command in connector-builder-mcp, providing users with direct access to manifest URLs when they already have connector info.

## Review & Testing Checklist for Human

- [ ] **Verify URL pattern works**: Test the manifest URL with several real connectors (e.g., `source-faker`, `destination-duckdb`) to ensure the endpoint returns valid YAML content
- [ ] **Test MCP tool functionality**: Use an MCP client to call `get_connector_info` and verify the `manifest_url` field is properly populated and accessible
- [ ] **Validate error handling**: Test with invalid/non-existent connector names to ensure the function still works (URL will be constructed but may 404 when accessed)
- [ ] **Consider version strategy**: Evaluate whether always using "latest" version is appropriate, or if we should allow version specification in future iterations

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    MCPClient["MCP Client"]
    GetConnectorInfo["get_connector_info()"]
    ConnectorInfo["ConnectorInfo Class"]
    ManifestURL["manifest_url field"]
    AirbyteAPI["connectors.airbyte.com"]
    
    MCPClient --> GetConnectorInfo
    GetConnectorInfo --> ConnectorInfo
    ConnectorInfo --> ManifestURL
    ManifestURL -.-> AirbyteAPI
    
    ConnectorInfo:::major-edit
    ManifestURL:::major-edit
    GetConnectorInfo:::minor-edit
    MCPClient:::context
    AirbyteAPI:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This change maintains backward compatibility - existing `ConnectorInfo` usage will continue to work unchanged
- The manifest URL uses the "latest" version consistently, which matches the default behavior in connector-builder-mcp
- URL construction follows the pattern discovered during connector-builder-mcp implementation
- Limited local testing due to missing GCP credentials for integration tests, but unit tests and linting pass

**Requested by:** AJ Steers (@aaronsteers)    
**Devin Session:** https://app.devin.ai/sessions/050f37720b8f485a86ad1fbe51d5e013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new field displaying a metadata URL for each connector, allowing users to access connector metadata files directly from the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._