### PR TITLE
Fix DeclarativeExecutor passing down empty configs

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -45,6 +45,7 @@ class DeclarativeExecutor(Executor):
         self,
         name: str,
         manifest: dict | Path,
+        config: dict[str, Any] = {},
         components_py: str | Path | None = None,
         components_py_checksum: str | None = None,
     ) -> None:
@@ -66,7 +67,7 @@ class DeclarativeExecutor(Executor):
         elif isinstance(manifest, dict):
             self._manifest_dict = manifest
 
-        config_dict: dict[str, Any] = {}
+        config_dict: dict[str, Any] = config
         if components_py:
             if isinstance(components_py, Path):
                 components_py = components_py.read_text()

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -169,6 +169,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
     install_root: Path | None = None,
     use_python: bool | Path | str | None = None,
     no_executor: bool = False,
+    config: dict[str, Any] = {}
 ) -> Executor:
     """This factory function creates an executor for a connector.
 
@@ -334,6 +335,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             return DeclarativeExecutor(
                 name=name,
                 manifest=source_manifest,
+                config=config,
                 components_py=components_py_path,
             )
 
@@ -349,6 +351,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             return DeclarativeExecutor(
                 name=name,
                 manifest=manifest_dict,
+                config=config,
                 components_py=components_py,
                 components_py_checksum=components_py_checksum,
             )

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -128,7 +128,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
         install_if_missing=install_if_missing,
         install_root=install_root,
         no_executor=no_executor,
-        config=config
+        config=config,
     )
 
     return Source(

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -128,6 +128,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
         install_if_missing=install_if_missing,
         install_root=install_root,
         no_executor=no_executor,
+        config=config
     )
 
     return Source(


### PR DESCRIPTION
Fixing proposal for: #868 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connectors and their executors now accept and receive a configuration dictionary during initialization.
  * Configuration passed at setup is propagated into connector initialization and source loading, enabling per-connector customization while preserving existing flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->