### PR TITLE
feat: Implement safe mode filtering for Cloud ops tools

### DIFF
--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -24,6 +24,7 @@ from airbyte.mcp._annotations import (
     READ_ONLY_HINT,
 )
 from airbyte.mcp._util import resolve_config, resolve_list_of_strings
+from airbyte.mcp.safe_mode import enforce_cloud_safe_mode
 
 
 def _get_cloud_workspace() -> CloudWorkspace:
@@ -691,115 +692,135 @@ def register_cloud_ops_tools(app: FastMCP) -> None:
 
     This is an internal function and should not be called directly.
     """
+    check_workspace_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    deploy_source_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    deploy_destination_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    deploy_noop_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    create_connection_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    run_sync_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    get_sync_status_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    get_sync_logs_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    list_sources_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    list_destinations_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    list_connections_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    publish_custom_annotations = {
+        DESTRUCTIVE_HINT: False,
+    }
+    list_custom_annotations = {
+        READ_ONLY_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+    update_custom_annotations = {
+        DESTRUCTIVE_HINT: True,
+    }
+    delete_custom_annotations = {
+        DESTRUCTIVE_HINT: True,
+        IDEMPOTENT_HINT: True,
+    }
+
     app.tool(
-        check_airbyte_cloud_workspace,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(check_workspace_annotations)(check_airbyte_cloud_workspace),
+        annotations=check_workspace_annotations,
     )
 
     app.tool(
-        deploy_source_to_cloud,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(deploy_source_annotations)(deploy_source_to_cloud),
+        annotations=deploy_source_annotations,
     )
 
     app.tool(
-        deploy_destination_to_cloud,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(deploy_destination_annotations)(deploy_destination_to_cloud),
+        annotations=deploy_destination_annotations,
     )
 
     app.tool(
-        deploy_noop_destination_to_cloud,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(deploy_noop_annotations)(deploy_noop_destination_to_cloud),
+        annotations=deploy_noop_annotations,
     )
 
     app.tool(
-        create_connection_on_cloud,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(create_connection_annotations)(create_connection_on_cloud),
+        annotations=create_connection_annotations,
     )
 
     app.tool(
-        run_cloud_sync,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(run_sync_annotations)(run_cloud_sync),
+        annotations=run_sync_annotations,
     )
 
     app.tool(
-        get_cloud_sync_status,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(get_sync_status_annotations)(get_cloud_sync_status),
+        annotations=get_sync_status_annotations,
     )
 
     app.tool(
-        get_cloud_sync_logs,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(get_sync_logs_annotations)(get_cloud_sync_logs),
+        annotations=get_sync_logs_annotations,
     )
 
     app.tool(
-        list_deployed_cloud_source_connectors,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(list_sources_annotations)(list_deployed_cloud_source_connectors),
+        annotations=list_sources_annotations,
     )
 
     app.tool(
-        list_deployed_cloud_destination_connectors,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(list_destinations_annotations)(
+            list_deployed_cloud_destination_connectors
+        ),
+        annotations=list_destinations_annotations,
     )
 
     app.tool(
-        list_deployed_cloud_connections,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(list_connections_annotations)(list_deployed_cloud_connections),
+        annotations=list_connections_annotations,
     )
 
     app.tool(
-        publish_custom_source_definition,
-        annotations={
-            DESTRUCTIVE_HINT: False,
-        },
+        enforce_cloud_safe_mode(publish_custom_annotations)(publish_custom_source_definition),
+        annotations=publish_custom_annotations,
     )
 
     app.tool(
-        list_custom_source_definitions,
-        annotations={
-            READ_ONLY_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(list_custom_annotations)(list_custom_source_definitions),
+        annotations=list_custom_annotations,
     )
 
     app.tool(
-        update_custom_source_definition,
-        annotations={
-            DESTRUCTIVE_HINT: True,
-        },
+        enforce_cloud_safe_mode(update_custom_annotations)(update_custom_source_definition),
+        annotations=update_custom_annotations,
     )
 
     app.tool(
-        permanently_delete_custom_source_definition,
-        annotations={
-            DESTRUCTIVE_HINT: True,
-            IDEMPOTENT_HINT: True,
-        },
+        enforce_cloud_safe_mode(delete_custom_annotations)(
+            permanently_delete_custom_source_definition
+        ),
+        annotations=delete_custom_annotations,
     )

--- a/airbyte/mcp/safe_mode.py
+++ b/airbyte/mcp/safe_mode.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Safe mode filtering for MCP tools.
+
+This module provides filtering logic to restrict destructive and write operations
+on Cloud resources based on environment variables.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+from airbyte.mcp._annotations import DESTRUCTIVE_HINT, READ_ONLY_HINT
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class SafeModeError(Exception):
+    """Raised when a tool is blocked by safe mode restrictions."""
+
+    pass
+
+
+def is_readonly_mode_enabled() -> bool:
+    """Check if read-only mode is enabled via environment variable.
+
+    Returns:
+        True if AIRBYTE_CLOUD_MCP_READONLY_MODE is set to "1", False otherwise.
+    """
+    return os.environ.get("AIRBYTE_CLOUD_MCP_READONLY_MODE", "").strip() == "1"
+
+
+def is_safe_mode_enabled() -> bool:
+    """Check if safe mode is enabled via environment variable.
+
+    Returns:
+        True if AIRBYTE_CLOUD_MCP_SAFE_MODE is set to "1", False otherwise.
+    """
+    return os.environ.get("AIRBYTE_CLOUD_MCP_SAFE_MODE", "").strip() == "1"
+
+
+def check_cloud_tool_allowed(annotations: dict[str, Any], tool_name: str) -> None:
+    """Check if a Cloud ops tool is allowed to execute based on safe mode settings.
+
+    Args:
+        annotations: Tool annotations dict containing readOnlyHint and destructiveHint
+        tool_name: Name of the tool being checked
+
+    Raises:
+        SafeModeError: If the tool is blocked by safe mode restrictions
+    """
+    readonly_mode = is_readonly_mode_enabled()
+    safe_mode = is_safe_mode_enabled()
+
+    if not readonly_mode and not safe_mode:
+        return
+
+    if readonly_mode:
+        is_readonly = annotations.get(READ_ONLY_HINT, False)
+        if not is_readonly:
+            raise SafeModeError(
+                f"Tool '{tool_name}' is blocked by AIRBYTE_CLOUD_MCP_READONLY_MODE. "
+                f"This tool performs write operations on Cloud resources. "
+                f"To allow write operations, set AIRBYTE_CLOUD_MCP_READONLY_MODE=0 or unset it."
+            )
+
+    if safe_mode:
+        is_destructive = annotations.get(DESTRUCTIVE_HINT, True)  # Default is True per FastMCP
+        if is_destructive:
+            raise SafeModeError(
+                f"Tool '{tool_name}' is blocked by AIRBYTE_CLOUD_MCP_SAFE_MODE. "
+                f"This tool performs destructive operations (updates/deletes) on Cloud resources. "
+                f"To allow destructive operations, set AIRBYTE_CLOUD_MCP_SAFE_MODE=0 or unset it."
+            )
+
+
+def enforce_cloud_safe_mode(annotations: dict[str, Any]) -> Callable[[F], F]:
+    """Decorator to enforce safe mode restrictions on Cloud ops tools.
+
+    Args:
+        annotations: Tool annotations dict containing readOnlyHint and destructiveHint
+
+    Returns:
+        Decorator function that wraps the tool and checks safe mode before execution
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            check_cloud_tool_allowed(annotations, func.__name__)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator


