### PR TITLE
chore(mcp): add `mcp-tool-test` Poe task

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -65,8 +65,10 @@ poe mcp-tool-test <tool_name> '<json_args>'
 
 poe mcp-tool-test list_connectors '{}'
 poe mcp-tool-test get_config_spec '{"connector_name": "source-pokeapi"}'
-poe mcp-tool-test validate_config '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
-poe mcp-tool-test run_sync '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+poe mcp-tool-test validate_config \
+    '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+poe mcp-tool-test run_sync \
+    '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
 
 poe mcp-tool-test check_airbyte_cloud_workspace '{}'
 poe mcp-tool-test list_deployed_cloud_connections '{}'

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -56,72 +56,32 @@ and then create the configuration file as follows:
 
 ## Testing the MCP Server
 
-You can use your tool of choice to test the MCP server. Below we'll use the Devin `mcp-cli`
-tool. First, we install our MCP CLI client:
 
-```
-uv tool install devin-mcp-cli
-```
-
-Next, we export the configuration path so that MCP CLI can find your server:
+The easiest way to test PyAirbyte MCP tools during development is using the built-in Poe tasks.
+These tasks automatically inherit environment variables from your shell session:
 
 ```bash
-# You can use a custom path in your home directory:
-export MCP_CLI_CONFIG_PATH=~/.mcp/mcp_server_config.json
-touch $MCP_CLI_CONFIG_PATH
+poe mcp-tool-test <tool_name> '<json_args>'
 
-# Then you can symlink your file to also be available in Claude Desktop path:
-mkdir -p ~/Library/"Application Support"/Claude
-ln -s $MCP_CLI_CONFIG_PATH ~/Library/"Application Support"/Claude/claude_desktop_config.json
+poe mcp-tool-test list_connectors '{}'
+poe mcp-tool-test get_config_spec '{"connector_name": "source-pokeapi"}'
+poe mcp-tool-test validate_config '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+poe mcp-tool-test run_sync '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
 
-# Confirm the Claude Desktop symlink is working:
-cat ~/Library/"Application Support"/Claude/claude_desktop_config.json
+poe mcp-tool-test check_airbyte_cloud_workspace '{}'
+poe mcp-tool-test list_deployed_cloud_connections '{}'
 ```
 
-### Check that your server is properly registered
 
 ```bash
-mcp-cli server list
-mcp-cli tool list
+poe mcp-serve-local    # STDIO transport (default)
+poe mcp-serve-http     # HTTP transport on localhost:8000
+poe mcp-serve-sse      # Server-Sent Events transport on localhost:8000
+
+poe mcp-inspect        # Show all available MCP tools and their schemas
 ```
 
-This should show `airbyte` in the list of available servers.
 
-### Verify the server can be reached
-
-```bash
-mcp-cli server check
-```
-
-This should show `✓ Connected` for the Airbyte server with a list of available tools.
-
-### Test the MCP Tools
-
-You should now be able to validate specific tools:
-
-```bash
-# Show a list of all available Airbyte source connectors:
-mcp-cli tool call list_connectors --server airbyte
-
-# Get JSON schema of expected config for the specified connector:
-mcp-cli tool call get_config_spec --server airbyte --input '{"connector_name": "source-pokeapi"}'
-
-# Validate the provided configuration:
-mcp-cli tool call validate_config --server airbyte --input '{
-  "connector_name": "source-pokeapi",
-  "config": {
-    "pokemon_name": "pikachu"
-  }
-}'
-
-# Run a sync operation with the provided configuration:
-mcp-cli tool call run_sync --server airbyte --input '{
-  "connector_name": "source-pokeapi",
-  "config": {
-    "pokemon_name": "pikachu"
-  }
-}'
-```
 
 ## Contributing to PyAirbyte and the Airbyte MCP Server
 

--- a/bin/test_mcp_tool.py
+++ b/bin/test_mcp_tool.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+One-liner CLI tool for testing PyAirbyte MCP tools directly with JSON arguments.
+
+Usage:
+    poe mcp-tool-test <tool_name> '<json_args>'
+
+Examples:
+    poe mcp-tool-test list_connectors '{}'
+    poe mcp-tool-test get_config_spec '{"connector_name": "source-pokeapi"}'
+    poe mcp-tool-test validate_config '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+    poe mcp-tool-test run_sync '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+
+    poe mcp-tool-test check_airbyte_cloud_workspace '{}'
+    poe mcp-tool-test list_deployed_cloud_connections '{}'
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastmcp import Client
+from airbyte.mcp.server import app
+
+
+async def call_mcp_tool(tool_name: str, args: dict[str, Any]) -> Any:
+    """Call an MCP tool using the FastMCP client."""
+
+    async with Client(app) as client:
+        result = await client.call_tool(tool_name, args)
+        return result
+
+
+def main() -> None:
+    """Main entry point for the MCP tool tester."""
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = sys.argv[1]
+    json_args = sys.argv[2]
+
+    try:
+        args: dict[str, Any] = json.loads(json_args)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON arguments: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = asyncio.run(call_mcp_tool(tool_name, args))
+
+        if hasattr(result, "text"):
+            print(result.text)
+        else:
+            print(str(result))
+
+    except Exception as e:
+        print(f"Error executing tool '{tool_name}': {e}", file=sys.stderr)
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/test_mcp_tool.py
+++ b/bin/test_mcp_tool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""
-One-liner CLI tool for testing PyAirbyte MCP tools directly with JSON arguments.
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""One-liner CLI tool for testing PyAirbyte MCP tools directly with JSON arguments.
 
 Usage:
     poe mcp-tool-test <tool_name> '<json_args>'
