### PR TITLE
fix(mcp): Auto-register .envrc files for secret management

### DIFF
--- a/airbyte/mcp/_util.py
+++ b/airbyte/mcp/_util.py
@@ -38,6 +38,14 @@ def initialize_secrets() -> None:
             custom_dotenv_secret_mgr,
         )
 
+    envrc_path = Path.cwd() / ".envrc"
+    if envrc_path.exists():
+        envrc_secret_mgr = DotenvSecretManager(envrc_path)
+        _load_dotenv_file(envrc_path)
+        register_secret_manager(
+            envrc_secret_mgr,
+        )
+
     if is_secret_available("GCP_GSM_CREDENTIALS") and is_secret_available("GCP_GSM_PROJECT_ID"):
         # Initialize the GoogleGSMSecretManager if the credentials and project are set.
         register_secret_manager(


### PR DESCRIPTION
# fix(mcp): Auto-register .envrc files for secret management

## Summary
Fixes an issue where MCP tools were prompting for credentials manually instead of automatically loading them from `.envrc` files. The problem was that PyAirbyte's default secret managers only looked for `.env` files, not `.envrc` files.

The fix adds automatic detection and registration of `.envrc` files in the MCP `initialize_secrets()` function. When a `.envrc` file exists in the current working directory, it gets registered as a `DotenvSecretManager` and loaded into the environment.

**Before**: MCP tools prompted for `AIRBYTE_CLOUD_WORKSPACE_ID`, `AIRBYTE_CLOUD_CLIENT_ID`, and `AIRBYTE_CLOUD_CLIENT_SECRET` even when they were defined in `.envrc`

**After**: MCP tools automatically load credentials from `.envrc` without prompting

## Review & Testing Checklist for Human
- [ ] **Test with different working directories** - Verify `.envrc` detection works when MCP tools are invoked from different directories
- [ ] **Test edge cases** - Verify behavior with missing `.envrc`, malformed `.envrc`, or `.envrc` with syntax errors
- [ ] **Verify secret manager priority** - Confirm that `.envrc` secrets have the intended precedence over other secret sources
- [ ] **Security review** - Consider security implications of automatically loading `.envrc` files from the current directory
- [ ] **Test broader MCP functionality** - Verify other MCP tools still work correctly (I only tested `check_airbyte_cloud_workspace` and `list_deployed_cloud_connections`)

### Test Plan
1. Run `poe mcp-tool-test check_airbyte_cloud_workspace '{}'` - should work without prompting
2. Run `poe mcp-tool-test list_deployed_cloud_connections '{}'` - should work without prompting  
3. Test from different directories to verify path resolution
4. Test with other MCP tools to ensure no regressions

### Notes
- This change affects all MCP operations since it modifies the core secret initialization
- The fix registers the `.envrc` secret manager after custom dotenv managers but before GCP GSM
- Both secret registration AND environment loading occur for `.envrc` files

---
**Link to Devin run**: https://app.devin.ai/sessions/3dbb42ea20ff42e59cb1a635753c2407    
**Requested by**: @aaronsteers