### PR TITLE
feat(mcp): allow MCP tools to specify a docker image / version for the connector

### DIFF
--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -93,9 +93,13 @@ def _resolve_docker_image_and_name(
     If `connector_name` looks like a docker image identifier (i.e. contains a `/`),
     it is treated as a docker image reference and parsed into:
 
-    - `name`: the last path segment, with any `:tag` suffix stripped (e.g.
-      `airbyte/source-mssql:4.4.2` becomes `source-mssql`).
+    - `name`: the last path segment, with any `@sha256:...` digest and `:tag`
+      suffix stripped (e.g. `airbyte/source-mssql:4.4.2` becomes `source-mssql`,
+      and `ghcr.io/airbytehq/source-mssql@sha256:abc` becomes `source-mssql`).
     - `docker_image`: the original `connector_name` string (full image reference).
+
+    Registry-port prefixes (e.g. `localhost:5000/airbyte/source-mssql`) are
+    handled correctly because parsing only inspects the last `/`-segment.
 
     Otherwise, `connector_name` is returned unchanged as `name`, and `docker_image`
     is returned as passed in.
@@ -108,7 +112,8 @@ def _resolve_docker_image_and_name(
         return connector_name, docker_image
 
     last_segment = connector_name.rsplit("/", 1)[-1]
-    name = last_segment.split(":", 1)[0]
+    image_base = last_segment.split("@", 1)[0]
+    name = image_base.split(":", 1)[0]
     return name, docker_image if docker_image is not None else connector_name
 
 
@@ -155,10 +160,14 @@ def _get_mcp_source(
     )
 
     # `get_source` raises if `version` is set and the docker image already has
-    # a `:tag`. Drop the version in that case so the explicit tag wins.
+    # a `:tag` or `@digest`. Drop the version in that case so the explicit ref
+    # wins. Inspect only the last path segment so registry-port prefixes like
+    # `localhost:5000/airbyte/source-mssql` (no tag) are not misread as tagged.
     docker_version = version
-    if isinstance(docker_image_arg, str) and ":" in docker_image_arg:
-        docker_version = None
+    if isinstance(docker_image_arg, str):
+        image_tail = docker_image_arg.rsplit("/", 1)[-1]
+        if "@" in image_tail or ":" in image_tail:
+            docker_version = None
 
     source: Source
     if override_execution_mode == "auto":
@@ -803,9 +812,7 @@ def sync_source_to_cache(  # noqa: PLR0913, PLR0917
     if isinstance(streams, str) and streams == "suggested":
         streams = "*"  # Default to all streams if 'suggested' is not otherwise specified.
         try:
-            metadata = get_connector_metadata(
-                source_connector_name,
-            )
+            metadata = get_connector_metadata(source.name)
         except Exception:
             streams = "*"  # Fallback to all streams if suggested streams fail.
         else:

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -74,8 +74,9 @@ _CONNECTOR_NAME_HELP = (
 _DOCKER_IMAGE_HELP = (
     "Optional docker image override for the connector "
     "(e.g. `airbyte/source-mssql:4.4.2`). When set, docker execution is used "
-    "regardless of `override_execution_mode`. Mutually exclusive with a "
-    "`:tag` already embedded in the image and an explicit `version`."
+    "regardless of `override_execution_mode`. If the image already includes a "
+    "`:tag` or `@digest`, any explicitly provided `version` is ignored. Cannot "
+    "be combined with `manifest_path`."
 )
 _VERSION_HELP = (
     "Optional connector version to pin (e.g. `4.4.2`). Applied to registry "
@@ -141,11 +142,22 @@ def _get_mcp_source(
     `version` pins the registry version when staying on the registry-name path
     and (for docker) sets the image tag if the resolved docker image does not
     already include one.
+
+    Raises `ValueError` if both a docker image (via `connector_name` or
+    `docker_image`) and a `manifest_path` are supplied, since those select
+    different execution modes.
     """
     name, resolved_docker_image = _resolve_docker_image_and_name(
         connector_name=connector_name,
         docker_image=docker_image,
     )
+
+    if resolved_docker_image is not None and manifest_path:
+        raise ValueError(
+            "Cannot combine a docker image with `manifest_path`: "
+            f"got docker_image={resolved_docker_image!r} and "
+            f"manifest_path={manifest_path!r}. Pass only one."
+        )
 
     if resolved_docker_image is not None:
         override_execution_mode = "docker"

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -64,6 +64,53 @@ version. This is useful for testing custom or locally-developed
 connector manifests.
 """
 
+_CONNECTOR_NAME_HELP = (
+    "Either a registered connector name (e.g. `source-mssql`) or a docker "
+    "image identifier containing a `/` "
+    "(e.g. `airbyte/source-mssql`, `airbyte/source-mssql:4.4.2`, or a "
+    "locally-built `airbyte/source-mssql:dev`). Image-shaped values bypass "
+    "registry lookup for the executable and force docker execution."
+)
+_DOCKER_IMAGE_HELP = (
+    "Optional docker image override for the connector "
+    "(e.g. `airbyte/source-mssql:4.4.2`). When set, docker execution is used "
+    "regardless of `override_execution_mode`. Mutually exclusive with a "
+    "`:tag` already embedded in the image and an explicit `version`."
+)
+_VERSION_HELP = (
+    "Optional connector version to pin (e.g. `4.4.2`). Applied to registry "
+    "lookups and to docker image tags when the image does not already "
+    "include a `:tag`."
+)
+
+
+def _resolve_docker_image_and_name(
+    connector_name: str,
+    docker_image: str | None,
+) -> tuple[str, str | None]:
+    """Resolve a connector registry name and docker image override.
+
+    If `connector_name` looks like a docker image identifier (i.e. contains a `/`),
+    it is treated as a docker image reference and parsed into:
+
+    - `name`: the last path segment, with any `:tag` suffix stripped (e.g.
+      `airbyte/source-mssql:4.4.2` becomes `source-mssql`).
+    - `docker_image`: the original `connector_name` string (full image reference).
+
+    Otherwise, `connector_name` is returned unchanged as `name`, and `docker_image`
+    is returned as passed in.
+
+    If the caller passes both an image-shaped `connector_name` and an explicit
+    non-`None` `docker_image`, the explicit `docker_image` wins; the registry
+    name extracted from `connector_name` is still used as `name`.
+    """
+    if "/" not in connector_name:
+        return connector_name, docker_image
+
+    last_segment = connector_name.rsplit("/", 1)[-1]
+    name = last_segment.split(":", 1)[0]
+    return name, docker_image if docker_image is not None else connector_name
+
 
 def _get_mcp_source(
     connector_name: str,
@@ -71,40 +118,79 @@ def _get_mcp_source(
     *,
     install_if_missing: bool = True,
     manifest_path: str | Path | None,
+    docker_image: str | None = None,
+    version: str | None = None,
 ) -> Source:
-    """Get the MCP source for a connector."""
+    """Get the MCP source for a connector.
+
+    `connector_name` accepts either a registered connector name (e.g.
+    `source-mssql`, resolved against the connector registry) or a docker image
+    identifier containing a `/` (e.g. `airbyte/source-mssql`,
+    `airbyte/source-mssql:4.4.2`, or a locally-built `airbyte/source-mssql:dev`).
+    Image-shaped values bypass registry lookup for the executable and force
+    `override_execution_mode="docker"`.
+
+    `docker_image` is an explicit override; when set, `override_execution_mode`
+    is forced to `"docker"` regardless of `connector_name`.
+
+    `version` pins the registry version when staying on the registry-name path
+    and (for docker) sets the image tag if the resolved docker image does not
+    already include one.
+    """
+    name, resolved_docker_image = _resolve_docker_image_and_name(
+        connector_name=connector_name,
+        docker_image=docker_image,
+    )
+
+    if resolved_docker_image is not None:
+        override_execution_mode = "docker"
+
     if manifest_path:
         override_execution_mode = "yaml"
     elif override_execution_mode == "auto" and is_docker_installed():
         override_execution_mode = "docker"
 
+    docker_image_arg: bool | str = (
+        resolved_docker_image if resolved_docker_image is not None else True
+    )
+
+    # `get_source` raises if `version` is set and the docker image already has
+    # a `:tag`. Drop the version in that case so the explicit tag wins.
+    docker_version = version
+    if isinstance(docker_image_arg, str) and ":" in docker_image_arg:
+        docker_version = None
+
     source: Source
     if override_execution_mode == "auto":
         # Use defaults with no overrides
         source = get_source(
-            connector_name,
+            name,
             install_if_missing=False,
             source_manifest=manifest_path or None,
+            version=version,
         )
     elif override_execution_mode == "python":
         source = get_source(
-            connector_name,
+            name,
             use_python=True,
             install_if_missing=False,
             source_manifest=manifest_path or None,
+            version=version,
         )
     elif override_execution_mode == "docker":
         source = get_source(
-            connector_name,
-            docker_image=True,
+            name,
+            docker_image=docker_image_arg,
             install_if_missing=False,
             source_manifest=manifest_path or None,
+            version=docker_version,
         )
     elif override_execution_mode == "yaml":
         source = get_source(
-            connector_name,
+            name,
             source_manifest=manifest_path or True,
             install_if_missing=False,
+            version=version,
         )
     else:
         raise ValueError(
@@ -127,7 +213,7 @@ def _get_mcp_source(
 def validate_connector_config(
     connector_name: Annotated[
         str,
-        Field(description="The name of the connector to validate."),
+        Field(description="The name of the connector to validate. " + _CONNECTOR_NAME_HELP),
     ],
     config: Annotated[
         dict | str | None,
@@ -165,6 +251,14 @@ def validate_connector_config(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> tuple[bool, str]:
     """Validate a connector configuration.
 
@@ -175,6 +269,8 @@ def validate_connector_config(
             connector_name,
             override_execution_mode=override_execution_mode,
             manifest_path=manifest_path,
+            docker_image=docker_image,
+            version=version,
         )
     except Exception as ex:
         return False, f"Failed to get connector '{connector_name}': {ex}"
@@ -254,7 +350,7 @@ def list_dotenv_secrets() -> dict[str, list[str]]:
 def list_source_streams(
     source_connector_name: Annotated[
         str,
-        Field(description="The name of the source connector."),
+        Field(description="The name of the source connector. " + _CONNECTOR_NAME_HELP),
     ],
     config: Annotated[
         dict | str | None,
@@ -292,6 +388,14 @@ def list_source_streams(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> list[str]:
     """List all streams available in a source connector.
 
@@ -301,6 +405,8 @@ def list_source_streams(
         connector_name=source_connector_name,
         override_execution_mode=override_execution_mode,
         manifest_path=manifest_path,
+        docker_image=docker_image,
+        version=version,
     )
     config_dict = resolve_connector_config(
         config=config,
@@ -317,10 +423,10 @@ def list_source_streams(
     idempotent=True,
     extra_help_text=_CONFIG_HELP,
 )
-def get_source_stream_json_schema(
+def get_source_stream_json_schema(  # noqa: PLR0913, PLR0917
     source_connector_name: Annotated[
         str,
-        Field(description="The name of the source connector."),
+        Field(description="The name of the source connector. " + _CONNECTOR_NAME_HELP),
     ],
     stream_name: Annotated[
         str,
@@ -362,12 +468,22 @@ def get_source_stream_json_schema(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> dict[str, Any]:
     """List all properties for a specific stream in a source connector."""
     source: Source = _get_mcp_source(
         connector_name=source_connector_name,
         override_execution_mode=override_execution_mode,
         manifest_path=manifest_path,
+        docker_image=docker_image,
+        version=version,
     )
     config_dict = resolve_connector_config(
         config=config,
@@ -383,10 +499,10 @@ def get_source_stream_json_schema(
     read_only=True,
     extra_help_text=_CONFIG_HELP,
 )
-def read_source_stream_records(
+def read_source_stream_records(  # noqa: PLR0913
     source_connector_name: Annotated[
         str,
-        Field(description="The name of the source connector."),
+        Field(description="The name of the source connector. " + _CONNECTOR_NAME_HELP),
     ],
     config: Annotated[
         dict | str | None,
@@ -436,6 +552,14 @@ def read_source_stream_records(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> list[dict[str, Any]] | str:
     """Get records from a source connector."""
     try:
@@ -443,6 +567,8 @@ def read_source_stream_records(
             connector_name=source_connector_name,
             override_execution_mode=override_execution_mode,
             manifest_path=manifest_path,
+            docker_image=docker_image,
+            version=version,
         )
         config_dict = resolve_connector_config(
             config=config,
@@ -473,10 +599,10 @@ def read_source_stream_records(
     read_only=True,
     extra_help_text=_CONFIG_HELP,
 )
-def get_stream_previews(
+def get_stream_previews(  # noqa: PLR0913, PLR0917
     source_name: Annotated[
         str,
-        Field(description="The name of the source connector."),
+        Field(description="The name of the source connector. " + _CONNECTOR_NAME_HELP),
     ],
     config: Annotated[
         dict | str | None,
@@ -531,6 +657,14 @@ def get_stream_previews(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> dict[str, list[dict[str, Any]] | str]:
     """Get sample records (previews) from streams in a source connector.
 
@@ -542,6 +676,8 @@ def get_stream_previews(
         connector_name=source_name,
         override_execution_mode=override_execution_mode,
         manifest_path=manifest_path,
+        docker_image=docker_image,
+        version=version,
     )
 
     config_dict = resolve_connector_config(
@@ -585,10 +721,10 @@ def get_stream_previews(
     destructive=False,
     extra_help_text=_CONFIG_HELP,
 )
-def sync_source_to_cache(
+def sync_source_to_cache(  # noqa: PLR0913, PLR0917
     source_connector_name: Annotated[
         str,
-        Field(description="The name of the source connector."),
+        Field(description="The name of the source connector. " + _CONNECTOR_NAME_HELP),
     ],
     config: Annotated[
         dict | str | None,
@@ -633,12 +769,22 @@ def sync_source_to_cache(
             default=None,
         ),
     ],
+    docker_image: Annotated[
+        str | None,
+        Field(description=_DOCKER_IMAGE_HELP, default=None),
+    ],
+    version: Annotated[
+        str | None,
+        Field(description=_VERSION_HELP, default=None),
+    ],
 ) -> str:
     """Run a sync from a source connector to the default DuckDB cache."""
     source: Source = _get_mcp_source(
         connector_name=source_connector_name,
         override_execution_mode=override_execution_mode,
         manifest_path=manifest_path,
+        docker_image=docker_image,
+        version=version,
     )
     config_dict = resolve_connector_config(
         config=config,

--- a/tests/unit_tests/test_mcp_local.py
+++ b/tests/unit_tests/test_mcp_local.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Unit tests for the local MCP wrappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from airbyte.mcp.local import _resolve_docker_image_and_name
+
+
+@pytest.mark.parametrize(
+    ("connector_name", "docker_image", "expected_name", "expected_image"),
+    [
+        pytest.param(
+            "source-mssql",
+            None,
+            "source-mssql",
+            None,
+            id="registry_name_passthrough",
+        ),
+        pytest.param(
+            "source-mssql",
+            "airbyte/source-mssql:dev",
+            "source-mssql",
+            "airbyte/source-mssql:dev",
+            id="registry_name_with_explicit_image_override",
+        ),
+        pytest.param(
+            "airbyte/source-mssql",
+            None,
+            "source-mssql",
+            "airbyte/source-mssql",
+            id="image_id_no_tag",
+        ),
+        pytest.param(
+            "airbyte/source-mssql:4.4.2",
+            None,
+            "source-mssql",
+            "airbyte/source-mssql:4.4.2",
+            id="image_id_with_pinned_tag",
+        ),
+        pytest.param(
+            "airbyte/source-mssql:dev",
+            None,
+            "source-mssql",
+            "airbyte/source-mssql:dev",
+            id="image_id_with_dev_tag",
+        ),
+        pytest.param(
+            "ghcr.io/airbytehq/source-mssql:4.4.2",
+            None,
+            "source-mssql",
+            "ghcr.io/airbytehq/source-mssql:4.4.2",
+            id="multi_segment_image_path",
+        ),
+        pytest.param(
+            "airbyte/source-mssql:4.4.2",
+            "airbyte/source-mssql:dev",
+            "source-mssql",
+            "airbyte/source-mssql:dev",
+            id="image_id_plus_explicit_image_override_wins",
+        ),
+    ],
+)
+def test_resolve_docker_image_and_name(
+    connector_name: str,
+    docker_image: str | None,
+    expected_name: str,
+    expected_image: str | None,
+) -> None:
+    name, image = _resolve_docker_image_and_name(
+        connector_name=connector_name,
+        docker_image=docker_image,
+    )
+    assert name == expected_name
+    assert image == expected_image

--- a/tests/unit_tests/test_mcp_local.py
+++ b/tests/unit_tests/test_mcp_local.py
@@ -60,6 +60,27 @@ from airbyte.mcp.local import _resolve_docker_image_and_name
             "airbyte/source-mssql:dev",
             id="image_id_plus_explicit_image_override_wins",
         ),
+        pytest.param(
+            "ghcr.io/airbytehq/source-mssql@sha256:abc123",
+            None,
+            "source-mssql",
+            "ghcr.io/airbytehq/source-mssql@sha256:abc123",
+            id="image_id_with_digest",
+        ),
+        pytest.param(
+            "localhost:5000/airbyte/source-mssql",
+            None,
+            "source-mssql",
+            "localhost:5000/airbyte/source-mssql",
+            id="image_id_with_registry_port_no_tag",
+        ),
+        pytest.param(
+            "localhost:5000/airbyte/source-mssql:4.4.2",
+            None,
+            "source-mssql",
+            "localhost:5000/airbyte/source-mssql:4.4.2",
+            id="image_id_with_registry_port_and_tag",
+        ),
     ],
 )
 def test_resolve_docker_image_and_name(


### PR DESCRIPTION
## Summary

Closes airbytehq/PyAirbyte#1018.

The local MCP tools in `airbyte/mcp/local.py` previously accepted only a registry connector name (`source-mssql`) and silently resolved everything via the registry. As a result, MCP callers could not pin to a specific connector version, could not point at a custom-built image (e.g. `airbyte/source-mssql:dev` after `docker build`), and would always pull whatever the registry resolved at the moment of the call.

This PR exposes both compatible shapes from the issue, mirroring `get_source(name=..., docker_image=..., version=...)`:

1. **Overloads `connector_name`** — values containing a `/` are treated as docker image identifiers (e.g. `airbyte/source-mssql`, `airbyte/source-mssql:4.4.2`, `airbyte/source-mssql:dev`, `ghcr.io/airbytehq/source-mssql:4.4.2`). Image-shaped values bypass registry lookup for the executable, infer the registry name from the last path segment (with any `:tag` stripped), and force docker execution.
2. **Adds explicit `docker_image: str | None` and `version: str | None` keyword args** — these mirror the `get_source(...)` parameters. When `docker_image` is set, docker execution is forced regardless of `override_execution_mode`. `version` pins the registry version when staying on the registry-name path and the docker image tag when the resolved image does not already include one.

Updated tools:
- `validate_connector_config`
- `list_source_streams`
- `get_source_stream_json_schema`
- `read_source_stream_records`
- `get_stream_previews`
- `sync_source_to_cache`

The existing `destination_smoke_test` already accepted `docker_image`, so it is unchanged.

The previous code path always passed `docker_image=True` to `get_source(...)` in docker mode, which forced the registry-name lookup before the docker override could take effect. The new `_get_mcp_source` resolves an explicit docker image first, decouples the registry name from the executable image, and forwards both `docker_image` and `version` through to `get_source(...)`.

A small private helper `_resolve_docker_image_and_name` encapsulates the parsing rules and is unit-tested against the worked examples from the issue (registry passthrough, image identifiers with/without tags, multi-segment paths, explicit override precedence).

## Review & Testing Checklist for Human

- [ ] Verify image-shaped `connector_name` values still work for connectors whose registry name does NOT match the last path segment (e.g. private registries with renamed images). The current behavior treats the last path segment with any `:tag` stripped as the registry `name`; if that segment is not a registered connector, the registry lookup is silently skipped (matching `get_source(docker_image=...)` behavior).
- [ ] Smoke-test the worked example from the issue: invoke `validate_connector_config` (and `read_source_stream_records`) with a pinned image like `airbyte/source-mssql:4.4.2` and verify the source executes against that exact image without permission/path errors.
- [ ] Confirm the new `docker_image` / `version` kwargs surface correctly in coral-mcp / FastMCP schemas (the `_DOCKER_IMAGE_HELP` / `_VERSION_HELP` field descriptions are what callers will see).

### Notes

- Lint (`ruff check`, `ruff format --check`) and type check (`pyrefly check`) pass cleanly.
- Full unit test suite passes locally (`pytest tests/unit_tests/ -m "not slow"` — 219 passed, 1 skipped).
- The new test module `tests/unit_tests/test_mcp_local.py` covers `_resolve_docker_image_and_name` with parametrized cases mirroring the proposal in airbytehq/PyAirbyte#1018.
- This unblocks the CDC repro harness work in airbytehq/airbyte#77775 and the playbook update in airbytehq/ai-skills#302.


Link to Devin session: https://app.devin.ai/sessions/a734523681944e4d9b1dfee5792cce69
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support explicit Docker image overrides and version pinning for MCP data sources, enabling per-connector execution control.
  * MCP source tooling and endpoints now accept docker image and version parameters and surface updated field descriptions for clarity.

* **Tests**
  * Added unit tests covering Docker image resolution and override precedence across connector naming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->