### PR TITLE
fix: Use /local/db.duckdb path for destination-duckdb tests

### DIFF
--- a/tests/integration_tests/destinations/test_source_to_destination.py
+++ b/tests/integration_tests/destinations/test_source_to_destination.py
@@ -30,13 +30,11 @@ def new_duckdb_destination_executor() -> Executor:
     if local_mount_dir.exists():
         shutil.rmtree(local_mount_dir, ignore_errors=True)
 
-    # Create the directory structure with world-writable permissions
+    # Create the directory with world-writable permissions
     # This is needed for Docker volume mounts in CI environments where
     # user namespace remapping may cause permission issues
     local_mount_dir.mkdir(parents=True, exist_ok=True)
-    (local_mount_dir / "temp").mkdir(parents=True, exist_ok=True)
     local_mount_dir.chmod(0o777)
-    (local_mount_dir / "temp").chmod(0o777)
 
     return get_connector_executor(
         name="destination-duckdb",


### PR DESCRIPTION
## Summary

Fixes destination-duckdb integration tests that were failing after PR #934. The previous PR added cleanup logic (`shutil.rmtree`) to remove the `destination-duckdb` directory before each test, but the test config still referenced `/local/temp/db.duckdb`. After cleanup, the `temp` subdirectory was never recreated, causing:

```
IO Error: Cannot open file "/local/temp/db.duckdb": No such file or directory
```

This PR removes the unnecessary `/temp/` subdirectory from the path, writing directly to `/local/db.duckdb` in the container's volume mount.

## Review & Testing Checklist for Human

- [ ] Verify CI passes - all 6 destination-duckdb tests should pass
- [ ] Confirm the path `/local/db.duckdb` is appropriate for the Docker volume mount (the `/local` directory is mounted from the host)

### Notes

All 6 destination tests passed locally before this PR was created.

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/49728e8ed39b40e9ab728baee97d3d60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test fixture filesystem setup by removing the intermediate temporary directory and related permission adjustments.
  * Updated DuckDB destination test configuration to use a container-local path and clarified comments about paths relative to the container's mounted volume.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**