### PR TITLE
feat(mcp): proxy Kapa knowledge MCP server for inline Airbyte doc search

### DIFF
--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 
+from fastmcp import FastMCP
 from fastmcp_extensions import mcp_server
 
 from airbyte._util.meta import set_mcp_mode
@@ -92,6 +94,47 @@ register_cloud_tools(app)
 register_local_tools(app)
 register_registry_tools(app)
 register_prompts(app)
+
+
+def _mount_kapa_proxy(app: FastMCP) -> None:
+    """Mount the Kapa knowledge MCP proxy if credentials are configured.
+
+    When KAPA_API_KEY is set, this creates a proxy to Kapa's hosted MCP server
+    and mounts it into the main server, giving agents inline access to Airbyte
+    documentation search alongside native PyAirbyte tools.
+
+    If KAPA_API_KEY is not set, this is a no-op.
+    """
+    kapa_api_key = os.environ.get("KAPA_API_KEY")
+    if not kapa_api_key:
+        print(
+            "Kapa knowledge proxy not mounted (KAPA_API_KEY not set).",
+            file=sys.stderr,
+        )
+        return
+
+    kapa_url = os.environ.get("KAPA_MCP_SERVER_URL", "https://airbyte.mcp.kapa.ai")
+    kapa_proxy = FastMCP.as_proxy(
+        {
+            "mcpServers": {
+                "kapa": {
+                    "url": kapa_url,
+                    "transport": "http",
+                    "headers": {
+                        "Authorization": f"Bearer {kapa_api_key}",
+                    },
+                }
+            }
+        }
+    )
+    app.mount(kapa_proxy, prefix="kapa")
+    print(
+        f"Kapa knowledge proxy mounted from {kapa_url}.",
+        file=sys.stderr,
+    )
+
+
+_mount_kapa_proxy(app)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Mounts [Kapa's hosted MCP server](https://docs.airbyte.com/developers/mcp-servers/airbyte-knowledge-mcp) as a proxy into the PyAirbyte MCP server (`airbyte-mcp`), so agents get inline Airbyte documentation search alongside native PyAirbyte tools — without users needing to install a separate MCP server.

When `KAPA_API_KEY` is set, a `FastMCP.as_proxy()` proxy is created and mounted with a `kapa` prefix. When not set, this is a no-op. The Kapa server URL defaults to `https://airbyte.mcp.kapa.ai` and is configurable via `KAPA_MCP_SERVER_URL`.

Follows the [Kapa proxy tutorial](https://docs.kapa.ai/integrations/mcp/guides/tutorial-proxy-kapa-from-your-mcp) pattern. Companion PR for connector-builder-mcp: https://github.com/airbytehq/connector-builder-mcp/pull/209

Refs: https://github.com/airbytehq/airbyte-internal-issues/issues/15904

## Review & Testing Checklist for Human

- [ ] **Verify `FastMCP.as_proxy` is lazy at startup**: `_mount_kapa_proxy` runs at module load time. Confirm that `FastMCP.as_proxy()` + `mount()` do NOT eagerly connect to the Kapa server — otherwise a misconfigured or unreachable URL with `KAPA_API_KEY` set could block/crash server startup.
- [ ] **Test with a real `KAPA_API_KEY`**: Only the no-op path (no key) was verified. The actual proxy mount path was not tested end-to-end with real Kapa credentials. Recommended test: set `KAPA_API_KEY` and use `poe mcp-tool-test` (or equivalent) to call the proxied Kapa tool and verify it returns results.
- [ ] **Confirm `prefix="kapa"` namespacing**: Verify that Kapa's tools appear with a `kapa_` prefix (e.g., `kapa_search_knowledge_base`) and don't collide with existing PyAirbyte tools.
- [ ] **Rate limit awareness**: Kapa has 40 req/hr and 200 req/day limits per API key. All proxied requests share the server's key. No client-side rate limiting is added. Decide if that's acceptable for initial rollout.

### Notes
- This is the second of two PRs (PyAirbyte + [connector-builder-mcp](https://github.com/airbytehq/connector-builder-mcp/pull/209)) for the Kapa proxy rollout per [airbytehq/airbyte-internal-issues#15904](https://github.com/airbytehq/airbyte-internal-issues/issues/15904).
- Requested by: @aaronsteers
- [Link to Devin run](https://app.devin.ai/sessions/3f6a9c6d123849dfa0fa77e995b3dafc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kapa knowledge base integration to the Airbyte MCP server. When environment variables are configured with the necessary API credentials and server URL, the server automatically mounts the Kapa knowledge proxy during startup, providing enhanced knowledge capabilities. If credentials are not configured, the server operates with standard functionality unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->