### PR TITLE
docs: recommend uvx with airbyte@latest and --python flag for MCP setup

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -67,15 +67,20 @@ Note:
 First install `uv` (`brew install uv`).
 
 Then, create a file named `server_config.json` (or the file name required by your MCP client)
-with the following content, using `uvx` with version pinning to ensure you always get the
-latest stable release:
+with the following content. This uses `uvx` (`brew install uv`) to run the MCP
+server, including a stable `uv`-managed Python version and auto-updating to the
+latest Airbyte MCP release:
 
 ```json
 {
   "mcpServers": {
     "airbyte": {
       "command": "uvx",
-      "args": ["--python=3.11", "--from=airbyte@latest", "airbyte-mcp"],
+      "args": [
+        "--python=3.11",
+        "--from=airbyte@latest",
+        "airbyte-mcp"
+      ],
       "env": {
         "AIRBYTE_MCP_ENV_FILE": "/path/to/my/.mcp/airbyte_mcp.env"
       }
@@ -84,9 +89,6 @@ latest stable release:
 }
 ```
 
-Alternatively, if you prefer to pre-install (though `uvx` with `airbyte@latest` is
-recommended for automatic updates), first run `uv tool install airbyte` or
-`pipx install airbyte`, and then create the configuration file as follows:
 
 ```json
 {

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -69,7 +69,10 @@ First install `uv` (`brew install uv`).
 Then, create a file named `server_config.json` (or the file name required by your MCP client)
 with the following content. This uses `uvx` (from `brew install uv`) to run the MCP
 server. If a matching version Python is not yet installed, a `uv`-managed Python 
-version will be installed. This will also auto-update to use the "latest" Airbyte MCP release at time of launch.
+version will be installed automatically. This will also auto-update to use the
+"latest" Airbyte MCP release at time of launch. You can alternatively pin to a 
+specific version of Python and/or of the Airbyte library if you have special 
+requirements.
 
 ```json
 {

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -67,14 +67,15 @@ Note:
 First install `uv` (`brew install uv`).
 
 Then, create a file named `server_config.json` (or the file name required by your MCP client)
-with the following content:
+with the following content, using `uvx` with version pinning to ensure you always get the
+latest stable release:
 
 ```json
 {
   "mcpServers": {
     "airbyte": {
       "command": "uvx",
-      "args": ["--from=airbyte", "airbyte-mcp"],
+      "args": ["--python=3.11", "--from=airbyte@latest", "airbyte-mcp"],
       "env": {
         "AIRBYTE_MCP_ENV_FILE": "/path/to/my/.mcp/airbyte_mcp.env"
       }
@@ -83,8 +84,9 @@ with the following content:
 }
 ```
 
-If you prefer to pre-install, first run `uv install airbyte` or `pipx install airbyte`,
-and then create the configuration file as follows:
+Alternatively, if you prefer to pre-install (though `uvx` with `airbyte@latest` is
+recommended for automatic updates), first run `uv tool install airbyte` or
+`pipx install airbyte`, and then create the configuration file as follows:
 
 ```json
 {

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -67,9 +67,9 @@ Note:
 First install `uv` (`brew install uv`).
 
 Then, create a file named `server_config.json` (or the file name required by your MCP client)
-with the following content. This uses `uvx` (`brew install uv`) to run the MCP
-server, including a stable `uv`-managed Python version and auto-updating to the
-latest Airbyte MCP release:
+with the following content. This uses `uvx` (from `brew install uv`) to run the MCP
+server. If a matching version Python is not yet installed, a `uv`-managed Python 
+version will be installed. This will also auto-update to use the "latest" Airbyte MCP release at time of launch.
 
 ```json
 {

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -68,10 +68,10 @@ First install `uv` (`brew install uv`).
 
 Then, create a file named `server_config.json` (or the file name required by your MCP client)
 with the following content. This uses `uvx` (from `brew install uv`) to run the MCP
-server. If a matching version Python is not yet installed, a `uv`-managed Python 
+server. If a matching version Python is not yet installed, a `uv`-managed Python
 version will be installed automatically. This will also auto-update to use the
-"latest" Airbyte MCP release at time of launch. You can alternatively pin to a 
-specific version of Python and/or of the Airbyte library if you have special 
+"latest" Airbyte MCP release at time of launch. You can alternatively pin to a
+specific version of Python and/or of the Airbyte library if you have special
 requirements.
 
 ```json
@@ -92,6 +92,9 @@ requirements.
 }
 ```
 
+Alternatively, if you prefer to pre-install (though `uvx` with `airbyte@latest` is
+recommended for automatic updates), first run `uv tool install airbyte` or
+`pipx install airbyte`, and then create the configuration file as follows:
 
 ```json
 {


### PR DESCRIPTION
# docs: recommend uvx with airbyte@latest and --python flag for MCP setup

## Summary
Updates PyAirbyte MCP documentation to recommend using `uvx` with version pinning (`airbyte@latest`) and explicit Python version specification (`--python=3.11`). This ensures users always get the latest stable release and can use a compatible Python version even if their system Python differs.

**Key changes:**
- Primary MCP config example now uses `uvx --python=3.11 --from=airbyte@latest airbyte-mcp`
- Added explanatory text about version pinning for latest stable releases
- Reworded pre-install alternative to emphasize uvx is recommended for automatic updates
- Fixed line length compliance issues

## Review & Testing Checklist for Human
- [ ] **Test uvx command syntax** - Verify `uvx --python=3.11 --from=airbyte@latest airbyte-mcp` actually works and starts the MCP server correctly
- [ ] **Validate Python version choice** - Confirm Python 3.11 is appropriate (PyAirbyte supports 3.10-3.12, I chose 3.11 as middle ground)
- [ ] **Test MCP client integration** - Ensure the updated configuration works with actual MCP clients (Claude Desktop, etc.)

### Notes
- This change only affects documentation, no code changes
- Existing users with pre-installed setups should continue working unchanged
- The `@latest` syntax ensures users get updates automatically vs being pinned to old versions

**Link to Devin run:** https://app.devin.ai/sessions/10d9f92c120641dcb5f5cdb281484a6a  
**Requested by:** @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Recommend running the MCP server with uvx using Python 3.11 and airbyte@latest for uv-managed Python and automatic MCP updates.
  * Updated example invocation and clarified version-pinning and automatic-update behavior.
  * Replaced prior separate uv/pipx pre-install guidance with streamlined uvx-based setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._