### PR TITLE
ci: Add 'prompts' to allowed semantic PR title types

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -79,5 +79,6 @@ jobs:
                 - 'test'
                 - 'perf'
                 - 'docs'
+                - 'prompts'
               collapse-after: 3
               display-order: 999

--- a/.github/workflows/semantic_pr_check.yml
+++ b/.github/workflows/semantic_pr_check.yml
@@ -42,6 +42,8 @@ jobs:
             Build
             test
             Test
+            prompts
+            Prompts
 
           # # We don't use scopes as of now
           # scopes: |


### PR DESCRIPTION
# ci: Add 'prompts' to allowed semantic PR title types

## Summary

Adds `prompts` as a new allowed semantic PR title type across the semantic PR check workflow and release drafter configuration. This is part of an org-wide rollout adding a dedicated type for changes to AI/LLM prompts, agent instructions, skills, and playbooks — content that doesn't fit neatly into `docs`, `ci`, `feat`, or `fix`.

**Changes:**
- `semantic_pr_check.yml`: Added `prompts` and `Prompts` (matching existing case-insensitive pattern)
- `release_drafter.yml`: Added `prompts` to the "Under the Hood" collapse category

Companion PRs are being created across ~9 other Airbyte repos and the `ai-skills` skill definition.

## Review & Testing Checklist for Human

- [ ] Verify `prompts` belongs in the "Under the Hood" release-drafter category (vs. its own dedicated section like "🤖 Prompt Engineering")
- [ ] Confirm both `prompts` and `Prompts` case variants are correct (matches existing pattern in this repo)

### Notes

- Requested by: @aaronsteers
- [Devin session](https://app.devin.ai/sessions/1559b22d46df416e816ad743d46edb60)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow configurations to support additional commit type conventions in release documentation and pull request validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
