### PR TITLE
feat(mcp): Add `job_type` filtering support to `list_cloud_sync_jobs`

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -587,7 +587,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
     bearer_token: SecretString | None,
     offset: int | None = None,
     order_by: str | None = None,
-    job_type: str | None = None,
+    job_type: models.JobTypeEnum | None = None,
 ) -> list[models.JobResponse]:
     """Get a list of jobs for a connection.
 
@@ -601,17 +601,12 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         bearer_token: Bearer token for authentication (alternative to client credentials).
         offset: Number of jobs to skip from the beginning. Defaults to None (0).
         order_by: Field and direction to order by (e.g., "createdAt|DESC"). Defaults to None.
-        job_type: Filter by job type. Options: 'sync', 'reset', 'refresh', 'clear'.
+        job_type: Filter by job type (e.g., JobTypeEnum.SYNC, JobTypeEnum.REFRESH).
             If not specified, defaults to sync and reset jobs only (API default behavior).
 
     Returns:
         A list of JobResponse objects.
     """
-    # Convert string job_type to JobTypeEnum if provided
-    job_type_enum: models.JobTypeEnum | None = None
-    if job_type is not None:
-        job_type_enum = models.JobTypeEnum(job_type)
-
     airbyte_instance = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,
@@ -625,7 +620,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
             limit=limit,
             offset=offset,
             order_by=order_by,
-            job_type=job_type_enum,
+            job_type=job_type,
         ),
     )
     if status_ok(response.status_code) and response.jobs_response:

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -12,7 +12,7 @@ from airbyte.exceptions import AirbyteWorkspaceMismatchError
 
 
 if TYPE_CHECKING:
-    from airbyte_api.models import ConnectionResponse, JobResponse
+    from airbyte_api.models import ConnectionResponse, JobResponse, JobTypeEnum
 
     from airbyte.cloud.workspaces import CloudWorkspace
 
@@ -291,7 +291,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         limit: int = 20,
         offset: int | None = None,
         from_tail: bool = True,
-        job_type: str | None = None,
+        job_type: JobTypeEnum | None = None,
     ) -> list[SyncResult]:
         """Get previous sync jobs for a connection with pagination support.
 
@@ -305,7 +305,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             from_tail: If True, returns jobs ordered newest-first (createdAt DESC).
                 If False, returns jobs ordered oldest-first (createdAt ASC).
                 Defaults to True.
-            job_type: Filter by job type. Options: 'sync', 'reset', 'refresh', 'clear'.
+            job_type: Filter by job type (e.g., JobTypeEnum.SYNC, JobTypeEnum.REFRESH).
                 If not specified, defaults to sync and reset jobs only (API default behavior).
 
         Returns:

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
+from airbyte_api.models import JobTypeEnum
 from fastmcp import Context, FastMCP
 from fastmcp_extensions import get_mcp_config, mcp_tool, register_mcp_tools
 from pydantic import BaseModel, Field
@@ -738,7 +739,7 @@ def list_cloud_sync_jobs(
         ),
     ],
     job_type: Annotated[
-        str | None,
+        JobTypeEnum | None,
         Field(
             description=(
                 "Filter by job type. Options: 'sync', 'reset', 'refresh', 'clear'. "


### PR DESCRIPTION
## Summary

Adds `job_type` filtering support to the `list_cloud_sync_jobs` MCP tool and its underlying API functions. This allows users to filter jobs by type: `sync`, `reset`, `refresh`, or `clear`.

Previously, the Airbyte API defaulted to returning only sync and reset jobs when no `job_type` was specified, which prevented users from discovering stuck refresh or clear jobs via the API.

**Changes:**
- `api_util.get_job_logs()`: Added `job_type` parameter with string-to-enum conversion
- `CloudConnection.get_previous_sync_logs()`: Added `job_type` parameter pass-through
- `list_cloud_sync_jobs` MCP tool: Added `job_type` parameter with descriptive help text

Closes #973

## Review & Testing Checklist for Human

- [ ] Verify the `job_type` parameter correctly filters jobs when tested against a real Airbyte Cloud connection (especially for `refresh` and `clear` job types)
- [ ] Confirm that passing an invalid `job_type` value raises an appropriate error (currently relies on `models.JobTypeEnum` constructor to raise `ValueError`)
- [ ] Test that omitting `job_type` maintains backward compatibility (should return only sync/reset jobs per API default)

**Recommended test plan:** Use the MCP tool test task to verify the parameter is correctly exposed:
```bash
poe mcp-tool-test list_cloud_sync_jobs '{"connection_id": "<test_connection_id>", "job_type": "refresh"}'
```

### Notes

- Link to Devin run: https://app.devin.ai/sessions/832399adb94748e5b9c113072f0794a6
- Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/974">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional job-type filtering for viewing job logs and connection sync job history. Users can filter by 'sync', 'reset', 'refresh', or 'clear'. When unset, listings default to showing sync and reset jobs for convenience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._