### PR TITLE
chore: bump airbyte-api to 0.53.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "airbyte-api"
-version = "0.52.2"
+version = "0.53.0"
 description = "Python Client SDK for Airbyte API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "airbyte-api-0.52.2.tar.gz", hash = "sha256:0abd4570083352cad9c23d1f6f59f288aeecca84d85746018d41de9c531aa852"},
-    {file = "airbyte_api-0.52.2-py3-none-any.whl", hash = "sha256:d08ee620e8dc9b85e3f167087225a7867702aa3cf1a06d8b42eb48a48e64382d"},
+    {file = "airbyte-api-0.53.0.tar.gz", hash = "sha256:f054ed170f9a691c3304e93a5212670fd2a38e5debb667c72d5ef8eb89cf7e9d"},
+    {file = "airbyte_api-0.53.0-py3-none-any.whl", hash = "sha256:0bd86d5122789a7c97115a4b52ce492b013d0ea8eeab597b6495b0b310332f28"},
 ]
 
 [package.dependencies]
@@ -6022,4 +6022,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "ea17fb2ea89208b551a2fc6ded0bad9966597ff65ba027f622c4b5ed544b2fa4"
+content-hash = "f2853e586cee0d7b884a76084c3e582accadb324e0a035c33181f9148e375731"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ enable = true
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 
-airbyte-api = "^0.52.1"
+airbyte-api = "^0.53.0"
 airbyte-cdk = ">=6.61.6,<7.0.0"
 airbyte-protocol-models-pdv2 = "^0.13.0"
 click = "^8.1.7"


### PR DESCRIPTION
# chore: bump airbyte-api to 0.53.0

## Summary

Updates the `airbyte-api` dependency from `^0.52.1` to `^0.53.0` to include the latest SDK features:

- ✅ v1.6 custom connector endpoints (DeclarativeSourceDefinitions, SourceDefinitions, DestinationDefinitions)
- ✅ Missing `full_refresh_overwrite_deduped` enum value in `ConnectionSyncModeEnum`
- ✅ Latest connector catalog and API improvements

**Changes:**
- Updated `airbyte-api = "^0.53.0"` in pyproject.toml
- Refreshed poetry.lock with new dependency versions
- Verified static checks pass (lint, type check, test collection)

## Review & Testing Checklist for Human

- [ ] **Run full test suite** - especially integration tests that use airbyte-api SDK
- [ ] **Test key PyAirbyte workflows** - verify source/destination operations, syncs, and connector management work correctly
- [ ] **Verify v1.6 custom connector features** - test creating/managing custom Docker and YAML connectors if possible

### Notes

This dependency bump enables PyAirbyte to use the latest Airbyte API features. Static analysis passes cleanly, but runtime testing is important to ensure the new SDK version doesn't introduce behavioral changes.

Requested by: AJ Steers (@aaronsteers)  
Devin session: https://app.devin.ai/sessions/42d70f0eaebd4b86902767fbadcc9e95

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the Airbyte API client dependency to version ^0.53.0 to align with upstream updates and maintain compatibility.

* Impact
  * No user-facing changes; existing features and workflows remain unaffected.
  * This maintenance update helps ensure continued compatibility with upstream services.

* Action Required
  * None. Users do not need to modify settings or update configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->