### PR TITLE
feat(cloud): Add log reading capabilities to SyncAttempt

### DIFF
--- a/airbyte/cloud/sync_results.py
+++ b/airbyte/cloud/sync_results.py
@@ -182,6 +182,83 @@ class SyncAttempt:
         )
         return self._attempt_info
 
+    def get_log_text_tail(self, num_lines: int = 1000) -> str:
+        """Return the last N lines of log text for this attempt.
+
+        Args:
+            num_lines: Maximum number of lines to return from the end of the logs.
+                      Defaults to 1000 lines.
+
+        Returns:
+            String containing the last N lines of log text, with lines separated by newlines.
+        """
+        attempt_info = self._fetch_attempt_info()
+        logs_data = attempt_info.get("logs")
+
+        if not logs_data:
+            return ""
+
+        if "events" in logs_data:
+            log_events = logs_data["events"]
+            if not log_events:
+                return ""
+
+            tail_events = log_events[-num_lines:] if len(log_events) > num_lines else log_events
+            log_lines = []
+
+            for event in tail_events:
+                timestamp = event.get("timestamp", "")
+                level = event.get("level", "INFO")
+                message = event.get("message", "")
+                log_lines.append(f"[{timestamp}] {level}: {message}")
+
+            return "\n".join(log_lines)
+
+        if "logLines" in logs_data:
+            log_lines = logs_data["logLines"]
+            if not log_lines:
+                return ""
+
+            tail_lines = log_lines[-num_lines:] if len(log_lines) > num_lines else log_lines
+            return "\n".join(tail_lines)
+
+        return ""
+
+    def get_full_log_text(self) -> str:
+        """Return the complete log text for this attempt.
+
+        Returns:
+            String containing all log text for this attempt, with lines separated by newlines.
+        """
+        attempt_info = self._fetch_attempt_info()
+        logs_data = attempt_info.get("logs")
+
+        if not logs_data:
+            return ""
+
+        if "events" in logs_data:
+            log_events = logs_data["events"]
+            if not log_events:
+                return ""
+
+            log_lines = []
+            for event in log_events:
+                timestamp = event.get("timestamp", "")
+                level = event.get("level", "INFO")
+                message = event.get("message", "")
+                log_lines.append(f"[{timestamp}] {level}: {message}")
+
+            return "\n".join(log_lines)
+
+        if "logLines" in logs_data:
+            log_lines = logs_data["logLines"]
+            if not log_lines:
+                return ""
+
+            return "\n".join(log_lines)
+
+        return ""
+
 
 @dataclass
 class SyncResult:

--- a/airbyte/cloud/sync_results.py
+++ b/airbyte/cloud/sync_results.py
@@ -182,48 +182,6 @@ class SyncAttempt:
         )
         return self._attempt_info
 
-    def get_log_text_tail(self, num_lines: int = 1000) -> str:
-        """Return the last N lines of log text for this attempt.
-
-        Args:
-            num_lines: Maximum number of lines to return from the end of the logs.
-                      Defaults to 1000 lines.
-
-        Returns:
-            String containing the last N lines of log text, with lines separated by newlines.
-        """
-        attempt_info = self._fetch_attempt_info()
-        logs_data = attempt_info.get("logs")
-
-        if not logs_data:
-            return ""
-
-        if "events" in logs_data:
-            log_events = logs_data["events"]
-            if not log_events:
-                return ""
-
-            tail_events = log_events[-num_lines:] if len(log_events) > num_lines else log_events
-            log_lines = []
-
-            for event in tail_events:
-                timestamp = event.get("timestamp", "")
-                level = event.get("level", "INFO")
-                message = event.get("message", "")
-                log_lines.append(f"[{timestamp}] {level}: {message}")
-
-            return "\n".join(log_lines)
-
-        if "logLines" in logs_data:
-            log_lines = logs_data["logLines"]
-            if not log_lines:
-                return ""
-
-            tail_lines = log_lines[-num_lines:] if len(log_lines) > num_lines else log_lines
-            return "\n".join(tail_lines)
-
-        return ""
-
     def get_full_log_text(self) -> str:
         """Return the complete log text for this attempt.
 


### PR DESCRIPTION
This PR targets the following PR:
- #781

---

# feat(cloud): Add log reading capabilities to SyncAttempt

## Summary

Adds two new methods to the `SyncAttempt` class to enable log retrieval from Cloud sync attempts:

- `get_log_text_tail(num_lines: int = 1000) -> str`: Returns the last N lines of log text
- `get_full_log_text() -> str`: Returns complete log text for the attempt

Both methods use the existing Config API integration (`_fetch_attempt_info()`) and handle both structured (`LogEvents`) and unstructured (`LogRead`) log formats returned by the `/v1/attempts/get_for_job` endpoint.

## Review & Testing Checklist for Human

- [ ] **Test with real log data**: Verify the methods work with actual Cloud sync attempts and return properly formatted logs
- [ ] **Verify API response format**: Confirm the Config API actually returns logs in "events" and "logLines" fields as expected from the schema analysis
- [ ] **Test edge cases**: Try with failed attempts, attempts with no logs, very large log files, and attempts with different log formats
- [ ] **Performance testing**: Check behavior with large log files to ensure `get_full_log_text()` doesn't cause memory issues

### Notes

- Implementation follows existing PyAirbyte patterns using lazy loading via `_fetch_attempt_info()`
- Field names (`events` vs `logLines`) were verified against the Config API OpenAPI schema
- Could not test locally due to environment dependency issues (missing 'six' module in pandas chain)
- Uses the established `_make_config_api_request()` pattern with proper noqa comments

**Link to Devin run**: https://app.devin.ai/sessions/946366cdd71140c88397678ef6fb16fd  
**Requested by**: @aaronsteers