### PR TITLE
feat: prototype MCP docs generation via mcpdocs-gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ viztracer_report.json
 # Packaged docs
 docs/*.zip
 
+# Generated MCP server docs (regenerate via `poe mcp-docs-generate`)
+docs/mcp-generated/
+
 # Misc
 .DS_Store
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -143,3 +143,22 @@ poe mcp-serve-sse      # Server-Sent Events transport on localhost:8000
 
 poe mcp-inspect        # Show all available MCP tools and their schemas
 ```
+
+### Generating static HTML docs for the MCP Server
+
+The repo ships a prototype integration with
+[`mcpdocs-gen`](https://github.com/smytsyk/mcpdocs) that introspects the
+running MCP server (over SSE) and emits a static HTML documentation site:
+
+```bash
+# One-time: install the generator alongside the project's dev deps.
+uv pip install mcpdocs-gen
+
+# Start the MCP server in SSE mode, run mcpdocs, then tear the server down.
+poe mcp-docs-generate
+```
+
+The generated site is written to `docs/mcp-generated/` (git-ignored). Open
+`docs/mcp-generated/index.html` in a browser to browse tools, resources, and
+prompts. The underlying script is at `scripts/generate_mcp_docs.py` and
+handles starting/stopping the SSE server as well as waiting for readiness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ mcp-serve-http = { cmd = "python -c \"from airbyte.mcp.server import app; app.ru
 mcp-serve-sse = { cmd = "python -c \"from airbyte.mcp.server import app; app.run(transport='sse', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with SSE transport" }
 mcp-inspect = { cmd = "fastmcp inspect airbyte/mcp/server.py:app", help = "Inspect MCP tools and resources (supports --tools, --health, etc.)" }
 mcp-tool-test = { cmd = "python -m fastmcp_extensions.utils.test_tool --app airbyte.mcp.server:app", help = "Test MCP tools directly with JSON arguments: poe mcp-tool-test <tool_name> '<json_args>'" }
+mcp-docs-generate = { cmd = "python scripts/generate_mcp_docs.py", help = "Generate static HTML docs for the MCP server into docs/mcp-generated/ using mcpdocs-gen" }
 
 # Claude Code MCP Testing Tasks
 [tool.poe.tasks.test-my-tools]

--- a/scripts/generate_mcp_docs.py
+++ b/scripts/generate_mcp_docs.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Generate static HTML docs for the PyAirbyte MCP server using `mcpdocs-gen`.
+
+This script:
+
+1. Starts the PyAirbyte MCP server in SSE mode as a background subprocess.
+2. Waits for the SSE endpoint to become reachable.
+3. Shells out to `mcpdocs generate` to emit a static HTML site.
+4. Tears down the server subprocess cleanly, even on failure or `Ctrl+C`.
+
+Usage:
+
+```
+uv run python scripts/generate_mcp_docs.py [--port 8765] [--output docs/mcp-generated]
+```
+
+Or via the project's poe task:
+
+```
+poe mcp-docs-generate
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_PORT = 8765
+DEFAULT_OUTPUT = Path("docs/mcp-generated")
+STARTUP_TIMEOUT_SECONDS = 60.0
+
+
+def _wait_for_port(host: str, port: int, timeout: float) -> None:
+    """Block until `host:port` accepts TCP connections or `timeout` elapses."""
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as ex:
+            last_error = ex
+            time.sleep(0.5)
+    raise TimeoutError(
+        f"MCP SSE server did not become reachable at {host}:{port} "
+        f"within {timeout:.0f}s (last error: {last_error!r})."
+    )
+
+
+def _start_mcp_server(host: str, port: int) -> subprocess.Popen[bytes]:
+    """Start the PyAirbyte MCP server in SSE mode as a background subprocess."""
+    cmd = [
+        sys.executable,
+        "-c",
+        (
+            "from airbyte.mcp.server import app; "
+            f"app.run(transport='sse', host={host!r}, port={port})"
+        ),
+    ]
+    # Start in its own process group so we can signal the whole tree on shutdown.
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+
+def _stop_mcp_server(proc: subprocess.Popen[bytes]) -> None:
+    """Terminate the MCP server subprocess tree cleanly."""
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=10.0)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5.0)
+
+
+def _run_mcpdocs(url: str, output: Path) -> None:
+    """Invoke the `mcpdocs generate` CLI to emit a static HTML site."""
+    mcpdocs_bin = shutil.which("mcpdocs")
+    if mcpdocs_bin is None:
+        raise RuntimeError(
+            "`mcpdocs` CLI not found on PATH. Install it with "
+            "`uv pip install mcpdocs-gen` (or `pip install mcpdocs-gen`)."
+        )
+    output.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [mcpdocs_bin, "generate", "--url", url, "--output", str(output)],
+        check=True,
+    )
+
+
+def generate(host: str, port: int, output: Path) -> None:
+    """Start the MCP server, generate docs with mcpdocs-gen, then shut down."""
+    print(f"Starting PyAirbyte MCP server on http://{host}:{port} (SSE)...")
+    proc = _start_mcp_server(host=host, port=port)
+    try:
+        _wait_for_port(host=host, port=port, timeout=STARTUP_TIMEOUT_SECONDS)
+        print(f"Generating MCP docs into {output}/ ...")
+        _run_mcpdocs(url=f"http://{host}:{port}/sse", output=output)
+        print(f"MCP docs written to {output}/index.html")
+    finally:
+        print("Stopping MCP server...")
+        _stop_mcp_server(proc)
+
+
+def main() -> int:
+    """CLI entrypoint for the MCP docs generator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the MCP SSE server to (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"Port to bind the MCP SSE server to (default: {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output directory for generated HTML (default: {DEFAULT_OUTPUT}).",
+    )
+    args = parser.parse_args()
+    try:
+        generate(host=args.host, port=args.port, output=args.output)
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        return 130
+    except (subprocess.CalledProcessError, TimeoutError, RuntimeError) as ex:
+        print(f"MCP docs generation failed: {ex}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Prototype end-to-end workflow for generating static HTML documentation for the PyAirbyte MCP server using [`mcpdocs-gen`](https://github.com/smytsyk/mcpdocs). The generator introspects a running FastMCP server over SSE and emits a searchable static site covering tools, resources, and prompts — positioned as a possible "pdoc3 for MCP servers."

Changes:
- `scripts/generate_mcp_docs.py` — standalone script that starts `airbyte.mcp.server:app` in SSE mode as a background subprocess (in its own process group), TCP-healthchecks the port, shells out to `mcpdocs generate`, and tears the server down cleanly on success, failure, or `Ctrl+C` (SIGTERM with SIGKILL fallback).
- `pyproject.toml` — adds `poe mcp-docs-generate` task alias.
- `.gitignore` — ignores the generated `docs/mcp-generated/` output directory.
- `docs/CONTRIBUTING.md` — adds a short section on how to regenerate MCP docs locally.

`mcpdocs-gen` is **not** added to project dependencies — it's installed ad-hoc via `uv pip install mcpdocs-gen` per the contributing doc, since this is an exploration PR and we don't want to commit to the tool as a first-party dep yet.

Smoke test: the script ran end-to-end against the live PyAirbyte MCP server and produced a site documenting **51 tools, 1 resource, and 1 prompt**. See screenshots and candid evaluation in the session report.

## Review & Testing Checklist for Human

- [ ] Run `uv pip install mcpdocs-gen && poe mcp-docs-generate` on a fresh checkout and confirm `docs/mcp-generated/index.html` renders all 51 tools with arguments, descriptions, and JSON schemas.
- [ ] Sanity-check subprocess cleanup: interrupt the script with `Ctrl+C` mid-run and verify no orphaned Python process is listening on port 8765 afterward (`lsof -iTCP:8765` or `ss -ltnp`).
- [ ] Decide whether the "install mcpdocs-gen separately" UX is acceptable for a prototype, or whether it should be pinned under a dev dependency group before merge.
- [ ] Review the candid evaluation in the session report and decide whether to adopt `mcpdocs-gen` org-wide, restrict it to one-off dumps, or pick a different tool.

### Notes

- The script defaults to port `8765` (not `8000`) to avoid colliding with the existing `poe mcp-serve-sse` task, which hardcodes `127.0.0.1:8000`. `--port` is configurable.
- Per the task's non-goals: the MCP server's tool definitions/docstrings were **not** modified; any doc-quality gaps in the generated output reflect the current state of tool annotations and are called out in the evaluation, not papered over.
- Lint (`uv run ruff check .`, `uv run ruff format --check .`) and type checking (`uv run pyrefly check` — repo uses pyrefly, not mypy) all pass locally.

Link to Devin session: https://app.devin.ai/sessions/359e794efeb844b2a8adf02b5831f999
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for generating static HTML documentation for the MCP server.

* **Documentation**
  * Added instructions for generating MCP server documentation with setup details.

* **Chores**
  * Updated version control configuration to exclude generated documentation directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->