### PR TITLE
fix(postgres-cache): Store timestamps with timezone

### DIFF
--- a/airbyte/_processors/sql/bigquery.py
+++ b/airbyte/_processors/sql/bigquery.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, cast, final
+from typing import TYPE_CHECKING, final
 
 import google.oauth2
 import sqlalchemy
@@ -103,7 +103,7 @@ class BigQueryTypeConverter(SQLTypeConverter):
     @classmethod
     def get_string_type(cls) -> sqlalchemy.types.TypeEngine:
         """Return the string type for BigQuery."""
-        return cast("sqlalchemy.types.TypeEngine", "String")  # BigQuery uses STRING for all strings
+        return sqlalchemy.types.String()
 
     @overrides
     def to_sql_type(
@@ -210,7 +210,7 @@ class BigQuerySqlProcessor(SqlProcessorBase):
         project = self.sql_config.project_name
         schema = self.sql_config.schema_name
         location = self.sql_config.dataset_location
-        sql = f"CREATE SCHEMA IF NOT EXISTS `{project}.{schema}` " f'OPTIONS(location="{location}")'
+        sql = f'CREATE SCHEMA IF NOT EXISTS `{project}.{schema}` OPTIONS(location="{location}")'
         try:
             self._execute_sql(sql)
         except Exception as ex:
@@ -294,8 +294,7 @@ class BigQuerySqlProcessor(SqlProcessorBase):
         deletion_name = f"{final_table_name}_deleteme"
         commands = "\n".join(
             [
-                f"ALTER TABLE {self._fully_qualified(final_table_name)} "
-                f"RENAME TO {deletion_name};",
+                f"ALTER TABLE {self._fully_qualified(final_table_name)} RENAME TO {deletion_name};",
                 f"ALTER TABLE {self._fully_qualified(temp_table_name)} "
                 f"RENAME TO {final_table_name};",
                 f"DROP TABLE {self._fully_qualified(deletion_name)};",

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -576,7 +576,7 @@ class SqlProcessorBase(abc.ABC):
         temp_table_name = self._get_temp_table_name(stream_name, batch_id)
         engine = self.get_sql_engine()
         column_definition_str = ",\n  ".join(
-            f"{self._quote_identifier(column_name)} {sql_type.compile(dialect=engine.dialect)}"
+            f"{self._quote_identifier(column_name)} {sql_type.compile(engine.dialect)}"
             for column_name, sql_type in self._get_sql_column_definitions(stream_name).items()
         )
         self._create_table(temp_table_name, column_definition_str)

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -574,8 +574,9 @@ class SqlProcessorBase(abc.ABC):
     ) -> str:
         """Create a new table for loading data."""
         temp_table_name = self._get_temp_table_name(stream_name, batch_id)
+        engine = self.get_sql_engine()
         column_definition_str = ",\n  ".join(
-            f"{self._quote_identifier(column_name)} {sql_type}"
+            f"{self._quote_identifier(column_name)} {sql_type.compile(dialect=engine.dialect)}"
             for column_name, sql_type in self._get_sql_column_definitions(stream_name).items()
         )
         self._create_table(temp_table_name, column_definition_str)
@@ -623,9 +624,10 @@ class SqlProcessorBase(abc.ABC):
         """
         table_name = self.get_sql_table_name(stream_name)
         did_exist = self._table_exists(table_name)
+        engine = self.get_sql_engine()
         if not did_exist and create_if_missing:
             column_definition_str = ",\n  ".join(
-                f"{self._quote_identifier(column_name)} {sql_type}"
+                f"{self._quote_identifier(column_name)} {sql_type.compile(engine.dialect)}"
                 for column_name, sql_type in self._get_sql_column_definitions(
                     stream_name,
                 ).items()
@@ -687,7 +689,7 @@ class SqlProcessorBase(abc.ABC):
             )
 
         columns[AB_RAW_ID_COLUMN] = self.type_converter_class.get_string_type()
-        columns[AB_EXTRACTED_AT_COLUMN] = sqlalchemy.TIMESTAMP()
+        columns[AB_EXTRACTED_AT_COLUMN] = sqlalchemy.TIMESTAMP(timezone=True)
         columns[AB_META_COLUMN] = self.type_converter_class.get_json_type()
 
         return columns

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -151,7 +151,7 @@ class SQLTypeConverter:
             return sqlalchemy.types.DATE()
 
         if json_schema_type == "string" and json_schema_format == "date-time":
-            return sqlalchemy.types.TIMESTAMP()
+            return sqlalchemy.types.TIMESTAMP(timezone=True)
 
         if json_schema_type == "array":
             return sqlalchemy.types.JSON()

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -18,8 +18,8 @@ CONVERSION_MAP = {
     "number": sqlalchemy.types.DECIMAL(38, 9),
     "boolean": sqlalchemy.types.BOOLEAN,
     "date": sqlalchemy.types.DATE,
-    "timestamp_with_timezone": sqlalchemy.types.TIMESTAMP,
-    "timestamp_without_timezone": sqlalchemy.types.TIMESTAMP,
+    "timestamp_with_timezone": sqlalchemy.types.TIMESTAMP(timezone=True),
+    "timestamp_without_timezone": sqlalchemy.types.TIMESTAMP(timezone=False),
     "time_with_timezone": sqlalchemy.types.TIME,
     "time_without_timezone": sqlalchemy.types.TIME,
     # Technically 'object' and 'array' as JSON Schema types, not airbyte types.

--- a/tests/unit_tests/test_processors.py
+++ b/tests/unit_tests/test_processors.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
+from unittest.mock import patch
+
 import pytest_mock
-from airbyte.caches.snowflake import SnowflakeSqlProcessor, SnowflakeConfig
-from airbyte_protocol.models import ConfiguredAirbyteCatalog
+from airbyte._processors.sql.postgres import PostgresConfig, PostgresSqlProcessor
+from airbyte.caches.postgres import PostgresCache
+from airbyte.caches.snowflake import SnowflakeConfig, SnowflakeSqlProcessor
 from airbyte.secrets.base import SecretString
 from airbyte.shared.catalog_providers import CatalogProvider
+from airbyte.sources.util import get_source
+from airbyte_protocol.models import ConfiguredAirbyteCatalog
 
 
 def test_snowflake_cache_config_data_retention_time_in_days(
@@ -49,6 +54,54 @@ def test_snowflake_cache_config_no_data_retention_time_in_days(
     config._create_table(table_name="table_name", column_definition_str="col_name type")
 
     assert actual_cmd == expected_cmd
+
+
+def test_postgres_cache_config_generates_timestamps_with_timezone_settings():
+    expected_sql = """
+        CREATE TABLE airbyte_raw."products" (
+            "id" BIGINT,
+  "make" VARCHAR,
+  "model" VARCHAR,
+  "year" BIGINT,
+  "price" DECIMAL(38, 9),
+  "created_at" TIMESTAMP WITH TIME ZONE,
+  "updated_at" TIMESTAMP WITH TIME ZONE,
+  "_airbyte_raw_id" VARCHAR,
+  "_airbyte_extracted_at" TIMESTAMP WITH TIME ZONE,
+  "_airbyte_meta" JSON
+        )
+        \n        """
+    source = get_source(
+        name="source-faker",
+        config={},
+    )
+
+    config = PostgresConfig(
+        host="localhost",
+        port=5432,
+        username="postgres",
+        password="postgres",
+        database="postgres",
+        schema_name="airbyte_raw",
+    )
+
+    processor = PostgresSqlProcessor(
+        catalog_provider=CatalogProvider(source.configured_catalog),
+        temp_dir=Path(),
+        temp_file_cleanup=True,
+        sql_config=config,
+    )
+
+    with (
+        patch.object(processor, "_execute_sql") as _execute_sql_mock,
+        patch.object(
+            processor, "_table_exists", return_value=False
+        ) as _table_exists_mock,
+    ):
+        processor._ensure_final_table_exists(
+            stream_name="products",
+        )
+        _execute_sql_mock.assert_called_with(expected_sql)
 
 
 def _build_mocked_snowflake_processor(

--- a/tests/unit_tests/test_processors.py
+++ b/tests/unit_tests/test_processors.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest_mock
 from airbyte._processors.sql.postgres import PostgresConfig, PostgresSqlProcessor
-from airbyte.caches.postgres import PostgresCache
 from airbyte.caches.snowflake import SnowflakeConfig, SnowflakeSqlProcessor
 from airbyte.secrets.base import SecretString
 from airbyte.shared.catalog_providers import CatalogProvider

--- a/tests/unit_tests/test_processors.py
+++ b/tests/unit_tests/test_processors.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
-from unittest.mock import patch
-
 import pytest_mock
-from airbyte._processors.sql.postgres import PostgresConfig, PostgresSqlProcessor
-from airbyte.caches.snowflake import SnowflakeConfig, SnowflakeSqlProcessor
+from airbyte.caches.snowflake import SnowflakeSqlProcessor, SnowflakeConfig
+from airbyte_protocol.models import ConfiguredAirbyteCatalog
 from airbyte.secrets.base import SecretString
 from airbyte.shared.catalog_providers import CatalogProvider
-from airbyte.sources.util import get_source
-from airbyte_protocol.models import ConfiguredAirbyteCatalog
 
 
 def test_snowflake_cache_config_data_retention_time_in_days(
@@ -53,54 +49,6 @@ def test_snowflake_cache_config_no_data_retention_time_in_days(
     config._create_table(table_name="table_name", column_definition_str="col_name type")
 
     assert actual_cmd == expected_cmd
-
-
-def test_postgres_cache_config_generates_timestamps_with_timezone_settings():
-    expected_sql = """
-        CREATE TABLE airbyte_raw."products" (
-            "id" BIGINT,
-  "make" VARCHAR,
-  "model" VARCHAR,
-  "year" BIGINT,
-  "price" DECIMAL(38, 9),
-  "created_at" TIMESTAMP WITH TIME ZONE,
-  "updated_at" TIMESTAMP WITH TIME ZONE,
-  "_airbyte_raw_id" VARCHAR,
-  "_airbyte_extracted_at" TIMESTAMP WITH TIME ZONE,
-  "_airbyte_meta" JSON
-        )
-        \n        """
-    source = get_source(
-        name="source-faker",
-        config={},
-    )
-
-    config = PostgresConfig(
-        host="localhost",
-        port=5432,
-        username="postgres",
-        password="postgres",
-        database="postgres",
-        schema_name="airbyte_raw",
-    )
-
-    processor = PostgresSqlProcessor(
-        catalog_provider=CatalogProvider(source.configured_catalog),
-        temp_dir=Path(),
-        temp_file_cleanup=True,
-        sql_config=config,
-    )
-
-    with (
-        patch.object(processor, "_execute_sql") as _execute_sql_mock,
-        patch.object(
-            processor, "_table_exists", return_value=False
-        ) as _table_exists_mock,
-    ):
-        processor._ensure_final_table_exists(
-            stream_name="products",
-        )
-        _execute_sql_mock.assert_called_with(expected_sql)
 
 
 def _build_mocked_snowflake_processor(

--- a/tests/unit_tests/test_type_translation.py
+++ b/tests/unit_tests/test_type_translation.py
@@ -25,7 +25,7 @@ from sqlalchemy import types
                 "format": "date-time",
                 "airbyte_type": "timestamp_without_timezone",
             },
-            types.TIMESTAMP,
+            types.TIMESTAMP(timezone=False),
         ),
         (
             {
@@ -33,7 +33,7 @@ from sqlalchemy import types
                 "format": "date-time",
                 "airbyte_type": "timestamp_with_timezone",
             },
-            types.TIMESTAMP,
+            types.TIMESTAMP(timezone=True),
         ),
         (
             {
@@ -68,7 +68,11 @@ from sqlalchemy import types
 def test_to_sql_type(json_schema_property_def, expected_sql_type):
     converter = SQLTypeConverter()
     sql_type = converter.to_sql_type(json_schema_property_def)
-    assert isinstance(sql_type, expected_sql_type)
+    if isinstance(expected_sql_type, types.TIMESTAMP):
+        assert isinstance(sql_type, types.TIMESTAMP)
+        assert sql_type.timezone == expected_sql_type.timezone
+    else:
+        assert isinstance(sql_type, expected_sql_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PyAirbyte documentation recommends using the `cache` instead of the docker based destinations.

While testing the PostgresCache, I found that timestamps were created without timezone information. 

This PR adds timezone information where possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datetime columns in created tables are timezone-aware by default.
  * SQL type generation is now dialect-aware, producing CREATE TABLE definitions tailored to each database.

* **Bug Fixes**
  * Corrected mapping for timestamp types with/without timezone to ensure consistent schema generation and caching columns.

* **Tests**
  * Added and updated unit and integration tests validating timezone-aware timestamps and dialect-specific SQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->