### PR DESCRIPTION
# feat: Implement safe mode filtering for Cloud ops tools

## Summary
Implements server-side filtering for PyAirbyte MCP Cloud operations based on two environment variables:

- `AIRBYTE_CLOUD_MCP_READONLY_MODE=1`: Blocks all write operations on Cloud resources (allows only read-only tools like list/get operations)
- `AIRBYTE_CLOUD_MCP_SAFE_MODE=1`: Blocks destructive operations (updates/deletes) on Cloud resources while allowing non-destructive writes (deploy, create, run syncs)

**Implementation details:**
- Created `airbyte/mcp/safe_mode.py` module with `enforce_cloud_safe_mode` decorator
- Wrapped all 15 Cloud ops tools in `register_cloud_ops_tools()` with safe mode enforcement
- Uses existing MCP annotations (`readOnlyHint`, `destructiveHint`) to determine which tools to block
- Local ops tools are unaffected - restrictions only apply to Cloud operations
- Raises `SafeModeError` with clear error messages when tools are blocked

## Review & Testing Checklist for Human

⚠️ **WARNING: This PR contains untested code. Manual testing is critical before merge.**

- [ ] **Test READONLY_MODE**: Set `AIRBYTE_CLOUD_MCP_READONLY_MODE=1` and verify:
  - Read-only tools (list operations, get sync status/logs) work correctly
  - Write tools (deploy_source_to_cloud, create_connection_on_cloud, run_cloud_sync) are blocked with clear error messages
  
- [ ] **Test SAFE_MODE**: Set `AIRBYTE_CLOUD_MCP_SAFE_MODE=1` and verify:
  - Non-destructive write tools (deploy operations, create connection, run sync) work correctly  
  - Destructive tools (update_custom_source_definition, permanently_delete_custom_source_definition) are blocked with clear error messages
  
- [ ] **Test both modes together**: Set both env vars to "1" and verify expected behavior (readonly mode should block all writes)

- [ ] **Verify local ops unaffected**: Confirm that local ops tools (sync_source_to_cache, run_sql_query, etc.) work normally regardless of these env var settings

- [ ] **Check error messages**: Verify SafeModeError messages are clear and provide guidance on how to disable restrictions

### Notes
- The decorator pattern wraps functions and may affect how FastMCP sees function signatures - verify tools register correctly
- Critical assumption: `DESTRUCTIVE_HINT` defaults to `True` per FastMCP spec (line 74 in safe_mode.py) - if wrong, filtering breaks
- When both modes are enabled, readonly check runs first and will block everything before safe mode check runs
- No unit tests were added yet - these should be added in a follow-up

Requested by: AJ Steers (@aaronsteers)  
Devin session: https://app.devin.ai/sessions/026dbd2898474bc2a3ce21aec839533e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable safety restrictions for cloud operations through environment-based modes.
  * Cloud operations now validate authorization checks to prevent potentially destructive actions when safety constraints are active.
  * Enhanced error messaging to clearly indicate when an operation violates safety constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->