### PR TITLE
feat: Add support for publishing custom connector definitions

### DIFF
--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -501,6 +501,267 @@ def list_deployed_cloud_connections() -> list[CloudConnection]:
     return workspace.list_connections()
 
 
+def publish_custom_yaml_source_definition(
+    name: Annotated[
+        str,
+        Field(description="The name for the custom connector definition."),
+    ],
+    manifest: Annotated[
+        dict | str,
+        Field(
+            description=(
+                "The Low-code CDK manifest as a dict or YAML string. "
+                "Must be a valid declarative YAML connector manifest."
+            ),
+        ),
+    ],
+    *,
+    unique: Annotated[
+        bool,
+        Field(
+            description="Whether to require a unique name.",
+            default=True,
+        ),
+    ] = True,
+    pre_validate: Annotated[
+        bool,
+        Field(
+            description="Whether to validate the manifest client-side before publishing.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Publish a custom YAML source connector definition to Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.publish_custom_yaml_source(
+            name=name,
+            manifest=manifest,
+            unique=unique,
+            pre_validate=pre_validate,
+        )
+    except Exception as ex:
+        return f"Failed to publish custom YAML source definition '{name}': {ex}"
+    else:
+        return (
+            f"Successfully published custom YAML source definition '{name}' "
+            f"with ID '{result['id']}' (version {result.get('version', 'N/A')})"
+        )
+
+
+def list_custom_yaml_source_definitions() -> list[dict[str, Any]]:
+    """List all custom YAML source definitions in the Airbyte Cloud workspace."""
+    workspace: CloudWorkspace = _get_cloud_workspace()
+    return workspace.list_custom_yaml_sources()
+
+
+def update_custom_yaml_source_definition(
+    definition_id: Annotated[
+        str,
+        Field(description="The ID of the definition to update."),
+    ],
+    manifest: Annotated[
+        dict | str,
+        Field(
+            description="New manifest as dict or YAML string.",
+        ),
+    ],
+    *,
+    pre_validate: Annotated[
+        bool,
+        Field(
+            description="Whether to validate the manifest client-side before updating.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Update a custom YAML source definition in Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.update_custom_yaml_source(
+            definition_id=definition_id,
+            manifest=manifest,
+            pre_validate=pre_validate,
+        )
+    except Exception as ex:
+        return f"Failed to update custom YAML source definition '{definition_id}': {ex}"
+    else:
+        return (
+            f"Successfully updated custom YAML source definition. "
+            f"New name: {result.get('name')}, version: {result.get('version', 'N/A')}"
+        )
+
+
+def publish_custom_docker_source_definition(
+    name: Annotated[
+        str,
+        Field(description="The name for the custom connector definition."),
+    ],
+    docker_repository: Annotated[
+        str,
+        Field(description="Docker repository (e.g., 'airbyte/source-custom')."),
+    ],
+    docker_image_tag: Annotated[
+        str,
+        Field(description="Docker image tag (e.g., '1.0.0')."),
+    ],
+    *,
+    documentation_url: Annotated[
+        str | None,
+        Field(
+            description="Optional URL to connector documentation.",
+            default=None,
+        ),
+    ] = None,
+    unique: Annotated[
+        bool,
+        Field(
+            description="Whether to require a unique name.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Publish a custom Docker source connector definition to Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.publish_custom_docker_source(
+            name=name,
+            docker_repository=docker_repository,
+            docker_image_tag=docker_image_tag,
+            documentation_url=documentation_url,
+            unique=unique,
+        )
+    except Exception as ex:
+        return f"Failed to publish custom Docker source definition '{name}': {ex}"
+    else:
+        return (
+            f"Successfully published custom Docker source definition '{name}' "
+            f"with ID '{result['id']}' ({result['docker_repository']}:{result['docker_image_tag']})"
+        )
+
+
+def list_custom_docker_source_definitions() -> list[dict[str, Any]]:
+    """List all custom Docker source definitions in the Airbyte Cloud workspace."""
+    workspace: CloudWorkspace = _get_cloud_workspace()
+    return workspace.list_custom_docker_sources()
+
+
+def update_custom_docker_source_definition(
+    definition_id: Annotated[
+        str,
+        Field(description="The ID of the definition to update."),
+    ],
+    name: Annotated[
+        str,
+        Field(description="New name for the definition."),
+    ],
+    docker_image_tag: Annotated[
+        str,
+        Field(description="New Docker image tag."),
+    ],
+) -> str:
+    """Update a custom Docker source definition in Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.update_custom_docker_source(
+            definition_id=definition_id,
+            name=name,
+            docker_image_tag=docker_image_tag,
+        )
+    except Exception as ex:
+        return f"Failed to update custom Docker source definition '{definition_id}': {ex}"
+    else:
+        return (
+            f"Successfully updated custom Docker source definition. "
+            f"New name: {result.get('name')}, tag: {result.get('docker_image_tag')}"
+        )
+
+
+def publish_custom_docker_destination_definition(
+    name: Annotated[
+        str,
+        Field(description="The name for the custom connector definition."),
+    ],
+    docker_repository: Annotated[
+        str,
+        Field(description="Docker repository (e.g., 'airbyte/destination-custom')."),
+    ],
+    docker_image_tag: Annotated[
+        str,
+        Field(description="Docker image tag (e.g., '1.0.0')."),
+    ],
+    *,
+    documentation_url: Annotated[
+        str | None,
+        Field(
+            description="Optional URL to connector documentation.",
+            default=None,
+        ),
+    ] = None,
+    unique: Annotated[
+        bool,
+        Field(
+            description="Whether to require a unique name.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Publish a custom Docker destination connector definition to Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.publish_custom_docker_destination(
+            name=name,
+            docker_repository=docker_repository,
+            docker_image_tag=docker_image_tag,
+            documentation_url=documentation_url,
+            unique=unique,
+        )
+    except Exception as ex:
+        return f"Failed to publish custom Docker destination definition '{name}': {ex}"
+    else:
+        return (
+            f"Successfully published custom Docker destination definition '{name}' "
+            f"with ID '{result['id']}' ({result['docker_repository']}:{result['docker_image_tag']})"
+        )
+
+
+def list_custom_docker_destination_definitions() -> list[dict[str, Any]]:
+    """List all custom Docker destination definitions in the Airbyte Cloud workspace."""
+    workspace: CloudWorkspace = _get_cloud_workspace()
+    return workspace.list_custom_docker_destinations()
+
+
+def update_custom_docker_destination_definition(
+    definition_id: Annotated[
+        str,
+        Field(description="The ID of the definition to update."),
+    ],
+    name: Annotated[
+        str,
+        Field(description="New name for the definition."),
+    ],
+    docker_image_tag: Annotated[
+        str,
+        Field(description="New Docker image tag."),
+    ],
+) -> str:
+    """Update a custom Docker destination definition in Airbyte Cloud."""
+    try:
+        workspace: CloudWorkspace = _get_cloud_workspace()
+        result = workspace.update_custom_docker_destination(
+            definition_id=definition_id,
+            name=name,
+            docker_image_tag=docker_image_tag,
+        )
+    except Exception as ex:
+        return f"Failed to update custom Docker destination definition '{definition_id}': {ex}"
+    else:
+        return (
+            f"Successfully updated custom Docker destination definition. "
+            f"New name: {result.get('name')}, tag: {result.get('docker_image_tag')}"
+        )
+
+
 def register_cloud_ops_tools(app: FastMCP) -> None:
     """@private Register tools with the FastMCP app.
 
@@ -517,3 +778,12 @@ def register_cloud_ops_tools(app: FastMCP) -> None:
     app.tool(list_deployed_cloud_source_connectors)
     app.tool(list_deployed_cloud_destination_connectors)
     app.tool(list_deployed_cloud_connections)
+    app.tool(publish_custom_yaml_source_definition)
+    app.tool(list_custom_yaml_source_definitions)
+    app.tool(update_custom_yaml_source_definition)
+    app.tool(publish_custom_docker_source_definition)
+    app.tool(list_custom_docker_source_definitions)
+    app.tool(update_custom_docker_source_definition)
+    app.tool(publish_custom_docker_destination_definition)
+    app.tool(list_custom_docker_destination_definitions)
+    app.tool(update_custom_docker_destination_definition)

--- a/tests/integration_tests/cloud/test_custom_definitions.py
+++ b/tests/integration_tests/cloud/test_custom_definitions.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Tests for custom connector definition publishing."""
+
+import pytest
+
+from airbyte.cloud.workspaces import CloudWorkspace
+
+
+TEST_YAML_MANIFEST = {
+    "version": "0.1.0",
+    "type": "DeclarativeSource",
+    "check": {"type": "CheckStream", "stream_names": ["test"]},
+    "streams": [
+        {
+            "type": "DeclarativeStream",
+            "name": "test",
+            "primary_key": [],
+            "retriever": {
+                "type": "SimpleRetriever",
+                "requester": {
+                    "type": "HttpRequester",
+                    "url_base": "https://httpbin.org",
+                    "path": "/get",
+                },
+                "record_selector": {
+                    "type": "RecordSelector",
+                    "extractor": {"type": "DpathExtractor", "field_path": []},
+                },
+            },
+        }
+    ],
+}
+
+
+@pytest.mark.requires_creds
+def test_publish_custom_yaml_source(
+    cloud_workspace: CloudWorkspace,
+) -> None:
+    """Test publishing a custom YAML source definition."""
+    from airbyte._util import text_util
+
+    name = f"test-yaml-source-{text_util.generate_random_suffix()}"
+
+    result = cloud_workspace.publish_custom_yaml_source(
+        name=name,
+        manifest=TEST_YAML_MANIFEST,
+        unique=True,
+        pre_validate=True,
+    )
+
+    assert "id" in result
+    assert result["name"] == name
+    assert "manifest" in result
+    assert "version" in result
+
+    definition_id = result["id"]
+
+    try:
+        definitions = cloud_workspace.list_custom_yaml_sources(name=name)
+        assert len(definitions) == 1
+        assert definitions[0]["id"] == definition_id
+
+        fetched = cloud_workspace.get_custom_yaml_source(definition_id)
+        assert fetched["id"] == definition_id
+        assert fetched["name"] == name
+
+        updated_manifest = TEST_YAML_MANIFEST.copy()
+        updated_manifest["version"] = "0.2.0"
+        updated = cloud_workspace.update_custom_yaml_source(
+            definition_id=definition_id,
+            manifest=updated_manifest,
+        )
+        assert updated["manifest"]["version"] == "0.2.0"
+
+    finally:
+        cloud_workspace.delete_custom_yaml_source(definition_id)
+
+
+@pytest.mark.requires_creds
+def test_publish_custom_docker_source(
+    cloud_workspace: CloudWorkspace,
+) -> None:
+    """Test publishing a custom Docker source definition."""
+    from airbyte._util import text_util
+
+    name = f"test-docker-source-{text_util.generate_random_suffix()}"
+
+    result = cloud_workspace.publish_custom_docker_source(
+        name=name,
+        docker_repository="airbyte/test-source",
+        docker_image_tag="1.0.0",
+        documentation_url="https://example.com/docs",
+        unique=True,
+    )
+
+    assert "id" in result
+    assert result["name"] == name
+    assert result["docker_repository"] == "airbyte/test-source"
+    assert result["docker_image_tag"] == "1.0.0"
+
+    definition_id = result["id"]
+
+    try:
+        definitions = cloud_workspace.list_custom_docker_sources(name=name)
+        assert len(definitions) == 1
+        assert definitions[0]["id"] == definition_id
+
+        fetched = cloud_workspace.get_custom_docker_source(definition_id)
+        assert fetched["id"] == definition_id
+        assert fetched["name"] == name
+
+        updated = cloud_workspace.update_custom_docker_source(
+            definition_id=definition_id,
+            name=name,
+            docker_image_tag="2.0.0",
+        )
+        assert updated["docker_image_tag"] == "2.0.0"
+
+    finally:
+        cloud_workspace.delete_custom_docker_source(definition_id)
+
+
+@pytest.mark.requires_creds
+def test_publish_custom_docker_destination(
+    cloud_workspace: CloudWorkspace,
+) -> None:
+    """Test publishing a custom Docker destination definition."""
+    from airbyte._util import text_util
+
+    name = f"test-docker-dest-{text_util.generate_random_suffix()}"
+
+    result = cloud_workspace.publish_custom_docker_destination(
+        name=name,
+        docker_repository="airbyte/test-destination",
+        docker_image_tag="1.0.0",
+        unique=True,
+    )
+
+    assert "id" in result
+    assert result["name"] == name
+    assert result["docker_repository"] == "airbyte/test-destination"
+    assert result["docker_image_tag"] == "1.0.0"
+
+    definition_id = result["id"]
+
+    try:
+        definitions = cloud_workspace.list_custom_docker_destinations(name=name)
+        assert len(definitions) == 1
+        assert definitions[0]["id"] == definition_id
+
+        fetched = cloud_workspace.get_custom_docker_destination(definition_id)
+        assert fetched["id"] == definition_id
+        assert fetched["name"] == name
+
+        updated = cloud_workspace.update_custom_docker_destination(
+            definition_id=definition_id,
+            name=name,
+            docker_image_tag="2.0.0",
+        )
+        assert updated["docker_image_tag"] == "2.0.0"
+
+    finally:
+        cloud_workspace.delete_custom_docker_destination(definition_id)
+
+
+@pytest.mark.requires_creds
+def test_yaml_validation_error(
+    cloud_workspace: CloudWorkspace,
+) -> None:
+    """Test that validation catches invalid manifests."""
+    from airbyte._util import text_util
+    from airbyte.exceptions import PyAirbyteInputError
+
+    name = f"test-invalid-{text_util.generate_random_suffix()}"
+    invalid_manifest = {"version": "0.1.0"}
+
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        cloud_workspace.publish_custom_yaml_source(
+            name=name,
+            manifest=invalid_manifest,
+            pre_validate=True,
+        )
+
+    assert "type" in str(exc_info.value).lower()


### PR DESCRIPTION
# feat: Add support for publishing custom connector definitions

## Summary

Implements PyAirbyte support for publishing custom connector definitions using new Airbyte 1.6 API endpoints, enabling users to create YAML connectors without Docker builds and register custom Docker images.

**Added Support for 3 Definition Types:**
- **YAML Source Definitions**: Publish Low-code CDK manifests directly (no Docker build required)
- **Docker Source Definitions**: Register custom Docker source connector images  
- **Docker Destination Definitions**: Register custom Docker destination connector images

**Implementation Details:**
- **15 new API functions** in `api_util.py` for full CRUD operations (create, list, get, update, delete)
- **15 new CloudWorkspace methods** with client-side YAML validation (`pre_validate=True` by default)
- **9 new MCP tools** for publish/list/update operations across all 3 definition types
- **Comprehensive integration tests** covering all CRUD operations and error handling
- Uses **airbyte-api 0.53.0** with new `declarative_source_definitions`, `source_definitions`, `destination_definitions` endpoints

**Usage Examples:**
```python
# Python API - YAML Source
workspace.publish_custom_yaml_source(
    name="my-custom-source",
    manifest={"version": "0.1.0", "type": "DeclarativeSource", ...},
    pre_validate=True
)

# Python API - Docker Source  
workspace.publish_custom_docker_source(
    name="my-docker-source",
    docker_repository="myorg/custom-source",
    docker_image_tag="1.0.0"
)
```

## Review & Testing Checklist for Human

**🔴 High Risk - 5 items to verify:**

- [ ] **End-to-end MCP tool testing**: Test all 9 MCP tools with real YAML manifests and actual Docker images (not just the test data used in integration tests)
- [ ] **Authentication verification**: Confirm Airbyte Cloud authentication works correctly across different environments and credential configurations  
- [ ] **API error handling validation**: Test edge cases like network failures, invalid workspace IDs, malformed API responses to ensure error handling is robust
- [ ] **YAML validation logic review**: Verify the client-side manifest validation in `validate_yaml_manifest()` catches common errors but isn't overly restrictive for valid manifests
- [ ] **New API surface consistency**: Review method signatures, parameter naming, and return types across the 39 new functions/methods for consistency with existing PyAirbyte patterns

### Notes

- **Airbyte 1.6 Dependency**: This feature requires Airbyte 1.6+ API endpoints and airbyte-api SDK 0.53.0+
- **Integration Tests**: Tests are marked `@pytest.mark.requires_creds` and only run with valid Airbyte Cloud credentials
- **CLI Support Deferred**: CLI commands for these operations will be considered in a future issue after this PR merges
- **API Documentation**: [Airbyte 1.6 Release Notes](https://docs.airbyte.com/release_notes/v-1.6) | [API Reference](https://reference.airbyte.com/reference/createdeclarativesourcedefinition)

**Requested by:** @aaronsteers  
**Devin session:** https://app.devin.ai/sessions/7733e25275f44008ab6cb765d4ef5106