### PR TITLE
fix(mcp): Handle empty config dicts in validate_config

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -173,7 +173,7 @@ class ConnectorBase(abc.ABC):
         If config is not provided, the already-set config will be validated.
         """
         spec = self._get_spec(force_refresh=False)
-        config = hydrate_secrets(config) if config else self._hydrated_config
+        config = hydrate_secrets(config) if config is not None else self._hydrated_config
 
         try:
             jsonschema.validate(config, spec.connectionSpecification)


### PR DESCRIPTION
# fix(mcp): Handle empty config dicts in validate_config

## Summary
Fixes a bug in PyAirbyte MCP's `sync_source_to_cache` tool that was failing with `AirbyteConnectorConfigurationMissingError` for declarative connectors with empty config specifications. 

The root cause was in `validate_config()` where `if config` treated empty dicts `{}` as falsy, causing fallback to `self._hydrated_config` before the config was actually set. Changed to `if config is not None` to properly distinguish between "no config provided" vs "empty config provided".

## Review & Testing Checklist for Human
- [ ] **End-to-end MCP testing**: Test `sync_source_to_cache` with a declarative connector (e.g., Rick & Morty) to verify the complete workflow now works
- [ ] **Regression testing**: Review other callers of `validate_config()` method to ensure this change doesn't break existing workflows  
- [ ] **Edge case verification**: Confirm the fix properly handles `None`, `{}`, and populated config dicts in various scenarios
- [ ] **CI results**: Check that all integration tests pass, especially any MCP-related tests

### Notes
- I was able to verify the fix resolves the original configuration error, but encountered a downstream DuckDB compatibility issue that prevented complete end-to-end testing
- This change affects a core validation method used throughout PyAirbyte, so thorough testing is recommended
- The fix follows standard Python patterns for distinguishing between `None` and empty containers

**Link to Devin run**: https://app.devin.ai/sessions/f328e253bb424c01b30b3b9701682da7  
**Requested by**: @aaronsteers

Fixes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty configurations are now correctly recognized and hydrated during validation rather than being treated as missing, preventing unintended fallback to internal defaults. This yields more predictable behavior when supplying an empty config and improves handling of edge cases without altering public interfaces. No action is required unless your workflows relied on automatic defaulting when an empty config was passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->