### PR TITLE
test: xfail cloud tests with permission errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ packages = [{ include = "airbyte" }]
 
 # This project uses dynamic versioning
 # https://github.com/mtkennerly/poetry-dynamic-versioning
+# Dummy change to trigger CI for cloud test xfail investigation
 version = "0.0.0"
 
 [tool.poetry-dynamic-versioning]

--- a/tests/integration_tests/cloud/test_cloud_sql_reads.py
+++ b/tests/integration_tests/cloud/test_cloud_sql_reads.py
@@ -93,6 +93,9 @@ def test_read_from_deployed_connection(
         assert pandas_df[col].notnull().all()
 
 
+@pytest.mark.xfail(
+    reason="Cloud API permission errors: Status 403 - Caller does not have required WORKSPACE_READER permissions. Unrelated to code changes."
+)
 @pytest.mark.parametrize(
     "deployed_connection_id, cache_type",
     [


### PR DESCRIPTION
## Summary
This PR adds `@pytest.mark.xfail` markers to cloud integration tests that are failing with Status 403 permission errors. The tests fail because the API credentials don't have required `WORKSPACE_READER` permissions to access Airbyte Cloud job information. This prevents CI failures while the underlying permission issues are resolved in issue #764.

**Changes:**
- Added xfail decorator to `test_translate_cloud_job_to_sql_cache` for Snowflake and BigQuery variants
- Added minimal dummy comment to `pyproject.toml` to trigger CI

## Review & Testing Checklist for Human

- [ ] **Verify permission error diagnosis**: Confirm that the failing tests are indeed due to API permission issues (Status 403) and not actual code problems
- [ ] **Check issue tracking**: Ensure issue #764 properly tracks the resolution of the underlying permission problems  
- [ ] **Confirm removal plan**: Verify there's a clear process to remove these xfail markers once permissions are fixed

### Notes
- Tests now show as XFAIL instead of failures, preventing CI blockage
- This is a temporary fix - the xfail markers should be removed once Cloud API permissions are properly configured
- Local testing confirmed the xfail markers work correctly (tests show as expected failures)

**Requested by:** @aaronsteers for cloud test investigation  
**Session:** https://app.devin.ai/sessions/55544c0ad1d84984b252650d469f4f9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Triggered CI with a non-functional change; no impact on features, performance, or configuration.

* **Tests**
  * Marked a cloud integration test as expected to fail due to external permission issues to stabilize CI; no changes to product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._