### PR TITLE
fix: Use workflow_dispatch instead of workflow_call for OIDC compatibility

### DIFF
--- a/.github/workflows/prerelease-command.yml
+++ b/.github/workflows/prerelease-command.yml
@@ -68,14 +68,23 @@ jobs:
       prerelease-version: ${{ steps.version.outputs.version }}
 
   build-and-publish:
-    name: Call Publish Workflow
+    name: Trigger Publish Workflow
     needs: [resolve-pr]
-    uses: ./.github/workflows/pypi_publish.yml
-    with:
-      # Use refs/pull/<PR>/head instead of raw SHA for fork compatibility
-      git_ref: refs/pull/${{ github.event.inputs.pr }}/head
-      version_override: ${{ needs.resolve-pr.outputs.prerelease-version }}
-      publish: true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger pypi_publish workflow
+      id: dispatch
+      uses: the-actions-org/workflow-dispatch@v4
+      with:
+        workflow: pypi_publish.yml
+        token: ${{ secrets.GITHUB_CI_WORKFLOW_TRIGGER_PAT }}
+        ref: main  # Run from main so OIDC attestation matches trusted publisher
+        inputs: '{"git_ref": "refs/pull/${{ github.event.inputs.pr }}/head", "version_override": "${{ needs.resolve-pr.outputs.prerelease-version }}", "publish": "true"}'
+        wait-for-completion: true
+        wait-for-completion-timeout: 30m
+    outputs:
+      workflow-conclusion: ${{ steps.dispatch.outputs.workflow-conclusion }}
+      workflow-url: ${{ steps.dispatch.outputs.workflow-url }}
 
   post-result-comment:
     name: Write Status to PR
@@ -94,6 +103,7 @@ jobs:
           > **Prerelease Published to PyPI**
           >
           > Version: `${{ needs.resolve-pr.outputs.prerelease-version }}`
+          > [View publish workflow](${{ needs.build-and-publish.outputs.workflow-url }})
           >
           > Install with:
           > ```bash
@@ -110,7 +120,7 @@ jobs:
           > **Prerelease Build/Publish Failed**
           >
           > The prerelease encountered an error.
-          > [Check job output](${{ needs.resolve-pr.outputs.job-run-url }}) for details.
+          > [Check publish workflow output](${{ needs.build-and-publish.outputs.workflow-url }}) for details.
           >
           > You can still install directly from this PR branch:
           > ```bash

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -4,6 +4,20 @@ on:
   push:
 
   workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref (SHA or branch) to checkout and build'
+        required: false
+        type: string
+      version_override:
+        description: 'Version to use (overrides dynamic versioning)'
+        required: false
+        type: string
+      publish:
+        description: 'Whether to publish to PyPI (true/false)'
+        required: false
+        type: string
+        default: 'false'
 
   workflow_call:
     inputs:
@@ -56,8 +70,8 @@ jobs:
     environment:
       name: PyPi
       url: https://pypi.org/p/airbyte
-    # Publish when: (1) triggered by a tag push, OR (2) called with publish=true
-    if: startsWith(github.ref, 'refs/tags/') || inputs.publish == true
+    # Publish when: (1) triggered by a tag push, OR (2) called with publish=true (handles both boolean and string)
+    if: startsWith(github.ref, 'refs/tags/') || inputs.publish == true || inputs.publish == 'true'
     steps:
     - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
       with:


### PR DESCRIPTION
## Summary

Fixes the `/prerelease` command which was failing with OIDC attestation mismatch:
```
Certificate's Build Config URI (.../prerelease-command.yml@refs/heads/main) 
does not match expected Trusted Publisher (pypi_publish.yml @ airbytehq/PyAirbyte)
```

The root cause: when using `workflow_call`, PyPI's OIDC attestation sees the **caller** workflow (`prerelease-command.yml`) rather than the **called** workflow (`pypi_publish.yml`). 

The fix: use `the-actions-org/workflow-dispatch@v4` to trigger `pypi_publish.yml` via `workflow_dispatch` instead. This makes `pypi_publish.yml` the top-level workflow, so the OIDC attestation matches the trusted publisher config.

**Changes:**
- `prerelease-command.yml`: Replace `uses: ./.github/workflows/pypi_publish.yml` with `workflow-dispatch` action
- `pypi_publish.yml`: Add `workflow_dispatch.inputs` (mirroring existing `workflow_call.inputs`)
- Update publish condition to handle both boolean and string `'true'` for the `publish` input

## Review & Testing Checklist for Human

- [ ] **Verify `GITHUB_CI_WORKFLOW_TRIGGER_PAT` secret exists** with permissions to trigger workflows
- [ ] **Review the `ref: main` parameter** - This is intentional: the workflow runs from main (for OIDC) but builds code from the PR via `git_ref` input
- [ ] **Consider pinning workflow-dispatch action to SHA** - Currently using `@v4` tag, unlike other actions in the repo which use pinned SHAs
- [ ] **Test end-to-end after merge** by commenting `/prerelease` on a test PR - this is the only way to verify the OIDC fix works

### Notes

- The `workflow_call` trigger is preserved in `pypi_publish.yml` for backwards compatibility (though currently unused)
- The `publish` input uses string type for `workflow_dispatch` (API limitation) but boolean for `workflow_call`, hence the dual condition check

**Link to Devin run:** https://app.devin.ai/sessions/c86d36be59664129af00617d0e66bc4d
**Requested by:** AJ Steers (@aaronsteers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow automation with improved status reporting for published releases.
  * Added workflow configuration inputs for more flexible and reliable release management.
  * Implemented completion verification for publish operations to ensure successful deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->