### PR TITLE
fix(mcp): The check workspace tool should not fail when missing organization permissions

### DIFF
--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -150,7 +150,7 @@ class CloudWorkspace:
 
         Raises:
             AirbyteError: If raise_on_error=True and the organization info cannot be fetched
-                (e.g., due to insufficient permissions).
+                (e.g., due to insufficient permissions or missing data).
         """
         try:
             info = self._organization_info
@@ -159,9 +159,24 @@ class CloudWorkspace:
                 raise
             return None
 
+        organization_id = info.get("organizationId")
+        organization_name = info.get("organizationName")
+
+        # Validate that both organization_id and organization_name are non-null and non-empty
+        if not organization_id or not organization_name:
+            if raise_on_error:
+                raise AirbyteError(
+                    message="Organization info is incomplete.",
+                    context={
+                        "organization_id": organization_id,
+                        "organization_name": organization_name,
+                    },
+                )
+            return None
+
         return CloudOrganization(
-            organization_id=str(info.get("organizationId", "")),
-            organization_name=info.get("organizationName"),
+            organization_id=organization_id,
+            organization_name=organization_name,
         )
 
     # Test connection and creds

--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -159,9 +159,9 @@ class CloudWorkspaceResult(BaseModel):
     workspace_url: str | None = None
     """URL to access the workspace in Airbyte Cloud."""
     organization_id: str
-    """ID of the organization this workspace belongs to."""
+    """ID of the organization (requires ORGANIZATION_READER permission)."""
     organization_name: str | None = None
-    """Name of the organization this workspace belongs to."""
+    """Name of the organization (requires ORGANIZATION_READER permission)."""
 
 
 class LogReadResult(BaseModel):


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v0.33.7 where `check_airbyte_cloud_workspace` fails with a 403 error for users with workspace-scoped credentials that lack ORGANIZATION_READER permissions.

**Approach:** Per AJ's request, this refactors the organization info handling upstream to `CloudWorkspace` rather than just catching exceptions in the MCP tool:

1. **New `CloudOrganization` dataclass** - Minimal value object with `organization_id` and `organization_name`
2. **New `get_organization(raise_on_error: bool = True)` method** - With overloads for proper type inference:
   - `get_organization()` → `CloudOrganization` (non-nullable)
   - `get_organization(raise_on_error=False)` → `CloudOrganization | None`
3. **Removed `organization_id` and `organization_name` properties** - ⚠️ Breaking change
4. **Validation** - Both `organization_id` and `organization_name` must be non-null and non-empty; otherwise treated as an error

**Users affected by the original issue can pin to `v0.33.6` as a workaround.**

## Review & Testing Checklist for Human

- [ ] **Breaking change impact**: Verify no external code depends on `CloudWorkspace.organization_id` or `CloudWorkspace.organization_name` properties
- [ ] **Exception type**: Confirm `AirbyteError` is raised for 403 errors (verified at `airbyte/_util/api_util.py` line ~1206, but worth double-checking)
- [ ] **Validation strictness**: Confirm requiring BOTH `organization_id` AND `organization_name` to be non-empty is the desired behavior
- [ ] **Test with limited permissions**: Use a workspace with workspace-scoped credentials (no ORGANIZATION_READER) to confirm the tool returns the placeholder message instead of failing

**Recommended test plan:**
1. Create/use an API key with only workspace-level permissions (no org-level access)
2. Call `check_airbyte_cloud_workspace` and verify it returns successfully with `organization_id = "[unavailable - requires ORGANIZATION_READER permission]"`

### Notes

- Requested by AJ Steers (@aaronsteers) via Slack thread in #hydra-pyairbyte-mcp
- Link to Devin run: https://app.devin.ai/sessions/232375763cf84cb588a415821bbb9739
- Original issue reported by Ryan Waskewich

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new organization lookup API and value object to expose organization ID and optional name via a single call.

* **Bug Fixes**
  * Workspace verification now tolerates missing organization info (e.g., insufficient permissions) and returns clear placeholders instead of failing.

* **Breaking Changes**
  * Direct organization properties replaced by the new organization lookup API; callers should use the new API to obtain organization details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._