### PR TITLE
ci: fix release drafter race condition

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
@@ -19,7 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts the next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+      # Pinned to v6.0.0 to avoid v6.1.0 bug: https://github.com/release-drafter/release-drafter/issues/1425
+      - uses: release-drafter/release-drafter@805574fd5375e6902a5875239fb834f515c41111 # v6.0.0
         with:
           config-name: release-drafter.yml
           disable-autolabeler: false


### PR DESCRIPTION
## Summary

Fixes a race condition in the release-drafter workflow where merged PRs sometimes don't appear in the draft release notes when multiple PRs merge in quick succession.

**Changes:**
1. Add `concurrency` group with `cancel-in-progress: false` to queue (not cancel) overlapping runs
2. Downgrade from v6.1.0 to v6.0.0 to avoid a bug where the action fails to find existing draft releases and creates duplicates

## Review & Testing Checklist for Human

- [ ] Verify [release-drafter#1425](https://github.com/release-drafter/release-drafter/issues/1425) is still open before merging
- [ ] Confirm the SHA `805574fd5375e6902a5875239fb834f515c41111` corresponds to v6.0.0 tag
- [ ] After merging, test by merging 2-3 PRs in quick succession and verify all appear in the draft release (no duplicates created)

### Notes

- Same fix already applied to `airbyte-ops-mcp`, `awesome-python-template`, `airbyte-interop-catalog`, `airbyte-python-cdk`, and several other repos
- Requested by: AJ Steers (@aaronsteers)
- Link to Devin run: https://app.devin.ai/sessions/0dafc41101d144fe975937184b356eb3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->