### PR TITLE
feat(registry): Add KeyError validation for externalDocumentationUrls

### DIFF
--- a/airbyte/mcp/connector_registry.py
+++ b/airbyte/mcp/connector_registry.py
@@ -16,7 +16,7 @@ from airbyte._util.meta import is_docker_installed
 from airbyte.mcp._tool_utils import mcp_tool, register_tools
 from airbyte.mcp._util import resolve_list_of_strings
 from airbyte.registry import (
-    _DEFAULT_MANIFEST_URL,
+    _DEFAULT_METADATA_URL,
     ApiDocsUrl,
     ConnectorMetadata,
     ConnectorVersionInfo,
@@ -161,7 +161,7 @@ def get_connector_info(
         connector.install()
         config_spec_jsonschema = connector.config_spec
 
-    manifest_url = _DEFAULT_MANIFEST_URL.format(
+    manifest_url = _DEFAULT_METADATA_URL.format(
         source_name=connector_name,
         version="latest",
     )
@@ -195,7 +195,7 @@ def get_connector_docs_urls(
 
     This tool retrieves documentation URLs for a connector from multiple sources:
     - Registry metadata (documentationUrl, externalDocumentationUrls)
-    - Connector manifest.yaml file (data.externalDocumentationUrls)
+    - Connector metadata.yaml file (data.externalDocumentationUrls)
     """
     try:
         return _get_connector_docs_urls(connector_name)

--- a/tests/unit_tests/test_mcp_connector_registry.py
+++ b/tests/unit_tests/test_mcp_connector_registry.py
@@ -11,38 +11,38 @@ from airbyte import exceptions as exc
 from airbyte.mcp.connector_registry import get_connector_docs_urls
 from airbyte.registry import (
     ApiDocsUrl,
-    _fetch_manifest_dict,
-    _manifest_url_for,
+    _fetch_metadata_dict,
+    _metadata_url_for,
 )
 
 
-class TestManifestUrlFor:
-    """Tests for _manifest_url_for function."""
+class TestMetadataUrlFor:
+    """Tests for _metadata_url_for function."""
 
-    def test_manifest_url_for(self) -> None:
-        """Test generating manifest URL for a connector."""
-        url = _manifest_url_for("source-example")
+    def test_metadata_url_for(self) -> None:
+        """Test generating metadata URL for a connector."""
+        url = _metadata_url_for("source-example")
         assert "source-example" in url
-        assert "manifest.yaml" in url
+        assert "metadata.yaml" in url
         assert "latest" in url
 
 
-class TestFetchManifestDict:
-    """Tests for _fetch_manifest_dict function."""
+class TestFetchMetadataDict:
+    """Tests for _fetch_metadata_dict function."""
 
-    def test_manifest_not_found(self) -> None:
-        """Test handling when manifest.yaml doesn't exist (404)."""
+    def test_metadata_not_found(self) -> None:
+        """Test handling when metadata.yaml doesn't exist (404)."""
         with patch("airbyte.registry.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 404
             mock_get.return_value = mock_response
 
-            manifest_dict = _fetch_manifest_dict("https://example.com/manifest.yaml")
-            assert manifest_dict == {}
+            metadata_dict = _fetch_metadata_dict("https://example.com/metadata.yaml")
+            assert metadata_dict == {}
 
-    def test_fetch_manifest_dict(self) -> None:
-        """Test fetching and parsing manifest.yaml."""
-        manifest_yaml = """
+    def test_fetch_metadata_dict(self) -> None:
+        """Test fetching and parsing metadata.yaml."""
+        metadata_yaml = """
 version: 1.0.0
 type: DeclarativeSource
 data:
@@ -51,21 +51,21 @@ data:
         with patch("airbyte.registry.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.text = manifest_yaml
+            mock_response.text = metadata_yaml
             mock_get.return_value = mock_response
 
-            manifest_dict = _fetch_manifest_dict("https://example.com/manifest.yaml")
-            assert manifest_dict["version"] == "1.0.0"
-            assert manifest_dict["type"] == "DeclarativeSource"
-            assert manifest_dict["data"]["name"] == "Example"
+            metadata_dict = _fetch_metadata_dict("https://example.com/metadata.yaml")
+            assert metadata_dict["version"] == "1.0.0"
+            assert metadata_dict["type"] == "DeclarativeSource"
+            assert metadata_dict["data"]["name"] == "Example"
 
 
-class TestApiDocsUrlFromManifestDict:
-    """Tests for ApiDocsUrl.from_manifest_dict classmethod."""
+class TestApiDocsUrlFromMetadataDict:
+    """Tests for ApiDocsUrl.from_metadata_dict classmethod."""
 
-    def test_manifest_with_external_docs_urls(self) -> None:
+    def test_metadata_with_external_docs_urls(self) -> None:
         """Test extracting URLs from data.externalDocumentationUrls field."""
-        manifest_dict = {
+        metadata_dict = {
             "version": "1.0.0",
             "type": "DeclarativeSource",
             "data": {
@@ -90,7 +90,7 @@ class TestApiDocsUrlFromManifestDict:
             },
         }
 
-        urls = ApiDocsUrl.from_manifest_dict(manifest_dict)
+        urls = ApiDocsUrl.from_metadata_dict(metadata_dict)
         assert len(urls) == 3
         assert urls[0].title == "Versioning docs"
         assert urls[0].url == "https://api.example.com/versioning"
@@ -102,9 +102,9 @@ class TestApiDocsUrlFromManifestDict:
         assert urls[2].doc_type == "api_deprecations"
         assert urls[2].requires_login is True
 
-    def test_manifest_with_external_docs_no_type(self) -> None:
+    def test_metadata_with_external_docs_no_type(self) -> None:
         """Test extracting URLs from data.externalDocumentationUrls without type field."""
-        manifest_dict = {
+        metadata_dict = {
             "version": "1.0.0",
             "type": "DeclarativeSource",
             "data": {
@@ -117,20 +117,20 @@ class TestApiDocsUrlFromManifestDict:
             },
         }
 
-        urls = ApiDocsUrl.from_manifest_dict(manifest_dict)
+        urls = ApiDocsUrl.from_metadata_dict(metadata_dict)
         assert len(urls) == 1
         assert urls[0].title == "General docs"
         assert urls[0].doc_type == "other"
         assert urls[0].requires_login is False
 
-    def test_empty_manifest(self) -> None:
-        """Test handling empty manifest dict."""
-        urls = ApiDocsUrl.from_manifest_dict({})
+    def test_empty_metadata(self) -> None:
+        """Test handling empty metadata dict."""
+        urls = ApiDocsUrl.from_metadata_dict({})
         assert len(urls) == 0
 
-    def test_manifest_missing_title_raises_error(self) -> None:
+    def test_metadata_missing_title_raises_error(self) -> None:
         """Test that missing 'title' field raises PyAirbyteInternalError."""
-        manifest_dict = {
+        metadata_dict = {
             "version": "1.0.0",
             "type": "DeclarativeSource",
             "data": {
@@ -143,13 +143,13 @@ class TestApiDocsUrlFromManifestDict:
         }
 
         with pytest.raises(
-            exc.PyAirbyteInternalError, match="Manifest parsing error.*'title'"
+            exc.PyAirbyteInternalError, match="Metadata parsing error.*'title'"
         ):
-            ApiDocsUrl.from_manifest_dict(manifest_dict)
+            ApiDocsUrl.from_metadata_dict(metadata_dict)
 
-    def test_manifest_missing_url_raises_error(self) -> None:
+    def test_metadata_missing_url_raises_error(self) -> None:
         """Test that missing 'url' field raises PyAirbyteInternalError."""
-        manifest_dict = {
+        metadata_dict = {
             "version": "1.0.0",
             "type": "DeclarativeSource",
             "data": {
@@ -162,9 +162,9 @@ class TestApiDocsUrlFromManifestDict:
         }
 
         with pytest.raises(
-            exc.PyAirbyteInternalError, match="Manifest parsing error.*'url'"
+            exc.PyAirbyteInternalError, match="Metadata parsing error.*'url'"
         ):
-            ApiDocsUrl.from_manifest_dict(manifest_dict)
+            ApiDocsUrl.from_metadata_dict(metadata_dict)
 
 
 class TestGetConnectorDocsUrls:


### PR DESCRIPTION
# feat(registry): Add KeyError validation for externalDocumentationUrls

## Summary
Adds validation to raise clear `PyAirbyteInputError` exceptions when `externalDocumentationUrls` entries are missing required `title` or `url` fields, instead of allowing KeyError to propagate. This applies to both manifest.yaml parsing and registry metadata parsing.

**Changes:**
- Modified `ApiDocsUrl.from_manifest_dict()` to wrap dict access in try-except and raise `PyAirbyteInputError` with clear message
- Modified `_extract_docs_from_registry()` with same validation pattern
- Added 2 unit tests verifying exception behavior for missing fields
- Updated docstrings to document the new exception

**Related PRs:**
- airbytehq/PyAirbyte#858 (merged) - Initial implementation of get_api_docs_urls tool

## Review & Testing Checklist for Human
This is a **yellow risk** change (behavior change with potential production impact):

- [ ] **Verify this won't break existing connectors**: Check if any connectors in production have malformed `externalDocumentationUrls` metadata (missing title/url fields). This change will cause those to fail instead of being silently skipped.
- [ ] **Test with source-faker**: Manually test `get_api_docs_urls("source-faker")` to ensure it still works correctly with valid metadata
- [ ] **Consider error message clarity**: The error messages are simple ("missing required field 'title'") - verify this provides enough context for debugging. May want to include connector name or manifest URL in future iteration.

### Notes
- This is a follow-up to PR #858 based on CodeRabbit's suggestion and user feedback
- The change converts silent failures (KeyError) into explicit exceptions with clear messages
- Test coverage: Added tests for manifest parsing path, but registry parsing path uses same pattern and isn't explicitly tested for error cases (relies on same code path)
- Requested by: AJ Steers (@aaronsteers)
- Devin session: https://app.devin.ai/sessions/02ae774e5a3a4052b5260e136bec5ea0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation ingestion now reads connector metadata (metadata.yaml) in addition to registry entries.

* **Bug Fixes**
  * Stronger validation with clearer errors for missing documentation fields.
  * Connector presence is validated before fetching docs; registry and metadata docs are returned together (duplicates may appear).

* **Tests**
  * Added tests ensuring errors for incomplete or malformed metadata.

* **Chores**
  * Renamed public function for retrieving connector documentation URLs for clearer intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->