### PR TITLE
[DO NOT MERGE] testing java connectors python packages

### DIFF
--- a/airbyte/_executors/python.py
+++ b/airbyte/_executors/python.py
@@ -117,7 +117,7 @@ class VenvExecutor(Executor):
         )
         try:
             self._run_subprocess_and_raise_on_failure(
-                args=[pip_path, "install","--no-cache-dir" , "https://storage.googleapis.com/pyairbyte-java-connectors-python-package-jose-test/airbyte_destination_dev_null/airbyte_destination_dev_null-0.0.1-py3-none-any.whl"]
+                args=[pip_path, "install","--no-cache-dir" , f"https://storage.googleapis.com/pyairbyte-java-connectors-python-package-jose-test/airbyte_{self.name.replace('-', '_')}/airbyte_{self.name.replace('-', '_')}-0.0.1-py3-none-any.whl"]
             )
 
             self._run_subprocess_and_raise_on_failure(

--- a/airbyte/_executors/python.py
+++ b/airbyte/_executors/python.py
@@ -44,14 +44,13 @@ class VenvExecutor(Executor):
                 created. If not provided, the current working directory will be used.
         """
         super().__init__(name=name, metadata=metadata, target_version=target_version)
-
-        if not pip_url and metadata and not metadata.pypi_package_name:
-            raise exc.AirbyteConnectorNotPyPiPublishedError(
-                connector_name=self.name,
-                context={
-                    "metadata": metadata,
-                },
-            )
+        # if not pip_url and metadata and not metadata.pypi_package_name:
+        #     raise exc.AirbyteConnectorNotPyPiPublishedError(
+        #         connector_name=self.name,
+        #         context={
+        #             "metadata": metadata,
+        #         },
+        #     )
 
         self.pip_url = pip_url or (
             metadata.pypi_package_name
@@ -118,9 +117,14 @@ class VenvExecutor(Executor):
         )
         try:
             self._run_subprocess_and_raise_on_failure(
+                args=[pip_path, "install","--no-cache-dir" , "https://storage.googleapis.com/pyairbyte-java-connectors-python-package-jose-test/airbyte_destination_dev_null/airbyte_destination_dev_null-0.0.1-py3-none-any.whl"]
+            )
+
+            self._run_subprocess_and_raise_on_failure(
                 args=[pip_path, "install", *shlex.split(self.pip_url)]
             )
         except exc.AirbyteSubprocessFailedError as ex:
+            pass
             # If the installation failed, remove the virtual environment
             # Otherwise, the connector will be considered as installed and the user may not be able
             # to retry the installation.

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -232,7 +232,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
 
     if install_method_count == 0:
         # User has not specified how to install the connector.
-        # Prefer local executable if found, then manifests, then python, then docker, depending upon
+        # Prefer local executable if found, then manifests, then python, depending upon
         # how the connector is declared in the connector registry.
         if which(name):
             local_executable = name
@@ -240,11 +240,9 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             match metadata.default_install_type:
                 case InstallType.YAML:
                     source_manifest = True
-                case InstallType.PYTHON:
+                case _:
                     pip_url = metadata.pypi_package_name
                     pip_url = f"{pip_url}=={version}" if version else pip_url
-                case _:
-                    docker_image = True
 
     if local_executable:
         return _get_local_executor(

--- a/airbyte/destinations/base.py
+++ b/airbyte/destinations/base.py
@@ -265,7 +265,7 @@ class Destination(ConnectorBase, AirbyteWriterInterface):
         with as_temp_files(
             files_contents=[
                 self._hydrated_config,
-                catalog_provider.configured_catalog.model_dump_json(),
+                catalog_provider.configured_catalog.model_dump_json(exclude_none=True),
             ]
         ) as [
             config_file,


### PR DESCRIPTION
I've been using these change to test https://github.com/airbytehq/airbyte/pull/64901


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-installs a remote wheel before the main package for Python-based connectors to improve installation reliability.

* **Chores**
  * Disabled strict PyPI publication checks; connectors without PyPI metadata no longer fail at runtime.
  * Made installation error handling more tolerant to reduce hard failures during setup.
  * Removed automatic Docker fallback when no install method is specified; Docker must now be explicitly selected.
  * Catalog JSON now omits null fields when written, producing smaller output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->