### PR TITLE
chore: Add workflow to auto-label community PRs from forks

### DIFF
--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Add community label
         # This action uses GitHub's addLabels API, which is idempotent.
         # If the label already exists, the API call succeeds without error.
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: community


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically applies the `community` label to PRs opened from forks. This enables automatic tracking on the [Community PRs project board](https://github.com/orgs/airbytehq/projects/148).

The workflow:
- Triggers on `pull_request_target` events (`opened` and `reopened`)
- Only runs for PRs from forks (via `if: github.event.pull_request.head.repo.fork == true`)
- Uses the [`actions-ecosystem/action-add-labels`](https://github.com/actions-ecosystem/action-add-labels) marketplace action (v1.1.3, pinned by SHA)
- The action's `addLabels` API is idempotent—if the label already exists, it succeeds without error

## Review & Testing Checklist for Human

- [ ] Verify the workflow does NOT checkout or execute any code from the fork (security requirement for `pull_request_target`)
- [ ] Confirm the `community` label exists in this repository
- [ ] Verify the pinned action SHA (`bd52874380e3909a1ac983768df6976535ece7f8`) matches [v1.1.3](https://github.com/actions-ecosystem/action-add-labels/releases/tag/v1.1.3)

**Test plan:** After merging, open a PR from a fork (or close/reopen an existing fork PR) to verify the label is applied automatically.

### Notes

This workflow cannot be tested via CI since it only triggers on actual fork PRs.

**Requested by:** @aaronsteers (AJ Steers)
**Devin session:** https://app.devin.ai/sessions/b0784474061f4084a04ce5251ce1e9f2

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull requests opened from forked repositories are automatically labeled "community" to improve organization and visibility. Labeling occurs on PR open/reopen to ensure consistent identification of community contributions.

✏️ Tip: You can customize this high-level summary in your review settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**