### PR TITLE
fix: use explicit connector versions from registry instead of 'latest' tags

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -289,7 +289,8 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
                     if logger:
                         logger.warning(
                             f"Using 'latest' tag for connector '{name}' because no explicit "
-                            f"version was specified and we could not locate the latest version number."
+                            f"version was specified and we could not locate the latest "
+                            f"version number."
                         )
 
             docker_image = f"{docker_image}:{resolved_version}"


### PR DESCRIPTION
# fix: use explicit connector versions from registry instead of 'latest' tags

## Summary

This PR addresses an issue where some Java connectors no longer receive 'latest' tag updates in DockerHub, potentially causing PyAirbyte to use outdated connector versions. The solution modifies the Docker executor creation logic to:

1. **Fetch explicit versions from registry**: When no version is specified, the system now attempts to retrieve `latest_available_version` from the connector registry metadata
2. **Use explicit version tags**: Instead of defaulting to 'latest', it constructs Docker image tags with explicit version numbers (e.g., `airbyte/source-faker:1.2.3`)
3. **Graceful fallback with warnings**: Falls back to 'latest' with descriptive warning messages when:
   - Registry is unavailable or offline mode is enabled
   - Connector metadata exists but lacks version information

The change maintains full backward compatibility - explicit versions still work as before, and the fallback ensures existing workflows continue to function.

## Review & Testing Checklist for Human

- [ ] **Test version resolution with real connectors**: Verify that common connectors (source-faker, source-postgres, etc.) correctly resolve to explicit versions from the registry instead of 'latest'
- [ ] **Validate fallback behavior**: Test offline mode (`AIRBYTE_OFFLINE_MODE=1`) to ensure it properly falls back to 'latest' with appropriate warnings
- [ ] **Check warning message frequency**: Ensure warning messages aren't too noisy in normal usage - verify that most registered connectors have `latest_available_version` data
- [ ] **Verify explicit version override**: Test that specifying an explicit version parameter still works correctly and bypasses registry lookup
- [ ] **End-to-end connector execution**: Run a complete source operation to ensure the resolved Docker images actually work and can be pulled/executed

**Recommended test plan**: 
1. Create sources for 3-4 different connectors without specifying versions
2. Check logs for version resolution messages  
3. Verify Docker images use explicit versions (not 'latest')
4. Test one connector in offline mode
5. Test one connector with explicit version specified

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    GetConnectorExecutor["get_connector_executor()<br/>util.py:161-385"]:::major-edit
    RegistryMetadata["get_connector_metadata()<br/>registry.py:191-218"]:::context
    Constants["AIRBYTE_OFFLINE_MODE<br/>constants.py"]:::context
    DockerImage["Docker Image Tag<br/>Construction Logic"]:::major-edit
    
    GetConnectorExecutor --> RegistryMetadata
    GetConnectorExecutor --> Constants
    GetConnectorExecutor --> DockerImage
    
    DockerImage --> ExplicitVersion["Use metadata.latest_available_version"]:::major-edit
    DockerImage --> FallbackLatest["Fallback to 'latest' + warning"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Key change location**: The main logic is in `airbyte/_executors/util.py` lines 283-302, where Docker image tag construction now includes version resolution
- **Logging added**: New warning messages help users understand when and why 'latest' fallback is used
- **Registry dependency**: Success depends on connector registry having reliable `latest_available_version` data
- **Testing limitation**: Full functionality testing was limited due to environment setup issues, making human testing especially important

**Link to Devin run**: https://app.devin.ai/sessions/fb2a065dd9a54e5cad797db5a3790ffc  
**Requested by**: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds runtime warnings to inform users when the system falls back to a default Docker tag, clarifying potential version risks.

- **Bug Fixes**
  - Improves Docker image tag resolution when no tag is provided: uses an explicit version if supplied, prefers the latest available version from metadata if present, and falls back to “latest” (with a warning) if metadata is unavailable.
  - Keeps non-Docker install flows unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._