### PR TITLE
fix(mcp): rename account_is_locked to is_account_locked and use CloudOrganization public methods

### DIFF
--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -197,7 +197,7 @@ class CloudOrganization:
         return (info.get("billing") or {}).get("subscriptionStatus")
 
     @property
-    def account_is_locked(self) -> bool:
+    def is_account_locked(self) -> bool:
         """Whether the account is locked due to billing issues.
 
         Returns True if payment_status is 'disabled'/'locked' or subscription_status is


### PR DESCRIPTION
## Summary

Fixes naming convention bug from the recently merged billing status PR. Renames `account_is_locked` to `is_account_locked` across all affected classes and refactors `check_airbyte_cloud_workspace` to use `CloudOrganization` public properties instead of calling `api_util` directly.

**Changes:**
- Renamed `account_is_locked` → `is_account_locked` in `CloudOrganization`, `CloudOrganizationResult`, and `CloudWorkspaceResult`
- Refactored `check_airbyte_cloud_workspace` to use `CloudOrganization` public properties (`payment_status`, `subscription_status`, `is_account_locked`) instead of making a separate `api_util.get_workspace_organization_info()` call
- Removed unused `suppress` import

## Review & Testing Checklist for Human

- [ ] Verify the naming convention `is_account_locked` matches expected conventions
- [ ] Verify `CloudOrganization` properties handle permission failures gracefully (should return `None`/`False` when billing info is unavailable)
- [ ] Test `check_airbyte_cloud_workspace` MCP tool with a workspace that has billing issues to confirm `is_account_locked=True` is returned correctly

**Suggested test plan:** Use the MCP tool against a test workspace with known billing status and verify the returned `is_account_locked` value matches expectations.

### Notes
- Requested by @aaronsteers
- Link to Devin run: https://app.devin.ai/sessions/ffd06414843642b8a7161965d8882836
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated account lock status field naming for consistency across API responses.
  * Simplified internal organization data retrieval logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->