### PR TITLE
fix: Prevent deadlock in subprocess executor by allowing concurrent I/O

### DIFF
--- a/airbyte/_executors/base.py
+++ b/airbyte/_executors/base.py
@@ -95,6 +95,7 @@ def _stream_from_subprocess(
                 stdin,
                 exception_holder,
             ),
+            daemon=True,  # Prevent blocking interpreter shutdown if thread gets stuck
         )
         input_thread.start()
         # Don't join here - let input and output happen concurrently to avoid deadlock.


### PR DESCRIPTION
## Summary

Fixes a potential deadlock in `_stream_from_subprocess` that could cause destination writes to hang indefinitely (reported in #871 as MySQL → Postgres sync hanging during write phase).

**Root cause:** The previous implementation called `input_thread.join()` immediately after starting the input thread, *before* reading from stdout. This creates a classic pipe deadlock:
1. Input thread writes to subprocess stdin
2. Subprocess processes data and writes to stdout  
3. If stdout buffer fills up, subprocess blocks
4. But we're blocked waiting for input thread to finish before reading stdout
5. Input thread can't finish because subprocess is blocked
6. **Deadlock**

**Fix:** Move `input_thread.join()` to the finally block after reading is complete, allowing input and output to happen concurrently.

Closes #871

### Updates since last revision

Addressed CodeRabbit feedback on exception handling order: Exit code is now checked **first** before raising input thread exceptions. This ensures `AirbyteSubprocessFailedError` is raised (with input thread exception as `original_exception`) when the subprocess fails, preserving the error-handling contract for callers that catch `AirbyteSubprocessFailedError`.

## Review & Testing Checklist for Human

- [ ] **Verify the deadlock analysis is correct** - The fix is based on theoretical understanding of pipe buffering, not empirical reproduction of the MySQL → Postgres hang
- [ ] **Test a high-volume destination write** - Run a sync with significant data volume (e.g., source-faker → destination-postgres) to verify no hangs occur
- [ ] **Verify exception handling order** - Exit code is now checked before input thread exceptions; confirm subprocess failures are properly wrapped in `AirbyteSubprocessFailedError`
- [ ] **Check for regressions** - This is core executor code affecting all connectors; run integration tests across multiple connector types

**Recommended test plan:** 
1. Run `python examples/run_faker.py` with a large record count
2. If possible, reproduce the original reporter's scenario (MySQL → Postgres incremental sync)
3. Verify early termination scenarios (Ctrl+C during sync) still clean up properly

### Notes

- The 10-second timeout on `input_thread.join()` in the finally block prevents indefinite hangs during cleanup
- BrokenPipeError continues to be ignored as it's expected during graceful shutdown
- All 218 unit tests pass locally

Requested by: AJ Steers (@aaronsteers)
Link to Devin run: https://app.devin.ai/sessions/5094f54055bd4fc68a357aa705357fce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Run input streaming concurrently with output processing to prevent deadlocks and ensure clean shutdown sequencing.
  * Input streaming now runs as a background thread and is properly awaited during termination.
  * Improved error handling: non‑zero subprocess exits are surfaced as errors (except expected terminations and broken pipe), and input-thread exceptions are reported after shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._