### PR TITLE
fix(telemetry): print analytics banners to stderr instead of stdout

### DIFF
--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -150,7 +150,10 @@ def _setup_analytics() -> str | bool:
 
     if DEBUG and issues:
         nl = "\n"
-        print(f"One or more issues occurred when configuring usage tracking:\n{nl.join(issues)}", file=sys.stderr)
+        print(
+            f"One or more issues occurred when configuring usage tracking:\n{nl.join(issues)}",
+            file=sys.stderr,
+        )
 
     return anonymous_user_id
 


### PR DESCRIPTION
## Summary

Redirects all `print()` calls in `_setup_analytics()` from stdout to stderr by adding `file=sys.stderr`.

**Why:** These diagnostic messages ("Thank you for using PyAirbyte!", analytics ID overrides, tracking config issues) are informational banners, not program output. When PyAirbyte is imported as a transitive dependency by CLI tools (e.g., `airbyte-ops`), shell captures like `RESULT=$(airbyte-ops some-command)` inadvertently pick up the banner text instead of the intended output. This caused a production failure where a connector docker image was tagged `airbyte/source-bing-ads:Thank you for using PyAirbyte!` instead of the expected version string.

Three `print()` calls are affected, all in `_setup_analytics()`:
1. The first-run telemetry notice (line 105)
2. The analytics ID override notice (line 131)
3. The DEBUG-mode issues summary (line 153)

## Review & Testing Checklist for Human

- [ ] Verify no tests assert against stdout content from `_setup_analytics()` — a quick `grep -r "Thank you for using PyAirbyte" tests/` should confirm
- [ ] Confirm the `sys` import doesn't conflict with anything (it shouldn't — `sys` is stdlib and wasn't previously imported in this file)

### Notes

The complementary workaround (`DO_NOT_TRACK=1`) is being added to the airbyte repo's `publish_connectors.yml` workflow as a belt-and-suspenders fix. This PR is the proper root-cause fix; the workflow change is defensive.

Link to Devin session: https://app.devin.ai/sessions/edf592e70e4e4cdf885d2428192500ac
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated message output handling to direct informational messages, warnings, and debug information to the error stream for improved log organization and scripting compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/1003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
