### PR TITLE
ci: Use GitHub App token for auto-draft PR conversion

### DIFF
--- a/.github/workflows/auto-draft-prs.yml
+++ b/.github/workflows/auto-draft-prs.yml
@@ -35,9 +35,18 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "PyAirbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       - name: Convert PR to draft
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr ready --undo "$PR_NUMBER" --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Fixes the auto-draft workflow failure caused by `GITHUB_TOKEN` lacking permission to execute the `convertPullRequestToDraft` GraphQL mutation. The fix uses the Octavia Bot GitHub App token instead, following the same pattern used by other workflows in this repo (fix-pr-command.yml, poe-command.yml, etc.).

**Error being fixed:**
```
API call failed: GraphQL: Resource not accessible by integration (convertPullRequestToDraft)
```

## Review & Testing Checklist for Human

- [ ] Verify the Octavia Bot GitHub App has permission to convert PRs to draft status
- [ ] Test by creating a non-draft PR (without `[ready]` in title or `skip-draft-status` label) and verify it gets converted to draft with the explanatory comment
- [ ] Confirm the `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets are properly configured

### Notes

**Requested by**: @aaronsteers  
**Link to Devin run**: https://app.devin.ai/sessions/41972af9ad72451c8443605775cc2105  
**Failed job**: https://github.com/airbytehq/PyAirbyte/actions/runs/21224793365/job/61068788787?pr=953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Improved pull request automation workflow with automatic notifications when PRs are converted to draft status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->