### PR TITLE
fix: Download components.zip instead of components.py from registry

### DIFF
--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -43,7 +43,7 @@ def _try_get_manifest_connector_files(
     source_name: str,
     version: str | None = None,
 ) -> tuple[dict, str | None, str | None]:
-    """Try to get source manifest and components.py from URLs.
+    """Try to get the source manifest and components.zip from URLs and extract components.py.
 
     Returns tuple of (manifest_dict, components_py_content, components_py_checksum).
     Components values are None if components.zip is not found (404 is handled gracefully).


### PR DESCRIPTION
## Summary

The Airbyte connector registry (`connectors.airbyte.com`) serves custom Python components as `components.zip` archives, but PyAirbyte was requesting `components.py` directly — which always 404s. This caused PyAirbyte to silently skip components for all 56 manifest-only connectors that require custom Python components (e.g., `source-slack`, `source-hubspot`, `source-jira`), leading to runtime failures.

This PR changes `_try_get_manifest_connector_files` to:
1. Download `components.zip` instead of `components.py`
2. Extract `components.py` from the zip archive using `zipfile.ZipFile`
3. Raise a clear error if the zip is corrupt or doesn't contain `components.py`

Closes https://github.com/airbytehq/PyAirbyte/issues/997

## Review & Testing Checklist for Human

- [ ] **Verify zip structure**: Confirm that `components.py` lives at the root of the `components.zip` archive served by the registry (not nested in a subdirectory). You can check with: `curl -s "https://connectors.airbyte.com/files/metadata/airbyte/source-slack/3.1.12/components.zip" | python3 -c "import zipfile,sys; print(zipfile.ZipFile(sys.stdin.buffer).namelist())"`
- [ ] **End-to-end test with an affected connector**: Run the reproduction script from the issue against a connector like `source-slack` to confirm components are loaded correctly and `get_available_streams()` succeeds
- [ ] **Verify 404 fallback still works**: Confirm that connectors *without* custom components (where `components.zip` returns 404) still work — the 404 graceful handling path is unchanged but worth a sanity check

### Notes
- No existing tests cover `_try_get_manifest_connector_files`; this fix is verified by lint/format only — manual or integration testing is needed to confirm correctness
- The checksum is computed on the decoded UTF-8 string, consistent with the original behavior

Link to Devin session: https://app.devin.ai/sessions/2164a710e6d3473f8b5ce8d4198b937a
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/pyairbyte/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more actionable error messages when connector component downloads or archive extraction fail, including explicit handling of HTTP 404 (components missing) and corrupt/malformed archives.
  * Graceful handling when components are not available, avoiding installation crashes.

* **Refactor**
  * Switched to retrieving connector components from a packaged archive and extracting the components file for validation; checksum behavior for extracted content remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._