### PR TITLE
feat: split config parameter into config and config_file for better MCP client interoperability

### DIFF
--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -128,11 +128,11 @@ def list_source_streams(
     ],
     config: Annotated[
         dict | str | None,
-        Field(description="The configuration for the source connector as a dict object or JSON string."),
+        Field(description="The configuration for the source connector as a dict or JSON string."),
     ] = None,
     config_file: Annotated[
         str | Path | None,
-        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+        Field(description="Path to a YAML or JSON file containing the source connector config."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -169,11 +169,11 @@ def get_source_stream_json_schema(
     ],
     config: Annotated[
         dict | str | None,
-        Field(description="The configuration for the source connector as a dict object or JSON string."),
+        Field(description="The configuration for the source connector as a dict or JSON string."),
     ] = None,
     config_file: Annotated[
         str | Path | None,
-        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+        Field(description="Path to a YAML or JSON file containing the source connector config."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -203,11 +203,11 @@ def read_source_stream_records(
     ],
     config: Annotated[
         dict | str | None,
-        Field(description="The configuration for the source connector as a dict object or JSON string."),
+        Field(description="The configuration for the source connector as a dict or JSON string."),
     ] = None,
     config_file: Annotated[
         str | Path | None,
-        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+        Field(description="Path to a YAML or JSON file containing the source connector config."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -231,6 +231,7 @@ def read_source_stream_records(
         )
         config_dict = resolve_config(
             config=config,
+            config_file=config_file,
             config_secret_name=config_secret_name,
             config_spec_jsonschema=source.config_spec,
         )
@@ -261,11 +262,11 @@ def get_stream_previews(
     ],
     config: Annotated[
         dict | str | None,
-        Field(description="The configuration for the source connector as a dict object or JSON string."),
+        Field(description="The configuration for the source connector as a dict or JSON string."),
     ] = None,
     config_file: Annotated[
         str | Path | None,
-        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+        Field(description="Path to a YAML or JSON file containing the source connector config."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -342,11 +343,11 @@ def sync_source_to_cache(
     ],
     config: Annotated[
         dict | str | None,
-        Field(description="The configuration for the source connector as a dict object or JSON string."),
+        Field(description="The configuration for the source connector as a dict or JSON string."),
     ] = None,
     config_file: Annotated[
         str | Path | None,
-        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+        Field(description="Path to a YAML or JSON file containing the source connector config."),
     ] = None,
     config_secret_name: Annotated[
         str | None,

--- a/airbyte/mcp/_local_ops.py
+++ b/airbyte/mcp/_local_ops.py
@@ -51,8 +51,12 @@ def validate_connector_config(
         Field(description="The name of the connector to validate."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the connector."),
+        dict | str | None,
+        Field(description="The configuration for the connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the connector configuration."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -74,6 +78,7 @@ def validate_connector_config(
     try:
         config_dict = resolve_config(
             config=config,
+            config_file=config_file,
             config_secret_name=config_secret_name,
             config_spec_jsonschema=source.config_spec,
         )
@@ -122,8 +127,12 @@ def list_source_streams(
         Field(description="The name of the source connector."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the source connector."),
+        dict | str | None,
+        Field(description="The configuration for the source connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -140,6 +149,7 @@ def list_source_streams(
     )
     config_dict = resolve_config(
         config=config,
+        config_file=config_file,
         config_secret_name=config_secret_name,
         config_spec_jsonschema=source.config_spec,
     )
@@ -158,13 +168,17 @@ def get_source_stream_json_schema(
         Field(description="The name of the stream."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the source connector."),
-    ],
+        dict | str | None,
+        Field(description="The configuration for the source connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
+    ] = None,
     config_secret_name: Annotated[
         str | None,
         Field(description="The name of the secret containing the configuration."),
-    ],
+    ] = None,
 ) -> dict[str, Any]:
     """List all properties for a specific stream in a source connector."""
     source: Source = get_source(
@@ -173,6 +187,7 @@ def get_source_stream_json_schema(
     )
     config_dict = resolve_config(
         config=config,
+        config_file=config_file,
         config_secret_name=config_secret_name,
         config_spec_jsonschema=source.config_spec,
     )
@@ -187,8 +202,12 @@ def read_source_stream_records(
         Field(description="The name of the source connector."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the source connector."),
+        dict | str | None,
+        Field(description="The configuration for the source connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -241,8 +260,12 @@ def get_stream_previews(
         Field(description="The name of the source connector."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the source connector."),
+        dict | str | None,
+        Field(description="The configuration for the source connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -272,6 +295,7 @@ def get_stream_previews(
     )
     config_dict = resolve_config(
         config=config,
+        config_file=config_file,
         config_secret_name=config_secret_name,
         config_spec_jsonschema=source.config_spec,
     )
@@ -317,8 +341,12 @@ def sync_source_to_cache(
         Field(description="The name of the source connector."),
     ],
     config: Annotated[
-        dict | Path | None,
-        Field(description="The configuration for the source connector."),
+        dict | str | None,
+        Field(description="The configuration for the source connector as a dict object or JSON string."),
+    ] = None,
+    config_file: Annotated[
+        str | Path | None,
+        Field(description="Path to a YAML or JSON file containing the source connector configuration."),
     ] = None,
     config_secret_name: Annotated[
         str | None,
@@ -336,6 +364,7 @@ def sync_source_to_cache(
     )
     config_dict = resolve_config(
         config=config,
+        config_file=config_file,
         config_secret_name=config_secret_name,
         config_spec_jsonschema=source.config_spec,
     )

--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -67,7 +67,7 @@ def resolve_config(
     We reject hardcoded secrets in a config dict if we detect them.
     """
     config_dict: dict[str, Any] = {}
-    
+
     if config is None and config_file is None and config_secret_name is None:
         raise ValueError(
             "No configuration provided. At least one of `config`, `config_file`, "
@@ -77,15 +77,15 @@ def resolve_config(
     if config_file is not None:
         if isinstance(config_file, str):
             config_file = Path(config_file)
-        
+
         if not isinstance(config_file, Path):
             raise ValueError(
                 f"config_file must be a string or Path object, got: {type(config_file).__name__}"
             )
-            
+
         if not config_file.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_file}")
-            
+
         try:
             file_config = yaml.safe_load(config_file.read_text())
             if not isinstance(file_config, dict):
@@ -105,15 +105,14 @@ def resolve_config(
                 parsed_config = json.loads(config)
                 if not isinstance(parsed_config, dict):
                     raise ValueError(
-                        f"Parsed JSON config must be an object/dict, got: {type(parsed_config).__name__}"
+                        f"Parsed JSON config must be an object/dict, "
+                        f"got: {type(parsed_config).__name__}"
                     )
                 config_dict.update(parsed_config)
             except json.JSONDecodeError as e:
                 raise ValueError(f"Invalid JSON in config parameter: {e}")
         else:
-            raise ValueError(
-                f"Config must be a dict or JSON string, got: {type(config).__name__}"
-            )
+            raise ValueError(f"Config must be a dict or JSON string, got: {type(config).__name__}")
 
     if config_dict and config_spec_jsonschema is not None:
         hardcoded_secrets: list[list[str]] = detect_hardcoded_secrets(

--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -60,12 +60,6 @@ def resolve_config(  # noqa: PLR0912
 ) -> dict[str, Any]:
     """Resolve a configuration dictionary, JSON string, or file path to a dictionary.
 
-    Args:
-        config: Configuration as a dict object OR a JSON string that will be parsed
-        config_file: Path to a YAML/JSON configuration file (separate from config)
-        config_secret_name: Name of secret containing configuration
-        config_spec_jsonschema: JSON schema for validation
-
     Returns:
         Resolved configuration dictionary
 

--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -140,7 +140,7 @@ def resolve_config(  # noqa: PLR0912
                 f"but got: {type(secret_config).__name__}"
             )
 
-        # Merge the secret config into the main config (highest priority):
+        # Merge the secret config into the main config:
         deep_update(
             config_dict,
             secret_config,

--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 """Internal utility functions for MCP."""
 
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -65,8 +66,6 @@ def resolve_config(
 
     We reject hardcoded secrets in a config dict if we detect them.
     """
-    import json
-    
     config_dict: dict[str, Any] = {}
     
     if config is None and config_file is None and config_secret_name is None:

--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -44,49 +44,95 @@ def initialize_secrets() -> None:
 
 
 def resolve_config(
-    config: dict | Path | None = None,
+    config: dict | str | None = None,
+    config_file: str | Path | None = None,
     config_secret_name: str | None = None,
     config_spec_jsonschema: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Resolve a configuration dictionary or file path to a dictionary.
+    """Resolve a configuration dictionary, JSON string, or file path to a dictionary.
+
+    Args:
+        config: Configuration as a dict object OR a JSON string that will be parsed
+        config_file: Path to a YAML/JSON configuration file (separate from config)
+        config_secret_name: Name of secret containing configuration
+        config_spec_jsonschema: JSON schema for validation
+
+    Returns:
+        Resolved configuration dictionary
+
+    Raises:
+        ValueError: If no configuration provided or if JSON parsing fails
 
     We reject hardcoded secrets in a config dict if we detect them.
     """
+    import json
+    
     config_dict: dict[str, Any] = {}
-    if config is None and config_secret_name is None:
+    
+    if config is None and config_file is None and config_secret_name is None:
         raise ValueError(
-            "No configuration provided. Either `config` or `config_secret_name` must be specified."
+            "No configuration provided. At least one of `config`, `config_file`, "
+            "or `config_secret_name` must be specified."
         )
 
-    if isinstance(config, Path):
-        config_dict.update(yaml.safe_load(config.read_text()))
-
-    elif isinstance(config, dict):
-        if config_spec_jsonschema is not None:
-            hardcoded_secrets: list[list[str]] = detect_hardcoded_secrets(
-                config=config,
-                spec_json_schema=config_spec_jsonschema,
+    if config_file is not None:
+        if isinstance(config_file, str):
+            config_file = Path(config_file)
+        
+        if not isinstance(config_file, Path):
+            raise ValueError(
+                f"config_file must be a string or Path object, got: {type(config_file).__name__}"
             )
-            if hardcoded_secrets:
-                error_msg = "Configuration contains hardcoded secrets in fields: "
-                error_msg += ", ".join(
-                    [".".join(hardcoded_secret) for hardcoded_secret in hardcoded_secrets]
+            
+        if not config_file.exists():
+            raise FileNotFoundError(f"Configuration file not found: {config_file}")
+            
+        try:
+            file_config = yaml.safe_load(config_file.read_text())
+            if not isinstance(file_config, dict):
+                raise ValueError(
+                    f"Configuration file must contain a valid JSON/YAML object, "
+                    f"got: {type(file_config).__name__}"
                 )
+            config_dict.update(file_config)
+        except Exception as e:
+            raise ValueError(f"Error reading configuration file {config_file}: {e}")
 
-                error_msg += (
-                    "Please use environment variables instead. For example:\n"
-                    "To set a secret via reference, set its value to "
-                    "`secret_reference::ENV_VAR_NAME`.\n"
-                )
-                raise ValueError(error_msg)
+    if config is not None:
+        if isinstance(config, dict):
+            config_dict.update(config)
+        elif isinstance(config, str):
+            try:
+                parsed_config = json.loads(config)
+                if not isinstance(parsed_config, dict):
+                    raise ValueError(
+                        f"Parsed JSON config must be an object/dict, got: {type(parsed_config).__name__}"
+                    )
+                config_dict.update(parsed_config)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in config parameter: {e}")
+        else:
+            raise ValueError(
+                f"Config must be a dict or JSON string, got: {type(config).__name__}"
+            )
 
-        config_dict.update(config)
-    elif config is not None:
-        # We shouldn't reach here.
-        raise ValueError(
-            "Config must be a dict or a Path object pointing to a YAML or JSON file. "
-            f"Found type: {type(config).__name__}"
+    if config_dict and config_spec_jsonschema is not None:
+        hardcoded_secrets: list[list[str]] = detect_hardcoded_secrets(
+            config=config_dict,
+            spec_json_schema=config_spec_jsonschema,
         )
+        if hardcoded_secrets:
+            error_msg = "Configuration contains hardcoded secrets in fields: "
+            error_msg += ", ".join(
+                [".".join(hardcoded_secret) for hardcoded_secret in hardcoded_secrets]
+            )
+
+            error_msg += (
+                "Please use environment variables instead. For example:\n"
+                "To set a secret via reference, set its value to "
+                "`secret_reference::ENV_VAR_NAME`.\n"
+            )
+            raise ValueError(error_msg)
 
     if config_secret_name is not None:
         # Assume this is a secret name that points to a JSON/YAML config.
@@ -97,7 +143,7 @@ def resolve_config(
                 f"but got: {type(secret_config).__name__}"
             )
 
-        # Merge the secret config into the main config:
+        # Merge the secret config into the main config (highest priority):
         deep_update(
             config_dict,
             secret_config,


### PR DESCRIPTION
# feat: split config parameter into config and config_file for better MCP client interoperability

## Summary

This PR addresses MCP client interoperability issues by splitting the `config` parameter into two separate parameters:
- `config`: Now accepts `dict | str | None` (dict objects OR JSON strings)
- `config_file`: New parameter accepting `str | Path | None` for file paths

The changes expand the `resolve_config()` utility function to parse JSON strings and handle the new parameter structure, then update all 6 MCP tools (`validate_connector_config`, `list_source_streams`, `get_source_stream_json_schema`, `read_source_stream_records`, `get_stream_previews`, `sync_source_to_cache`) to use the new signature.

**Key motivation**: Different MCP clients (like Claude Desktop) may serialize JSON objects as strings, causing type validation errors with the previous `dict | Path | None` typing. This change allows both programmatic clients (passing dict objects) and user-facing clients (passing JSON strings) to work seamlessly.

## Review & Testing Checklist for Human

**⚠️ CRITICAL TESTING NEEDED** - Environment issues prevented full end-to-end testing during development.

- [ ] **Test JSON string parsing**: Verify `config` parameter correctly handles JSON strings like `'{"count": 100}'` across all MCP tools
- [ ] **Test backward compatibility**: Ensure existing usage with dict objects continues to work without changes  
- [ ] **Test parameter priority logic**: Verify behavior when multiple config sources are provided (config + config_file + config_secret_name) - config should override config_file, secrets should have highest priority
- [ ] **Test file-based configs**: Confirm `config_file` parameter works correctly with YAML/JSON file paths
- [ ] **Test error handling**: Verify graceful failures for malformed JSON strings and invalid file paths

### Notes

- **Breaking change risk**: The `config` parameter no longer accepts `Path` objects directly - these should now use `config_file` instead
- **Type safety**: Added comprehensive JSON parsing with proper error messages for malformed input
- **Merge priority**: config_file < config < config_secret_name (highest priority)
- **Requested by**: @aaronsteers from session https://app.devin.ai/sessions/8a5a613809a34709967ffb7f8a130c90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept connector config as a JSON string or via a YAML/JSON config file (new config_file) and added .env loading via AIRBYTE_MCP_DOTENV_PATH_ENVVAR.

* **Bug Fixes / Validation**
  * Improved errors for missing/unreadable/malformed/non-dict config inputs; changed behavior to return empty config when no input provided; enforces clear precedence: file → config/string → secrets; detects hardcoded secrets and surfaces guidance.

* **Documentation**
  * Updated descriptions and error messages to reflect new input forms, precedence, and exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._