### PR TITLE
fix(mcp): MCP safe mode should use runtime checks instead of tool filtering

### DIFF
--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -63,7 +63,7 @@ def check_guid_created_in_session(guid: str) -> None:
 
 
 def should_register_tool(annotations: dict[str, Any]) -> bool:
-    """Check if a tool should be registered based on safe mode settings.
+    """Check if a tool should be registered based on mode settings.
 
     Args:
         annotations: Tool annotations dict containing domain, readOnlyHint, and destructiveHint
@@ -74,17 +74,9 @@ def should_register_tool(annotations: dict[str, Any]) -> bool:
     if annotations.get("domain") != "cloud":
         return True
 
-    if not AIRBYTE_CLOUD_MCP_READONLY_MODE and not AIRBYTE_CLOUD_MCP_SAFE_MODE:
-        return True
-
     if AIRBYTE_CLOUD_MCP_READONLY_MODE:
         is_readonly = annotations.get(READ_ONLY_HINT, False)
         if not is_readonly:
-            return False
-
-    if AIRBYTE_CLOUD_MCP_SAFE_MODE:
-        is_destructive = annotations.get(DESTRUCTIVE_HINT, True)  # Default is True per FastMCP
-        if is_destructive:
             return False
 
     return True

--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -1015,8 +1015,9 @@ def register_cloud_ops_tools(app: FastMCP) -> None:
 
     This is an internal function and should not be called directly.
 
-    Tools are filtered based on safe mode settings:
+    Tools are filtered based on mode settings:
     - AIRBYTE_CLOUD_MCP_READONLY_MODE=1: Only read-only tools are registered
-    - AIRBYTE_CLOUD_MCP_SAFE_MODE=1: Destructive tools are not registered
+    - AIRBYTE_CLOUD_MCP_SAFE_MODE=1: All tools are registered, but destructive
+      operations are protected by runtime session checks
     """
     register_tools(app, domain="cloud")


### PR DESCRIPTION
# Change MCP safe mode to use runtime checks instead of tool filtering

## Summary

Previously, when safe mode was enabled (`AIRBYTE_CLOUD_MCP_SAFE_MODE=1`, the default), tools marked as `destructive=True` were filtered out during registration and would not appear in the tool list at all.

This PR changes safe mode to register all tools regardless of their destructive flag, and instead rely on the existing runtime session checks (`check_guid_created_in_session()`) to prevent destructive operations on objects that were not created in the current session.

**Key changes:**
- Modified `should_register_tool()` to remove safe mode filtering logic
- All cloud tools are now registered when safe mode is enabled
- Destructive operations still protected by runtime `check_guid_created_in_session()` calls
- Read-only mode (`AIRBYTE_CLOUD_MCP_READONLY_MODE=1`) behavior unchanged - still filters out non-read-only tools
- Updated docstrings to reflect new behavior

**Verified that all destructive operations have session checks:**
- ✅ `update_custom_source_definition` (line 697)
- ✅ `permanently_delete_custom_source_definition` (line 747)  
- ✅ `update_cloud_source_config` (line 821)
- ✅ `update_cloud_destination_config` (line 897)
- ✅ `set_cloud_connection_selected_streams` (line 1000)

## Review & Testing Checklist for Human

**IMPORTANT**: Unit tests pass, but I have NOT tested this with the actual MCP server running. End-to-end testing is critical.

- [ ] **Test MCP server with safe mode enabled**: Verify all tools now appear in the tool list (including destructive ones like `update_cloud_source_config`)
- [ ] **Test runtime blocking**: Attempt to call a destructive operation on an existing object not created in session - should fail with `SafeModeError`
- [ ] **Test session-created objects**: Create a new source/destination/connection, then perform destructive operations on it - should succeed
- [ ] **Test read-only mode**: Verify `AIRBYTE_CLOUD_MCP_READONLY_MODE=1` still filters out non-read-only tools
- [ ] **Test session GUID tracking**: Verify `register_guid_created_in_session()` is called for all creation operations and GUIDs are tracked correctly

### Recommended Test Plan

```bash
# Start MCP server with safe mode (default)
poetry run airbyte-mcp

# In your MCP client:
# 1. List tools - should now see update_cloud_source_config, etc.
# 2. Deploy a test source
# 3. Try to update its config - should succeed
# 4. Try to update an existing source's config - should fail with SafeModeError
# 5. Test with AIRBYTE_CLOUD_MCP_SAFE_MODE=0 - all operations should work
# 6. Test with AIRBYTE_CLOUD_MCP_READONLY_MODE=1 - only read-only tools visible
```

### Notes

- All unit tests pass locally
- This change makes safe mode behavior match what was described in [this Slack thread](https://airbytehq-team.slack.com/archives/C065V6XFWNQ/p1761331879768719)
- Related analysis document: `/home/ubuntu/safe_mode_test_report.md`

---

**Devin session**: https://app.devin.ai/sessions/7b98e40852e94d14abfc95ed2ee253cc  
**Requested by**: AJ Steers (@aaronsteers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool availability in safe mode by removing unnecessary filtering restrictions.

* **Documentation**
  * Updated documentation to reflect revised tool registration and filtering behavior based on mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->