### PR TITLE
feat: Add 7 new smoke test scenarios for improved destination coverage

### DIFF
--- a/airbyte/cli/smoke_test_source/_scenarios.py
+++ b/airbyte/cli/smoke_test_source/_scenarios.py
@@ -497,8 +497,16 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {
                 "id": {"type": "integer"},
-                "time_no_tz": {"type": "string", "format": "time"},
-                "time_with_tz": {"type": "string", "format": "time"},
+                "time_no_tz": {
+                    "type": "string",
+                    "format": "time",
+                    "airbyte_type": "time_without_timezone",
+                },
+                "time_with_tz": {
+                    "type": "string",
+                    "format": "time",
+                    "airbyte_type": "time_with_timezone",
+                },
                 "timestamp_no_tz": {
                     "type": "string",
                     "format": "date-time",


### PR DESCRIPTION
## Summary

Adds 7 new single-sync smoke test scenarios to `source-smoke-test`, addressing coverage gaps identified by comparing against destination-snowflake integration tests. Total scenario count goes from 15 → 22.

New scenarios:
| Scenario | What it tests |
|---|---|
| `duplicate_primary_keys` | Dedup behavior when multiple records share the same PK |
| `time_types` | Time-with-timezone, time-without-timezone, timestamp-without-timezone formats (with explicit `airbyte_type` annotations) |
| `union_types` | `oneOf` schemas (string-or-integer, number-or-null, object-or-string) |
| `array_of_primitives` | Arrays of strings, integers, mixed types (complements existing `nested_json_objects`) |
| `large_string_values` | 1 KB / 10 KB / 100 KB strings via a new `generate_large_string_records()` generator |
| `sparse_records` | Different rows populate different column subsets; includes a row with only the PK |
| `special_number_values` | Float64 boundary values (MAX, MIN_SUBNORMAL) and int64/int32 boundaries |

Also adds a new `generate_large_string_records()` function and extends `get_scenario_records()` to dispatch on the `record_generator` field (supporting both `"large_batch"` and the new `"large_strings"`).

Minor cosmetic changes from `ruff format` collapsing implicit string concatenations in existing scenario descriptions.

Multi-execution scenarios (schema evolution, truncate refresh) are tracked separately in #1001.

## Review & Testing Checklist for Human

- [ ] **`union_types` oneOf pattern**: Confirm that `oneOf` is the correct JSON Schema construct for union types in the Airbyte protocol (vs. using `"type": ["string", "integer"]` shorthand). If destinations expect the shorthand form, this scenario may need adjustment.
- [ ] **`special_number_values` boundary floats**: `1.7976931348623157e308` (MAX_FLOAT64) and `5e-324` (MIN_SUBNORMAL) — verify these serialize correctly through the Airbyte protocol JSON layer and don't cause issues with any destination's JSON parser
- [ ] **Run a smoke test against at least one destination** to verify the new scenarios are accepted without errors (e.g. `airbyte destination smoke-test` against a test Snowflake or DuckDB destination). CI passes but no end-to-end destination test was performed.

### Notes
- `time_types` now uses explicit `airbyte_type` annotations (`time_without_timezone`, `time_with_timezone`, `timestamp_without_timezone`) per review feedback from CodeRabbit and Copilot.
- `math.pi` appears in a few test records because `ruff` enforces FURB152 (replace `3.14` literal with `math.pi`). Semantically harmless for test data.
- The `sparse_records` scenario includes `{"id": 7}` — a record with only the primary key and zero optional fields — as an intentional edge case.

Link to Devin session: https://app.devin.ai/sessions/130db0d36ce9492cbfabc49102b11613
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/1002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