@@ -8,8 +8,10 @@ Usage:
 Examples:
     poe mcp-tool-test list_connectors '{}'
     poe mcp-tool-test get_config_spec '{"connector_name": "source-pokeapi"}'
-    poe mcp-tool-test validate_config '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
-    poe mcp-tool-test run_sync '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+    poe mcp-tool-test validate_config \
+        '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
+    poe mcp-tool-test run_sync \
+        '{"connector_name": "source-pokeapi", "config": {"pokemon_name": "pikachu"}}'
 
     poe mcp-tool-test check_airbyte_cloud_workspace '{}'
     poe mcp-tool-test list_deployed_cloud_connections '{}'
@@ -18,24 +20,26 @@ Examples:
 import asyncio
 import json
 import sys
-from pathlib import Path
+import traceback
 from typing import Any
 
 from fastmcp import Client
+
 from airbyte.mcp.server import app
 
 
-async def call_mcp_tool(tool_name: str, args: dict[str, Any]) -> Any:
-    """Call an MCP tool using the FastMCP client."""
+MIN_ARGS = 3
 
+
+async def call_mcp_tool(tool_name: str, args: dict[str, Any]) -> object:
+    """Call an MCP tool using the FastMCP client."""
     async with Client(app) as client:
-        result = await client.call_tool(tool_name, args)
-        return result
+        return await client.call_tool(tool_name, args)
 
 
 def main() -> None:
     """Main entry point for the MCP tool tester."""
-    if len(sys.argv) < 3:
+    if len(sys.argv) < MIN_ARGS:
         print(__doc__, file=sys.stderr)
         sys.exit(1)
 
@@ -58,8 +62,6 @@ def main() -> None:
 
     except Exception as e:
         print(f"Error executing tool '{tool_name}': {e}", file=sys.stderr)
-        import traceback
-
         traceback.print_exc()
         sys.exit(1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,13 @@ fix = { shell = "ruff format . && ruff check --fix -s || ruff format ." }
 fix-unsafe = { shell = "ruff format . && ruff check --fix --unsafe-fixes . && ruff format ." }
 fix-and-check = { shell = "poe fix && poe check" }
 
+# MCP Server Tasks
+mcp-serve-local = { cmd = "poetry run airbyte-mcp", help = "Start the MCP server with STDIO transport" }
+mcp-serve-http = { cmd = "poetry run python -c \"from airbyte.mcp.server import app; app.run(transport='http', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with HTTP transport" }
+mcp-serve-sse = { cmd = "poetry run python -c \"from airbyte.mcp.server import app; app.run(transport='sse', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with SSE transport" }
+mcp-inspect = { cmd = "poetry run fastmcp inspect airbyte/mcp/server.py:app", help = "Inspect MCP tools and resources (supports --tools, --health, etc.)" }
+mcp-tool-test = { cmd = "poetry run python bin/test_mcp_tool.py", help = "Test MCP tools directly with JSON arguments: poe mcp-tool-test <tool_name> '<json_args>'" }
+
 [tool.airbyte_ci]
 extra_poetry_groups = ["dev"]
 poe_tasks = ["test"]


### PR DESCRIPTION
# chore(mcp): add `mcp-tool-test` Poe task

## Summary

This PR adds a new `mcp-tool-test` Poe task and updates MCP testing documentation to use built-in Poe tasks instead of the external `mcp-cli` tool (which is not publicly available).

**Key changes:**
- **Added 5 new MCP Poe tasks** in `pyproject.toml`: `mcp-serve-local`, `mcp-serve-http`, `mcp-serve-sse`, `mcp-inspect`, and `mcp-tool-test`
- **Created `bin/test_mcp_tool.py`** - executable script for testing MCP tools with JSON arguments, featuring PyAirbyte-specific examples
- **Updated MCP documentation** in `airbyte/mcp/__init__.py` to completely remove `mcp-cli` references and replace with Poe task examples
- **Improved developer experience** by providing built-in testing tools that automatically inherit environment variables

The new `poe mcp-tool-test` command allows developers to easily test both connector operations (`list_connectors`, `get_config_spec`, etc.) and cloud operations (`check_airbyte_cloud_workspace`, `list_deployed_cloud_connections`) without requiring external tooling.

## Review & Testing Checklist for Human

This is a **medium-risk** change affecting developer tooling and documentation:

- [ ] **Test the core functionality**: Run `poe mcp-tool-test check_airbyte_cloud_workspace '{}'` to verify cloud operations work
- [ ] **Verify environment variable inheritance**: Ensure `.envrc` credentials are automatically picked up by the poe tasks (no manual export needed)
- [ ] **Test connector operations**: Run `poe mcp-tool-test list_connectors '{}'` to verify connector functionality works
- [ ] **Validate all new poe tasks**: Try `poe mcp-serve-local`, `poe mcp-inspect` to ensure they work as documented

### Notes

- All lint/type checks pass (`poe check` successful)
- Environment variable inheritance relies on Poetry's process inheritance - this should work but needs verification in different shell environments
- Completely removed dependency on external `mcp-cli` tool per maintainer request

---
**Requested by:** @aaronsteers  
**Devin session:** https://app.devin.ai/sessions/6b6e50fa185a426e966816a8f6cf46ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Poe commands to run the MCP server via STDIO, HTTP, or SSE.
  - Introduced a tool inspection command to view available MCP tools and schemas.
  - Added a testing command to invoke MCP tools directly with JSON arguments (supports listing connectors, fetching specs, validating configs, and running syncs).

- Documentation
  - Rewrote MCP testing guidance to use Poe-based workflows instead of prior CLI steps.
  - Added examples for inspecting tools, verifying Airbyte Cloud workspaces, listing cloud connections, and running end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._