### PR TITLE
fix: Use GitHub App token for prerelease workflow dispatch

### DIFF
--- a/.github/workflows/prerelease-command.yml
+++ b/.github/workflows/prerelease-command.yml
@@ -72,12 +72,20 @@ jobs:
     needs: [resolve-pr]
     runs-on: ubuntu-latest
     steps:
+    - name: Authenticate as GitHub App
+      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      id: get-app-token
+      with:
+        owner: "airbytehq"
+        repositories: "PyAirbyte"
+        app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+        private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
     - name: Trigger pypi_publish workflow
       id: dispatch
       uses: the-actions-org/workflow-dispatch@v4
       with:
         workflow: pypi_publish.yml
-        token: ${{ secrets.GITHUB_CI_WORKFLOW_TRIGGER_PAT }}
+        token: ${{ steps.get-app-token.outputs.token }}
         ref: main  # Run from main so OIDC attestation matches trusted publisher
         inputs: '{"git_ref": "refs/pull/${{ github.event.inputs.pr }}/head", "version_override": "${{ needs.resolve-pr.outputs.prerelease-version }}", "publish": "true"}'
         wait-for-completion: true


### PR DESCRIPTION
## Summary

Fixes the `/prerelease` command which was failing with `Error: Parameter token or opts.auth is required` because `GITHUB_CI_WORKFLOW_TRIGGER_PAT` doesn't exist.

The fix uses the same GitHub App token pattern already used by other slash commands in this repo (`/fix-pr`, `/test-pr`): generate an installation token at runtime using `actions/create-github-app-token` with the Octavia Bot credentials.

## Review & Testing Checklist for Human

- [ ] **Verify secrets exist**: Confirm `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets are configured for this repo
- [ ] **Verify GitHub App permissions**: The Octavia Bot app must have permission to trigger `workflow_dispatch` events on this repo
- [ ] **Test end-to-end after merge**: Comment `/prerelease` on a test PR to verify the full flow works (this cannot be tested before merge)

### Notes

This is the third iteration fixing the `/prerelease` command:
1. First fix: Added missing permissions for nested workflow call
2. Second fix: Changed from `workflow_call` to `workflow_dispatch` for OIDC attestation compatibility
3. This fix: Use GitHub App token instead of non-existent PAT secret

**Link to Devin run:** https://app.devin.ai/sessions/c86d36be59664129af00617d0e66bc4d
**Requested by:** AJ Steers (@aaronsteers)