### PR TITLE
fix(mcp): resolve incorrect cloud auth help text env vars

### DIFF
--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -29,7 +29,7 @@ from airbyte.mcp._util import resolve_config, resolve_list_of_strings
 
 CLOUD_AUTH_TIP_TEXT = (
     "By default, the `AIRBYTE_CLOUD_CLIENT_ID`, `AIRBYTE_CLOUD_CLIENT_SECRET`, "
-    "`AIRBYTE_CLOUD_WORKSPACE_ID`, and `AIRBYTE_CLOUD_API_ROOT` environment variables "
+    "and `AIRBYTE_CLOUD_WORKSPACE_ID` environment variables "
     "will be used to authenticate with the Airbyte Cloud API."
 )
 WORKSPACE_ID_TIP_TEXT = "Workspace ID. Defaults to `AIRBYTE_CLOUD_WORKSPACE_ID` env var."


### PR DESCRIPTION
Correct the environment variable references in the cloud authentication help text for improved clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Unified and clearer authentication guidance across Airbyte Cloud operations' help text
  * Streamlined, concise descriptions for Cloud operations replacing verbose docstrings
  * Improved parameter descriptions with explicit workspace ID guidance for clarity and consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._