### PR TITLE
feat: Add MCP tool and Python API for connection enable/disable and scheduling

### DIFF
--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -500,7 +500,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         *,
         enabled: bool,
         ignore_noop: bool = True,
-    ) -> CloudConnection:
+    ) -> None:
         """Set the enabled status of the connection.
 
         Args:
@@ -509,9 +509,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             ignore_noop: If True (default), silently return if the connection is already
                 in the requested state. If False, raise ValueError when the requested
                 state matches the current state.
-
-        Returns:
-            Updated CloudConnection object with refreshed info.
 
         Raises:
             ValueError: If ignore_noop is False and the connection is already in the
@@ -528,7 +525,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
 
         if current_status == desired_status:
             if ignore_noop:
-                return self
+                return
             raise ValueError(
                 f"Connection is already {'enabled' if enabled else 'disabled'}. "
                 f"Current status: {current_status}"
@@ -543,14 +540,13 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             status=desired_status,
         )
         self._connection_info = updated_response
-        return self
 
     # Scheduling
 
     def set_schedule(
         self,
         cron_expression: str,
-    ) -> CloudConnection:
+    ) -> None:
         """Set a cron schedule for the connection.
 
         Args:
@@ -560,9 +556,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
                 - "0 0 * * *" - Daily at midnight UTC
                 - "0 */6 * * *" - Every 6 hours
                 - "0 0 * * 0" - Weekly on Sunday at midnight UTC
-
-        Returns:
-            Updated CloudConnection object with refreshed info
         """
         schedule = api_util.models.AirbyteAPIConnectionSchedule(
             schedule_type=api_util.models.ScheduleTypeEnum.CRON,
@@ -577,15 +570,11 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             schedule=schedule,
         )
         self._connection_info = updated_response
-        return self
 
-    def set_manual_schedule(self) -> CloudConnection:
+    def set_manual_schedule(self) -> None:
         """Set the connection to manual scheduling.
 
         Disables automatic syncs. Syncs will only run when manually triggered.
-
-        Returns:
-            Updated CloudConnection object with refreshed info
         """
         schedule = api_util.models.AirbyteAPIConnectionSchedule(
             schedule_type=api_util.models.ScheduleTypeEnum.MANUAL,
@@ -599,7 +588,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             schedule=schedule,
         )
         self._connection_info = updated_response
-        return self
 
     # Deletions
 

--- a/airbyte/mcp/cloud_ops.py
+++ b/airbyte/mcp/cloud_ops.py
@@ -2360,6 +2360,8 @@ def update_cloud_connection(
     At least one setting must be provided. The 'cron_expression' and 'manual_schedule'
     parameters are mutually exclusive.
     """
+    check_guid_created_in_session(connection_id)
+
     # Validate that at least one setting is provided
     if enabled is None and cron_expression is None and manual_schedule is None:
         raise ValueError(


### PR DESCRIPTION
# feat: Add MCP tool and Python API for connection enable/disable and scheduling

## Summary

Adds a consolidated MCP tool and underlying Python methods for enabling/disabling connections and managing connection schedules on Airbyte Cloud. The MCP tool is marked as `destructive=True` so it will be disabled when the MCP server runs in read-only mode.

**New CloudConnection methods:**
- `enabled` property - Gets/sets connection enabled status (getter always fetches fresh data from API using `force_refresh=True`)
- `set_enabled(*, enabled: bool, ignore_noop: bool = True) -> None` - Sets connection status with no-op handling
- `set_schedule(cron_expression) -> None` - Sets a cron schedule for automatic syncs
- `set_manual_schedule() -> None` - Disables automatic syncs

**New MCP tool:**
- `update_cloud_connection` - Consolidated tool accepting optional `enabled`, `cron_expression`, and `manual_schedule` parameters. Protected by safe mode guard (`check_guid_created_in_session`).

## Updates Since Last Revision

1. Combined separate `enable()` and `disable()` methods into a single `set_enabled()` method with `ignore_noop` flag (defaults to True)
2. Added `enabled` property with fresh-read getter and setter
3. Consolidated 4 separate MCP tools into a single `update_cloud_connection` tool that accepts multiple optional parameters
4. Merged latest main to incorporate the new `force_refresh` parameter in `_fetch_connection_info()`
5. Updated `enabled` getter and `set_enabled()` to use `force_refresh=True` to ensure fresh data is always fetched from the API
6. Changed `set_enabled()`, `set_schedule()`, `set_manual_schedule()` to return `None` instead of `CloudConnection`
7. Added `check_guid_created_in_session(connection_id)` guard to `update_cloud_connection` MCP tool for safe mode protection

## Review & Testing Checklist for Human

- [ ] **Verify API compatibility**: Confirm that `api_util.patch_connection` actually accepts `status` and `schedule` parameters - I followed the existing pattern but didn't test against the live API
- [ ] **Test enable/disable**: Try enabling and disabling a real connection to verify the status changes correctly
- [ ] **Test scheduling**: Try setting a cron schedule and manual schedule on a real connection
- [ ] **Verify safe mode behavior**: The MCP tool now requires the connection to have been created in the current session when `AIRBYTE_CLOUD_MCP_SAFE_MODE=1` (default). Verify this is the intended behavior for update operations.

### Recommended Test Plan
```bash
# Test enabling a connection
poe mcp-tool-test update_cloud_connection '{"connection_id": "<your-connection-id>", "enabled": true}'

# Test disabling a connection
poe mcp-tool-test update_cloud_connection '{"connection_id": "<your-connection-id>", "enabled": false}'

# Test setting a cron schedule
poe mcp-tool-test update_cloud_connection '{"connection_id": "<your-connection-id>", "cron_expression": "0 0 * * *"}'

# Test setting manual schedule
poe mcp-tool-test update_cloud_connection '{"connection_id": "<your-connection-id>", "manual_schedule": true}'

# Test multiple settings at once
poe mcp-tool-test update_cloud_connection '{"connection_id": "<your-connection-id>", "enabled": true, "cron_expression": "0 */6 * * *"}'
```

### Notes
- Added `# noqa: PLR0904` to CloudConnection class to suppress "too many public methods" lint warning (approved by user)
- Link to Devin run: https://app.devin.ai/sessions/a4f196f281df44b1b2dd283613e49a5e
- Requested by: AJ Steers (@aaronsteers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection lifecycle management: enable or disable cloud connections.
  * Automated CRON scheduling: configure recurring sync schedules.
  * Manual scheduling: switch connections to manual sync mode.

* **Management**
  * Single operation to update connection state and scheduling with input validation, mutual-exclusivity checks, and a concise summary of applied changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->