### PR TITLE
feat(mcp): Add mcp_smoke_tests_prompt for validating all tools and resources

### DIFF
--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -11,6 +11,7 @@ from airbyte.mcp._util import initialize_secrets
 from airbyte.mcp.cloud_ops import register_cloud_ops_tools
 from airbyte.mcp.connector_registry import register_connector_registry_tools
 from airbyte.mcp.local_ops import register_local_ops_tools
+from airbyte.mcp.smoke_tests import register_smoke_test_prompt
 
 
 set_mcp_mode()
@@ -22,6 +23,7 @@ app: FastMCP = FastMCP("airbyte-mcp")
 register_connector_registry_tools(app)
 register_local_ops_tools(app)
 register_cloud_ops_tools(app)
+register_smoke_test_prompt(app)
 
 
 def main() -> None:

--- a/airbyte/mcp/smoke_tests.py
+++ b/airbyte/mcp/smoke_tests.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""MCP smoke test prompt for validating all tools and resources."""
+
+from typing import Annotated
+
+from fastmcp import FastMCP
+from pydantic import Field
+
+from airbyte.mcp._tool_utils import get_registered_tools
+
+
+def mcp_smoke_tests_prompt(
+    read_only: Annotated[
+        bool,
+        Field(
+            description=(
+                "If True, only test read-only tools. "
+                "If False, test all tools including destructive ones."
+            ),
+            default=True,
+        ),
+    ],
+) -> list[dict[str, str]]:
+    """Run smoke tests on all MCP tools and resources to confirm they are working properly.
+
+    This prompt provides instructions for testing all available MCP tools and checking
+    all MCP resource assets. It generates a comprehensive test plan based on the
+    registered tools and resources.
+
+    Args:
+        read_only: If True, only test read-only tools. If False, test all tools.
+
+    Returns:
+        List of prompt messages with testing instructions.
+    """
+    all_tools = get_registered_tools()
+
+    if read_only:
+        tools_to_test = [(func, ann) for func, ann in all_tools if ann.get("readOnlyHint", False)]
+    else:
+        tools_to_test = all_tools
+
+    tools_by_domain: dict[str, list[str]] = {}
+    for func, ann in tools_to_test:
+        domain = ann.get("domain", "unknown")
+        if domain not in tools_by_domain:
+            tools_by_domain[domain] = []
+        tools_by_domain[domain].append(func.__name__)
+
+    prompt_parts = [
+        "# MCP Smoke Test Instructions\n",
+        f"Testing mode: {'READ-ONLY' if read_only else 'ALL TOOLS (including destructive)'}\n",
+        "\n## Overview\n",
+        "This smoke test will validate that all MCP tools and resources are "
+        "functioning correctly. ",
+        "Follow the instructions below to test each component systematically.\n",
+        "\n## Tools to Test\n",
+    ]
+
+    for domain, tool_names in sorted(tools_by_domain.items()):
+        prompt_parts.extend(
+            [
+                f"\n### Domain: {domain}\n",
+                f"Number of tools: {len(tool_names)}\n",
+                "Tools:\n",
+            ]
+        )
+        prompt_parts.extend(f"- {tool_name}\n" for tool_name in sorted(tool_names))
+
+    prompt_parts.extend(
+        [
+            "\n## Testing Instructions\n",
+            "\n### 1. Tool Testing\n",
+            "For each tool listed above:\n",
+            "1. Call the tool with minimal/safe parameters\n",
+            "2. Verify it returns a response without errors\n",
+            "3. Document any failures with error messages\n",
+            "\n### 2. Resource Testing\n",
+            "Test all available MCP resources:\n",
+            "1. List all available resources\n",
+            "2. Attempt to read each resource\n",
+            "3. Verify the content is accessible\n",
+            "\n### 3. Report Generation\n",
+            "After testing, generate a report with:\n",
+            "- Total tools tested\n",
+            "- Number of successful tests\n",
+            "- Number of failed tests\n",
+            "- List of any failures with error details\n",
+            "- Resource access results\n",
+            "\n## Expected Behavior\n",
+            "- Read-only tools should execute without modifying any data\n",
+            "- Tools requiring configuration should fail gracefully with clear error messages\n",
+            "- All resources should be accessible\n",
+            "\n## Notes\n",
+            "- Some tools may require valid configurations or credentials to fully test\n",
+            "- Failures due to missing configuration are expected and should be documented\n",
+            "- Focus on verifying that tools are callable and return appropriate responses\n",
+        ]
+    )
+
+    prompt_text = "".join(prompt_parts)
+
+    return [
+        {
+            "role": "user",
+            "content": prompt_text,
+        }
+    ]
+
+
+def register_smoke_test_prompt(app: FastMCP) -> None:
+    """Register the smoke test prompt with the FastMCP app.
+
+    Args:
+        app: The FastMCP app instance
+    """
+    app.prompt(
+        name="mcp_smoke_tests_prompt",
+        description=(
+            "Run smoke tests on all MCP tools and resources to confirm " "they are working properly"
+        ),
+    )(mcp_smoke_tests_prompt)


### PR DESCRIPTION
# feat(mcp): Add mcp_smoke_tests_prompt for validating all tools and resources

## Summary

Adds a new MCP prompt called `mcp_smoke_tests_prompt` that provides comprehensive testing instructions for validating all MCP tools and resources in the PyAirbyte MCP server. The prompt:

- Dynamically discovers all registered MCP tools using the existing `get_registered_tools()` function
- Groups tools by domain (cloud, local, registry) for organized testing
- Supports a `read_only` parameter (default: `True`) to filter tools by their read-only status
- Generates detailed testing instructions including tool testing, resource testing, and report generation guidelines
- Is registered as an MCP prompt that can be invoked by MCP clients like Claude Desktop

**Implementation Details:**
- New file: `airbyte/mcp/smoke_tests.py` containing the prompt function and registration logic
- Modified: `airbyte/mcp/server.py` to import and register the smoke test prompt
- The prompt generates instructions as text rather than executing tests automatically

## Review & Testing Checklist for Human

**⚠️ IMPORTANT: Please verify the requirements alignment**

- [ ] **Confirm this is what you wanted**: This PR implements a *prompt* that provides testing *instructions*, not an automated test runner. When invoked, it generates a markdown document with step-by-step guidance for manually testing tools. If you wanted an automated test function that actually calls all tools and reports results, please clarify and I can revise the implementation.

- [ ] **Test the prompt end-to-end**: Invoke the `mcp_smoke_tests_prompt` through an MCP client (e.g., Claude Desktop) with both `read_only=True` and `read_only=False` to verify it generates useful testing instructions

- [ ] **Verify read-only filtering**: Check that the `readOnlyHint` annotation filtering correctly identifies all read-only tools. Some tools might be implicitly read-only but not marked as such in their annotations.

- [ ] **Resource testing coverage**: Note that the prompt provides generic resource testing instructions but doesn't enumerate specific resources (PyAirbyte MCP doesn't appear to have a resource registry like Connector Builder does). Verify this is acceptable or if resource enumeration should be added.

### Notes

- This PR only covers the PyAirbyte MCP server. A separate PR for the Connector Builder MCP server is still pending.
- The prompt was tested locally to confirm it can be imported and called successfully, returning properly formatted instructions.
- Lint checks pass for all changes.

**Requested by:** AJ Steers (aj@airbyte.io / @aaronsteers)  
**Devin Session:** https://app.devin.ai/sessions/1145d85639d849b396b2021ba80433b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive smoke testing capability for validating MCP tools and resources.
  * Supports dual testing modes: read-only tests or comprehensive testing of all available tools.
  * New testing interface organizes tools by domain and provides detailed validation procedures with reporting and expected behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->