### PR TITLE
feat: Add `time_to_first_record` metric and adjusted performance stats

### DIFF
--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -105,6 +105,9 @@ class ProgressStyle(Enum):
 MAX_UPDATE_FREQUENCY = 5_000
 """The max number of records to read before updating the progress bar."""
 
+TIME_TO_FIRST_RECORD_THRESHOLD_SECONDS = 10
+"""Threshold for time_to_first_record above which adjusted metrics are calculated."""
+
 
 def _to_time_str(timestamp: float) -> str:
     """Convert a timestamp float to a local time string.
@@ -191,6 +194,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         # Stream reads
         self.stream_read_counts: dict[str, int] = defaultdict(int)
         self.stream_read_start_times: dict[str, float] = {}
+        self.stream_first_record_times: dict[str, float] = {}
         self.stream_read_end_times: dict[str, float] = {}
         self.stream_bytes_read: dict[str, int] = defaultdict(int)
 
@@ -277,6 +281,9 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
 
                     if message.record.stream not in self.stream_read_start_times:
                         self.log_stream_start(stream_name=message.record.stream)
+
+                    if message.record.stream not in self.stream_first_record_times:
+                        self.stream_first_record_times[message.record.stream] = time.time()
 
             elif message.trace and message.trace.stream_status:
                 if message.trace.stream_status.status is AirbyteStreamStatus.STARTED:
@@ -470,9 +477,36 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
 
         return job_info
 
+    def _calculate_adjusted_metrics(
+        self,
+        stream_name: str,
+        count: int,
+        time_to_first_record: float,
+        mb_read: float,
+    ) -> dict[str, float]:
+        """Calculate adjusted performance metrics when time_to_first_record exceeds threshold."""
+        adjusted_metrics = {}
+        if (
+            time_to_first_record > TIME_TO_FIRST_RECORD_THRESHOLD_SECONDS
+            and stream_name in self.stream_first_record_times
+            and stream_name in self.stream_read_end_times
+        ):
+            adjusted_duration = (
+                self.stream_read_end_times[stream_name]
+                - self.stream_first_record_times[stream_name]
+            )
+            if adjusted_duration > 0:
+                adjusted_metrics["records_per_second_adjusted"] = round(
+                    count / adjusted_duration, 4
+                )
+                if self.bytes_tracking_enabled:
+                    adjusted_metrics["mb_per_second_adjusted"] = round(
+                        mb_read / adjusted_duration, 4
+                    )
+        return adjusted_metrics
+
     def _log_read_metrics(self) -> None:
         """Log read performance metrics."""
-        # Source performance metrics
         if not self.total_records_read or not self._file_logger:
             return
 
@@ -502,6 +536,18 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
                 "read_start_time": self.stream_read_start_times.get(stream_name),
                 "read_end_time": self.stream_read_end_times.get(stream_name),
             }
+
+            time_to_first_record = None
+            if (
+                stream_name in self.stream_first_record_times
+                and stream_name in self.stream_read_start_times
+            ):
+                time_to_first_record = (
+                    self.stream_first_record_times[stream_name]
+                    - self.stream_read_start_times[stream_name]
+                )
+                stream_metrics[stream_name]["time_to_first_record"] = time_to_first_record
+
             if (
                 stream_name in self.stream_read_end_times
                 and stream_name in self.stream_read_start_times
@@ -525,6 +571,12 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
                         mb_read = self.stream_bytes_read[stream_name] / 1_000_000
                         stream_metrics[stream_name]["mb_read"] = mb_read
                         stream_metrics[stream_name]["mb_per_second"] = round(mb_read / duration, 4)
+
+                    if time_to_first_record is not None:
+                        adjusted_metrics = self._calculate_adjusted_metrics(
+                            stream_name, count, time_to_first_record, mb_read
+                        )
+                        stream_metrics[stream_name].update(adjusted_metrics)
 
         perf_metrics["stream_metrics"] = stream_metrics
         log_dict["performance_metrics"] = perf_metrics


### PR DESCRIPTION
# feat: Add time_to_first_record metric and adjusted performance stats

## Summary

Adds `time_to_first_record` tracking per stream to help distinguish between connector initialization latency and actual data processing speed. When the time to first record exceeds 10 seconds, additional adjusted throughput metrics (`records_per_second_adjusted`, `mb_per_second_adjusted`) are calculated using the first-record timestamp instead of the stream-start timestamp.

**Key changes:**
- Track `stream_first_record_times` dict alongside existing `stream_read_start_times`
- Calculate `time_to_first_record` = first_record_time - stream_start_time 
- Add conditional adjusted metrics when time_to_first_record > 10 seconds
- Existing metrics (`records_per_second`, `mb_per_second`) remain unchanged

**Example output:**
```json
"stream_metrics": {
  "users": {
    "records_read": 1000,
    "time_to_first_record": 15.2,
    "records_per_second": 45.2,
    "records_per_second_adjusted": 67.8,
    "mb_per_second": 2.1,
    "mb_per_second_adjusted": 3.1
  }
}
```

## Review & Testing Checklist for Human

- [ ] **Verify timing logic correctness**: Test with real connectors to ensure `time_to_first_record` values make sense and adjusted metrics only appear when threshold exceeded
- [ ] **Test edge cases**: Verify behavior with very fast/slow connectors, missing timestamps, streams that fail before producing records
- [ ] **Validate performance impact**: Monitor that additional timestamp tracking doesn't measurably slow down record processing  
- [ ] **Check metric format**: Confirm new metrics integrate properly with existing logging infrastructure and downstream consumers

### Notes

Requested by AJ Steers (@aaronsteers) in Devin session: https://app.devin.ai/sessions/c77d07731aad483da4af06da3058d26e

The 10-second threshold was chosen as the point where initialization delay becomes significant enough to warrant adjusted throughput calculations. All existing unit tests pass, but this PR would benefit from integration testing with real connectors to validate the timing logic works correctly in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-stream “time to first record” tracking.
  - Introduced adjusted throughput metrics that account for delays before the first record.
  - When byte tracking is enabled, logs include adjusted MB/s alongside existing metrics.

- Improvements
  - More accurate and informative per-stream performance reporting in logs and metrics output.
  - Conditional calculation ensures adjusted metrics appear only when relevant, keeping logs concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**