### PR TITLE
chore: add poe task to measure MCP tool list size

### DIFF
--- a/bin/measure_mcp_tool_list.py
+++ b/bin/measure_mcp_tool_list.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Measure the size of the MCP tool list output.
+
+This script measures the character count of the tool list returned by the MCP server,
+which is useful for tracking context truncation issues when AI agents call list_tools.
+
+Usage:
+    poe mcp-measure-tools
+
+Output:
+    Prints tool count and character count for the tool list descriptions.
+"""
+
+import asyncio
+import sys
+
+from fastmcp import Client
+
+from airbyte.mcp.server import app
+
+
+async def measure_tool_list() -> tuple[int, int]:
+    """Measure the tool list size from the MCP server.
+
+    Returns:
+        Tuple of (tool_count, total_character_count)
+    """
+    async with Client(app) as client:
+        tools = await client.list_tools()
+
+        tool_count = len(tools)
+        total_chars = 0
+
+        for tool in tools:
+            # Count characters in tool name
+            total_chars += len(tool.name)
+
+            # Count characters in description
+            if tool.description:
+                total_chars += len(tool.description)
+
+            # Count characters in input schema (parameter descriptions)
+            if tool.inputSchema:
+                total_chars += len(str(tool.inputSchema))
+
+        return tool_count, total_chars
+
+
+def main() -> None:
+    """Main entry point for the MCP tool list measurement."""
+    try:
+        tool_count, total_chars = asyncio.run(measure_tool_list())
+
+        print("MCP Server: airbyte-coral-mcp")
+        print(f"Tool count: {tool_count}")
+        print(f"Total characters: {total_chars:,}")
+        print(f"Average chars per tool: {total_chars // tool_count:,}")
+
+    except Exception as e:
+        print(f"Error measuring tool list: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ mcp-serve-http = { cmd = "poetry run python -c \"from airbyte.mcp.server import 
 mcp-serve-sse = { cmd = "poetry run python -c \"from airbyte.mcp.server import app; app.run(transport='sse', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with SSE transport" }
 mcp-inspect = { cmd = "poetry run fastmcp inspect airbyte/mcp/server.py:app", help = "Inspect MCP tools and resources (supports --tools, --health, etc.)" }
 mcp-tool-test = { cmd = "poetry run python bin/test_mcp_tool.py", help = "Test MCP tools directly with JSON arguments: poe mcp-tool-test <tool_name> '<json_args>'" }
+mcp-measure-tools = { cmd = "poetry run python bin/measure_mcp_tool_list.py", help = "Measure the size of the MCP tool list output (tool count and character count)" }
 
 # Claude Code MCP Testing Tasks
 [tool.poe.tasks.test-my-tools]


### PR DESCRIPTION
## Summary

Adds a new poe task `mcp-measure-tools` that measures the character count of the MCP tool list output. This provides a baseline metric for tracking progress on reducing tool description verbosity to prevent context truncation when AI agents call `list_tools`.

**Current baseline:**
- Tool count: 49
- Total characters: 64,169
- Average chars per tool: 1,309

Usage:
```bash
poe mcp-measure-tools
```

## Review & Testing Checklist for Human

- [ ] Run `poe mcp-measure-tools` locally to verify it produces reasonable output
- [ ] Verify the character counting approach (name + description + stringified inputSchema) is a reasonable approximation for tracking purposes

### Notes

- The character count includes the JSON schema representation of parameters, which may differ slightly from the actual MCP protocol output, but should be consistent for tracking relative changes over time
- Related PR in airbyte-ops-mcp: https://github.com/airbytehq/airbyte-ops-mcp/pull/268
- Requested by @aaronsteers
- Link to Devin run: https://app.devin.ai/sessions/09aeffb94d044f02a3865c41adeb44c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to measure MCP tool list metrics, providing tool count and character statistics for analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->