### PR TITLE
feat(mcp): expose connector LOG/stderr capture from read tools

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -440,6 +440,7 @@ class ConnectorBase(abc.ABC):
         stdin: IO[str] | AirbyteMessageIterator | None = None,
         *,
         progress_tracker: ProgressTracker | None = None,
+        log_file: IO[str] | None = None,
     ) -> Generator[AirbyteMessage, None, None]:
         """Execute the connector with the given arguments.
 
@@ -448,6 +449,13 @@ class ConnectorBase(abc.ABC):
         * Spawn a subprocess with .venv-<connector_name>/bin/<connector-name> <args>
         * Read the output line by line of the subprocess and serialize them AirbyteMessage objects.
           Drop if not valid.
+
+        If `log_file` is provided, the connector subprocess's stderr will be redirected to
+        that writable text-mode file object. This is useful in MCP-server mode where the
+        parent process's stderr is not visible to the caller. When a `progress_tracker`
+        is set, stderr is normally suppressed to avoid mixing with the progress display,
+        but providing a `log_file` overrides that and captures stderr to the file
+        instead.
 
         Raises:
             AirbyteConnectorFailedError: If the process returns a failure status (non-zero).
@@ -473,8 +481,16 @@ class ConnectorBase(abc.ABC):
         )
 
         try:
-            suppress_stderr = progress_tracker is not None
-            for line in self.executor.execute(args, stdin=stdin, suppress_stderr=suppress_stderr):
+            # Suppress stderr by default when a progress tracker is active to avoid
+            # mixing connector stderr with the progress display. If a log_file is
+            # explicitly provided, capture stderr to the file instead of suppressing it.
+            suppress_stderr = progress_tracker is not None and log_file is None
+            for line in self.executor.execute(
+                args,
+                stdin=stdin,
+                suppress_stderr=suppress_stderr,
+                log_file=log_file,
+            ):
                 try:
                     message: AirbyteMessage = AirbyteMessage.model_validate_json(json_data=line)
                     if progress_tracker and message.record:

--- a/airbyte/_executors/base.py
+++ b/airbyte/_executors/base.py
@@ -221,17 +221,24 @@ class Executor(ABC):
         *,
         stdin: IO[str] | AirbyteMessageIterator | None = None,
         suppress_stderr: bool = False,
+        log_file: IO[str] | None = None,
     ) -> Iterator[str]:
         """Execute a command and return an iterator of STDOUT lines.
 
-        If stdin is provided, it will be passed to the subprocess as STDIN.
-        If suppress_stderr is True, stderr output will be suppressed to reduce noise.
+        If `stdin` is provided, it will be passed to the subprocess as STDIN.
+
+        If `suppress_stderr` is `True`, stderr output will be suppressed to reduce noise.
+
+        If `log_file` is provided (and `suppress_stderr` is `False`), the connector
+        subprocess's stderr will be redirected to that writable text-mode file object.
+        Otherwise stderr is inherited from the parent process.
         """
         mapped_args = self.map_cli_args(args)
         with _stream_from_subprocess(
             [*self._cli, *mapped_args],
             stdin=stdin,
             suppress_stderr=suppress_stderr,
+            log_file=log_file,
         ) as stream_lines:
             yield from stream_lines
 

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -119,9 +119,10 @@ class DeclarativeExecutor(Executor):
         *,
         stdin: IO[str] | AirbyteMessageIterator | None = None,
         suppress_stderr: bool = False,
+        log_file: IO[str] | None = None,
     ) -> Iterator[str]:
         """Execute the declarative source."""
-        _ = stdin, suppress_stderr  # Not used
+        _ = stdin, suppress_stderr, log_file  # Not used (in-process execution)
         source_entrypoint = AirbyteEntrypoint(self.declarative_source)
 
         mapped_args: list[str] = self.map_cli_args(args)

--- a/airbyte/_executors/noop.py
+++ b/airbyte/_executors/noop.py
@@ -66,12 +66,13 @@ class NoOpExecutor(Executor):
         *,
         stdin: IO[str] | AirbyteMessageIterator | None = None,
         suppress_stderr: bool = False,
+        log_file: IO[str] | None = None,
     ) -> Iterator[str]:
         """Execute a command and return an iterator of STDOUT lines.
 
         Only the 'spec' command is supported. Other commands will raise an error.
         """
-        _ = stdin, suppress_stderr  # Unused
+        _ = stdin, suppress_stderr, log_file  # Unused (no subprocess)
 
         if args == ["spec"]:
             if self._cached_spec is None:

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -10,11 +10,14 @@
 # tool / helper definitions as a redundant "API Documentation" list.
 __all__: list[str] = []
 
+import contextlib
+import os
 import sys
+import tempfile
 import traceback
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import IO, TYPE_CHECKING, Annotated, Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp_extensions import mcp_tool, register_mcp_tools
@@ -63,6 +66,139 @@ specify a local YAML manifest file instead of using the registry
 version. This is useful for testing custom or locally-developed
 connector manifests.
 """
+
+
+_LOG_CAPTURE_HELP = """
+You can optionally capture the connector subprocess's stderr (LOG / TRACE
+output and any non-JSON-protocol writes) by setting `log_file_path` to a
+filesystem path. The file will be opened in text-mode write and overwritten
+if it already exists. The directory will be created if it does not exist.
+
+For short repros, you can also set `include_logs_in_response=True` to embed
+the captured logs in the response payload alongside the records. When set,
+the return shape becomes a structured object containing both the records
+and the logs. If `include_logs_in_response=True` is set without a
+`log_file_path`, a temporary file is used internally and discarded after
+its contents are read back into the response.
+"""
+
+
+class StreamRecordsResponse(BaseModel):
+    """Structured response for `read_source_stream_records` when logs are requested.
+
+    Returned when `include_logs_in_response=True`. Contains the records read from
+    the stream, the captured connector stderr, and an optional error message if
+    reading failed.
+    """
+
+    records: list[dict[str, Any]] = Field(default_factory=list)
+    """The records read from the stream. Empty if reading failed."""
+    logs: str = ""
+    """The captured stderr output from the connector subprocess."""
+    error: str | None = None
+    """The error message (with traceback) if reading failed; `None` on success."""
+
+
+class StreamPreviewsResponse(BaseModel):
+    """Structured response for `get_stream_previews` when logs are requested.
+
+    Returned when `include_logs_in_response=True`. Contains the per-stream sample
+    records and the captured connector stderr.
+    """
+
+    previews: dict[str, list[dict[str, Any]] | str] = Field(default_factory=dict)
+    """Mapping of stream name to sample records, or per-stream error message."""
+    logs: str = ""
+    """The captured stderr output from the connector subprocess."""
+    error: str | None = None
+    """A top-level error message if previewing failed before any per-stream attempt."""
+
+
+class SyncResultResponse(BaseModel):
+    """Structured response for `sync_source_to_cache` when logs are requested.
+
+    Returned when `include_logs_in_response=True`. Contains the sync summary
+    message and the captured connector stderr.
+    """
+
+    summary: str = ""
+    """The sync summary message."""
+    logs: str = ""
+    """The captured stderr output from the connector subprocess."""
+
+
+class _LogCapture:
+    """Context manager for connector stderr capture in MCP tools.
+
+    Behavior:
+
+    * If `log_file_path` is provided, the connector subprocess's stderr is
+      written to that path (parent directory created if needed). The file is
+      kept after the context exits.
+    * If `log_file_path` is `None` and `include_in_response` is `True`, a
+      temporary file is used and removed after the context exits.
+    * If both are unset, no capture occurs and `file` is `None`.
+
+    Use `read_logs()` after the subprocess has finished (still inside the
+    `with` block) to read back the captured contents. The file is closed
+    on first read so that all data is flushed to disk.
+    """
+
+    def __init__(
+        self,
+        log_file_path: str | Path | None,
+        *,
+        include_in_response: bool,
+    ) -> None:
+        self.include_in_response: bool = include_in_response
+        self._is_temp: bool = log_file_path is None and include_in_response
+        self._path: Path | None = None
+        self._file: IO[str] | None = None
+
+        if self._is_temp:
+            fd, name = tempfile.mkstemp(suffix=".log", prefix="pyairbyte-mcp-stderr-")
+            os.close(fd)
+            self._path = Path(name)
+        elif log_file_path is not None:
+            self._path = Path(log_file_path)
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def __enter__(self) -> "_LogCapture":
+        if self._path is not None:
+            self._file = self._path.open("w", encoding="utf-8")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        if self._file is not None and not self._file.closed:
+            self._file.close()
+        if self._is_temp and self._path is not None and self._path.exists():
+            # Best-effort cleanup; don't mask any in-flight exception.
+            with contextlib.suppress(OSError):
+                self._path.unlink()
+
+    @property
+    def file(self) -> IO[str] | None:
+        """The writable text-mode file for connector stderr, or `None` if no capture."""
+        return self._file
+
+    def read_logs(self) -> str:
+        """Read the captured logs.
+
+        Returns the log file contents, or an empty string if no capture was
+        configured. Closes the file (if still open) so that buffered writes
+        are flushed to disk before reading.
+        """
+        if self._path is None:
+            return ""
+        if self._file is not None and not self._file.closed:
+            self._file.flush()
+            self._file.close()
+        return self._path.read_text(encoding="utf-8")
 
 
 def _get_mcp_source(
@@ -381,9 +517,9 @@ def get_source_stream_json_schema(
 
 @mcp_tool(
     read_only=True,
-    extra_help_text=_CONFIG_HELP,
+    extra_help_text=_CONFIG_HELP + _LOG_CAPTURE_HELP,
 )
-def read_source_stream_records(
+def read_source_stream_records(  # noqa: PLR0913
     source_connector_name: Annotated[
         str,
         Field(description="The name of the source connector."),
@@ -436,44 +572,79 @@ def read_source_stream_records(
             default=None,
         ),
     ],
-) -> list[dict[str, Any]] | str:
+    log_file_path: Annotated[
+        str | Path | None,
+        Field(
+            description="Optional path to a file where the connector subprocess's stderr "
+            "(LOG / TRACE messages) will be written. The file is opened in text mode and "
+            "overwritten if it already exists. Parent directories are created as needed.",
+            default=None,
+        ),
+    ],
+    include_logs_in_response: Annotated[
+        bool,
+        Field(
+            description="If True, the captured connector stderr is read back and embedded "
+            "in the response payload. The return shape becomes a `StreamRecordsResponse` "
+            "object with `records`, `logs`, and `error` fields. If `log_file_path` is not "
+            "set, a temporary file is used internally.",
+            default=False,
+        ),
+    ],
+) -> list[dict[str, Any]] | str | StreamRecordsResponse:
     """Get records from a source connector."""
-    try:
-        source: Source = _get_mcp_source(
-            connector_name=source_connector_name,
-            override_execution_mode=override_execution_mode,
-            manifest_path=manifest_path,
-        )
-        config_dict = resolve_connector_config(
-            config=config,
-            config_file=config_file,
-            config_secret_name=config_secret_name,
-            config_spec_jsonschema=source.config_spec,
-        )
-        source.set_config(config_dict)
-        # First we get a generator for the records in the specified stream.
-        record_generator = source.get_records(stream_name)
-        # Next we load a limited number of records from the generator into our list.
-        records: list[dict[str, Any]] = list(islice(record_generator, max_records))
+    with _LogCapture(
+        log_file_path,
+        include_in_response=include_logs_in_response,
+    ) as log_capture:
+        try:
+            source: Source = _get_mcp_source(
+                connector_name=source_connector_name,
+                override_execution_mode=override_execution_mode,
+                manifest_path=manifest_path,
+            )
+            config_dict = resolve_connector_config(
+                config=config,
+                config_file=config_file,
+                config_secret_name=config_secret_name,
+                config_spec_jsonschema=source.config_spec,
+            )
+            source.set_config(config_dict)
+            # First we get a generator for the records in the specified stream.
+            record_generator = source.get_records(stream_name, log_file=log_capture.file)
+            # Next we load a limited number of records from the generator into our list.
+            records: list[dict[str, Any]] = list(islice(record_generator, max_records))
 
-        print(f"Retrieved {len(records)} records from stream '{stream_name}'", sys.stderr)
+            print(f"Retrieved {len(records)} records from stream '{stream_name}'", sys.stderr)
 
-    except Exception as ex:
-        tb_str = traceback.format_exc()
-        # If any error occurs, we print the error message to stderr and return an empty list.
-        return (
-            f"Error reading records from source '{source_connector_name}': {ex!r}, {ex!s}\n{tb_str}"
-        )
+        except Exception as ex:
+            tb_str = traceback.format_exc()
+            error_msg = (
+                f"Error reading records from source '{source_connector_name}': "
+                f"{ex!r}, {ex!s}\n{tb_str}"
+            )
+            if include_logs_in_response:
+                return StreamRecordsResponse(
+                    records=[],
+                    logs=log_capture.read_logs(),
+                    error=error_msg,
+                )
+            return error_msg
 
-    else:
+        if include_logs_in_response:
+            return StreamRecordsResponse(
+                records=records,
+                logs=log_capture.read_logs(),
+                error=None,
+            )
         return records
 
 
 @mcp_tool(
     read_only=True,
-    extra_help_text=_CONFIG_HELP,
+    extra_help_text=_CONFIG_HELP + _LOG_CAPTURE_HELP,
 )
-def get_stream_previews(
+def get_stream_previews(  # noqa: PLR0913, PLR0917
     source_name: Annotated[
         str,
         Field(description="The name of the source connector."),
@@ -531,61 +702,101 @@ def get_stream_previews(
             default=None,
         ),
     ],
-) -> dict[str, list[dict[str, Any]] | str]:
+    log_file_path: Annotated[
+        str | Path | None,
+        Field(
+            description="Optional path to a file where the connector subprocess's stderr "
+            "(LOG / TRACE messages) will be written, accumulating across all per-stream "
+            "preview calls. The file is opened in text mode and overwritten if it already "
+            "exists. Parent directories are created as needed.",
+            default=None,
+        ),
+    ],
+    include_logs_in_response: Annotated[
+        bool,
+        Field(
+            description="If True, the captured connector stderr is read back and embedded "
+            "in the response payload. The return shape becomes a `StreamPreviewsResponse` "
+            "object with `previews`, `logs`, and `error` fields. If `log_file_path` is not "
+            "set, a temporary file is used internally.",
+            default=False,
+        ),
+    ],
+) -> dict[str, list[dict[str, Any]] | str] | StreamPreviewsResponse:
     """Get sample records (previews) from streams in a source connector.
 
     This operation requires a valid configuration, including any required secrets.
     Returns a dictionary mapping stream names to lists of sample records, or an error
     message string if an error occurred for that stream.
     """
-    source: Source = _get_mcp_source(
-        connector_name=source_name,
-        override_execution_mode=override_execution_mode,
-        manifest_path=manifest_path,
-    )
-
-    config_dict = resolve_connector_config(
-        config=config,
-        config_file=config_file,
-        config_secret_name=config_secret_name,
-        config_spec_jsonschema=source.config_spec,
-    )
-    source.set_config(config_dict)
-
-    streams_param: list[str] | Literal["*"] | None = resolve_list_of_strings(
-        streams
-    )  # pyrefly: ignore[no-matching-overload]
-    if streams_param and len(streams_param) == 1 and streams_param[0] == "*":
-        streams_param = "*"
-
-    try:
-        samples_result = source.get_samples(
-            streams=streams_param,
-            limit=limit,
-            on_error="ignore",
+    with _LogCapture(
+        log_file_path,
+        include_in_response=include_logs_in_response,
+    ) as log_capture:
+        source: Source = _get_mcp_source(
+            connector_name=source_name,
+            override_execution_mode=override_execution_mode,
+            manifest_path=manifest_path,
         )
-    except Exception as ex:
-        tb_str = traceback.format_exc()
-        return {
-            "ERROR": f"Error getting stream previews from source '{source_name}': "
-            f"{ex!r}, {ex!s}\n{tb_str}"
-        }
 
-    result: dict[str, list[dict[str, Any]] | str] = {}
-    for stream_name, dataset in samples_result.items():
-        if dataset is None:
-            result[stream_name] = f"Could not retrieve stream samples for stream '{stream_name}'"
-        else:
-            result[stream_name] = list(dataset)
+        config_dict = resolve_connector_config(
+            config=config,
+            config_file=config_file,
+            config_secret_name=config_secret_name,
+            config_spec_jsonschema=source.config_spec,
+        )
+        source.set_config(config_dict)
 
-    return result
+        streams_param: list[str] | Literal["*"] | None = resolve_list_of_strings(
+            streams
+        )  # pyrefly: ignore[no-matching-overload]
+        if streams_param and len(streams_param) == 1 and streams_param[0] == "*":
+            streams_param = "*"
+
+        try:
+            samples_result = source.get_samples(
+                streams=streams_param,
+                limit=limit,
+                on_error="ignore",
+                log_file=log_capture.file,
+            )
+        except Exception as ex:
+            tb_str = traceback.format_exc()
+            error_msg = (
+                f"Error getting stream previews from source '{source_name}': "
+                f"{ex!r}, {ex!s}\n{tb_str}"
+            )
+            if include_logs_in_response:
+                return StreamPreviewsResponse(
+                    previews={},
+                    logs=log_capture.read_logs(),
+                    error=error_msg,
+                )
+            return {"ERROR": error_msg}
+
+        result: dict[str, list[dict[str, Any]] | str] = {}
+        for stream_name, dataset in samples_result.items():
+            if dataset is None:
+                result[stream_name] = (
+                    f"Could not retrieve stream samples for stream '{stream_name}'"
+                )
+            else:
+                result[stream_name] = list(dataset)
+
+        if include_logs_in_response:
+            return StreamPreviewsResponse(
+                previews=result,
+                logs=log_capture.read_logs(),
+                error=None,
+            )
+        return result
 
 
 @mcp_tool(
     destructive=False,
-    extra_help_text=_CONFIG_HELP,
+    extra_help_text=_CONFIG_HELP + _LOG_CAPTURE_HELP,
 )
-def sync_source_to_cache(
+def sync_source_to_cache(  # noqa: PLR0913, PLR0917
     source_connector_name: Annotated[
         str,
         Field(description="The name of the source connector."),
@@ -633,51 +844,82 @@ def sync_source_to_cache(
             default=None,
         ),
     ],
-) -> str:
+    log_file_path: Annotated[
+        str | Path | None,
+        Field(
+            description="Optional path to a file where the connector subprocess's stderr "
+            "(LOG / TRACE messages) will be written for the duration of the sync. The "
+            "file is opened in text mode and overwritten if it already exists. Parent "
+            "directories are created as needed.",
+            default=None,
+        ),
+    ],
+    include_logs_in_response: Annotated[
+        bool,
+        Field(
+            description="If True, the captured connector stderr is read back and embedded "
+            "in the response payload. The return shape becomes a `SyncResultResponse` "
+            "object with `summary` and `logs` fields. If `log_file_path` is not set, a "
+            "temporary file is used internally.",
+            default=False,
+        ),
+    ],
+) -> str | SyncResultResponse:
     """Run a sync from a source connector to the default DuckDB cache."""
-    source: Source = _get_mcp_source(
-        connector_name=source_connector_name,
-        override_execution_mode=override_execution_mode,
-        manifest_path=manifest_path,
-    )
-    config_dict = resolve_connector_config(
-        config=config,
-        config_file=config_file,
-        config_secret_name=config_secret_name,
-        config_spec_jsonschema=source.config_spec,
-    )
-    source.set_config(config_dict)
-    cache = get_default_cache()
+    with _LogCapture(
+        log_file_path,
+        include_in_response=include_logs_in_response,
+    ) as log_capture:
+        source: Source = _get_mcp_source(
+            connector_name=source_connector_name,
+            override_execution_mode=override_execution_mode,
+            manifest_path=manifest_path,
+        )
+        config_dict = resolve_connector_config(
+            config=config,
+            config_file=config_file,
+            config_secret_name=config_secret_name,
+            config_spec_jsonschema=source.config_spec,
+        )
+        source.set_config(config_dict)
+        cache = get_default_cache()
 
-    streams = resolve_list_of_strings(streams)
-    if streams and len(streams) == 1 and streams[0] in {"*", "suggested"}:
-        # Float '*' and 'suggested' to the top-level for special processing:
-        streams = streams[0]
+        streams = resolve_list_of_strings(streams)
+        if streams and len(streams) == 1 and streams[0] in {"*", "suggested"}:
+            # Float '*' and 'suggested' to the top-level for special processing:
+            streams = streams[0]
 
-    if isinstance(streams, str) and streams == "suggested":
-        streams = "*"  # Default to all streams if 'suggested' is not otherwise specified.
-        try:
-            metadata = get_connector_metadata(
-                source_connector_name,
+        if isinstance(streams, str) and streams == "suggested":
+            streams = "*"  # Default to all streams if 'suggested' is not otherwise specified.
+            try:
+                metadata = get_connector_metadata(
+                    source_connector_name,
+                )
+            except Exception:
+                streams = "*"  # Fallback to all streams if suggested streams fail.
+            else:
+                if metadata is not None:
+                    streams = metadata.suggested_streams or "*"
+
+        if isinstance(streams, str) and streams != "*":
+            streams = [streams]  # Ensure streams is a list
+
+        source.read(
+            cache=cache,
+            streams=streams,
+            log_file=log_capture.file,
+        )
+        del cache  # Ensure the cache is closed properly
+
+        summary: str = f"Sync completed for '{source_connector_name}'!\n\n"
+        summary += "Data written to default DuckDB cache\n"
+
+        if include_logs_in_response:
+            return SyncResultResponse(
+                summary=summary,
+                logs=log_capture.read_logs(),
             )
-        except Exception:
-            streams = "*"  # Fallback to all streams if suggested streams fail.
-        else:
-            if metadata is not None:
-                streams = metadata.suggested_streams or "*"
-
-    if isinstance(streams, str) and streams != "*":
-        streams = [streams]  # Ensure streams is a list
-
-    source.read(
-        cache=cache,
-        streams=streams,
-    )
-    del cache  # Ensure the cache is closed properly
-
-    summary: str = f"Sync completed for '{source_connector_name}'!\n\n"
-    summary += "Data written to default DuckDB cache\n"
-    return summary
+        return summary
 
 
 class CachedDatasetInfo(BaseModel):

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -8,7 +8,7 @@ import threading
 import time
 import warnings
 from itertools import islice
-from typing import TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 import yaml
 from rich import print  # noqa: A004  # Allow shadowing the built-in
@@ -518,6 +518,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
         stop_event: threading.Event | None = None,
         normalize_field_names: bool = False,
         prune_undeclared_fields: bool = True,
+        log_file: IO[str] | None = None,
     ) -> LazyDataset:
         """Read a stream from the connector.
 
@@ -533,6 +534,10 @@ class Source(ConnectorBase):  # noqa: PLR0904
                 which generally matches the behavior of PyAirbyte caches and most Airbyte
                 destinations, specifically when you expect the catalog may be stale. You can disable
                 this to keep all fields in the records.
+            log_file: Optional writable text-mode file object. When provided, the connector
+                subprocess's stderr will be redirected to this file instead of inherited from
+                the parent process. The file must remain open for the duration of record
+                iteration since records are pulled lazily.
 
         This involves the following steps:
         * Call discover to get the catalog
@@ -583,6 +588,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
                 catalog=configured_catalog,
                 progress_tracker=progress_tracker,
                 stop_event=stop_event,
+                log_file=log_file,
             )
             if record.record
         )
@@ -627,8 +633,14 @@ class Source(ConnectorBase):  # noqa: PLR0904
         *,
         limit: int = 5,
         on_error: Literal["raise", "ignore", "log"] = "raise",
+        log_file: IO[str] | None = None,
     ) -> dict[str, InMemoryDataset | None]:
-        """Get a sample of records from the given streams."""
+        """Get a sample of records from the given streams.
+
+        If `log_file` is provided, each per-stream connector subprocess's stderr will be
+        redirected to that writable text-mode file object. The file must remain open for
+        the duration of this call.
+        """
         if streams == "*":
             streams = self.get_available_streams()
         elif streams is None:
@@ -642,6 +654,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
                     stream,
                     limit=limit,
                     stop_event=stop_event,
+                    log_file=log_file,
                 ).fetch_all()
                 stop_event.set()
             except Exception as ex:
@@ -762,6 +775,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
         *,
         state: StateProviderBase | None = None,
         stop_event: threading.Event | None = None,
+        log_file: IO[str] | None = None,
     ) -> Generator[AirbyteMessage, None, None]:
         """Call read on the connector.
 
@@ -771,6 +785,9 @@ class Source(ConnectorBase):  # noqa: PLR0904
         * Listen to the messages and return the AirbyteRecordMessages that come along.
         * Send out telemetry on the performed sync (with information about which source was used and
           the type of the cache)
+
+        If `log_file` is provided, the connector subprocess's stderr will be redirected to
+        that writable text-mode file object.
         """
         with as_temp_files(
             [
@@ -794,6 +811,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
                     state_file,
                 ],
                 progress_tracker=progress_tracker,
+                log_file=log_file,
             )
             for message in progress_tracker.tally_records_read(message_generator):
                 if stop_event and stop_event.is_set():
@@ -843,6 +861,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
         write_strategy: str | WriteStrategy = WriteStrategy.AUTO,
         force_full_refresh: bool = False,
         skip_validation: bool = False,
+        log_file: IO[str] | None = None,
     ) -> ReadResult:
         """Read from the connector and write to the cache.
 
@@ -861,6 +880,11 @@ class Source(ConnectorBase):  # noqa: PLR0904
                 running the connector. This can be helpful in debugging, when you want to send
                 configurations to the connector that otherwise might be rejected by JSON Schema
                 validation rules.
+            log_file: Optional writable text-mode file object. When provided, the connector
+                subprocess's stderr will be redirected to this file. Stderr capture takes
+                precedence over the default progress-tracker stderr suppression, so the
+                file will contain the connector's full stderr output for the duration of
+                the sync.
         """
         cache = cache or get_default_cache()
         progress_tracker = ProgressTracker(
@@ -901,6 +925,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
                 force_full_refresh=force_full_refresh,
                 skip_validation=skip_validation,
                 progress_tracker=progress_tracker,
+                log_file=log_file,
             )
         except exc.PyAirbyteInternalError as ex:
             progress_tracker.log_failure(exception=ex)
@@ -927,8 +952,13 @@ class Source(ConnectorBase):  # noqa: PLR0904
         force_full_refresh: bool = False,
         skip_validation: bool = False,
         progress_tracker: ProgressTracker,
+        log_file: IO[str] | None = None,
     ) -> ReadResult:
-        """Internal read method."""
+        """Internal read method.
+
+        If `log_file` is provided, the connector subprocess's stderr will be redirected
+        to that writable text-mode file object.
+        """
         if write_strategy == WriteStrategy.REPLACE and not force_full_refresh:
             warnings.warn(
                 message=(
@@ -976,6 +1006,7 @@ class Source(ConnectorBase):  # noqa: PLR0904
                 catalog=catalog_provider.configured_catalog,
                 state=state_provider,
                 progress_tracker=progress_tracker,
+                log_file=log_file,
             )
         )
         cache._write_airbyte_message_stream(  # noqa: SLF001  # Non-public API

--- a/tests/unit_tests/test_mcp_log_capture.py
+++ b/tests/unit_tests/test_mcp_log_capture.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for the MCP log-capture helper and stderr plumbing.
+
+These tests validate that:
+
+* The `_LogCapture` context manager opens / closes / cleans up the right files
+  given `log_file_path` and `include_logs_in_response` combinations.
+* `_stream_from_subprocess(log_file=...)` actually redirects subprocess stderr
+  into the supplied file (this is the underlying primitive that the MCP layer
+  wires through `Executor.execute`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from airbyte._executors.base import _stream_from_subprocess
+from airbyte.mcp.local import _LogCapture
+
+
+def test_log_capture_no_capture_yields_no_file() -> None:
+    """`_LogCapture` should not open a file when no path and no readback are requested."""
+    with _LogCapture(log_file_path=None, include_in_response=False) as cap:
+        assert cap.file is None
+        assert cap.read_logs() == ""
+
+
+def test_log_capture_explicit_path_writes_and_persists(tmp_path: Path) -> None:
+    """Explicit `log_file_path` should be written to and kept on disk after exit."""
+    log_path = tmp_path / "subdir" / "stderr.log"
+
+    with _LogCapture(log_file_path=log_path, include_in_response=False) as cap:
+        assert cap.file is not None
+        cap.file.write("hello stderr\n")
+        cap.file.flush()
+
+    assert log_path.exists(), "log file should be persisted after the context exits"
+    assert log_path.read_text(encoding="utf-8") == "hello stderr\n"
+
+
+def test_log_capture_explicit_path_creates_parent_dirs(tmp_path: Path) -> None:
+    """Parent directories should be auto-created."""
+    log_path = tmp_path / "deeply" / "nested" / "stderr.log"
+
+    with _LogCapture(log_file_path=log_path, include_in_response=False) as cap:
+        assert cap.file is not None
+        cap.file.write("nested\n")
+
+    assert log_path.exists()
+    assert log_path.read_text(encoding="utf-8") == "nested\n"
+
+
+def test_log_capture_temp_path_when_response_requested() -> None:
+    """When `include_in_response=True` without an explicit path, a temp file is used and removed."""
+    with _LogCapture(log_file_path=None, include_in_response=True) as cap:
+        assert cap.file is not None
+        cap.file.write("temp logs\n")
+        # Read inside the with-block, before cleanup happens.
+        captured = cap.read_logs()
+        temp_path: Path | None = cap._path  # noqa: SLF001  # Implementation detail under test
+
+    assert captured == "temp logs\n"
+    assert temp_path is not None
+    assert not temp_path.exists(), "temp file should be removed after context exit"
+
+
+def test_log_capture_explicit_path_with_readback(tmp_path: Path) -> None:
+    """Explicit path + `include_in_response=True` should both persist file and return contents."""
+    log_path = tmp_path / "stderr.log"
+
+    with _LogCapture(log_file_path=log_path, include_in_response=True) as cap:
+        assert cap.file is not None
+        cap.file.write("dual capture\n")
+        captured = cap.read_logs()
+
+    assert captured == "dual capture\n"
+    assert log_path.exists(), (
+        "explicit path should persist even when readback is requested"
+    )
+    assert log_path.read_text(encoding="utf-8") == "dual capture\n"
+
+
+def test_log_capture_overwrites_existing_file(tmp_path: Path) -> None:
+    """Opening an existing log path should overwrite (write-mode), not append."""
+    log_path = tmp_path / "stderr.log"
+    log_path.write_text("previous contents\n", encoding="utf-8")
+
+    with _LogCapture(log_file_path=log_path, include_in_response=False) as cap:
+        assert cap.file is not None
+        cap.file.write("fresh\n")
+
+    assert log_path.read_text(encoding="utf-8") == "fresh\n"
+
+
+def test_log_capture_read_without_capture_returns_empty_string() -> None:
+    """`read_logs()` should be a safe no-op string when no capture was configured."""
+    with _LogCapture(log_file_path=None, include_in_response=False) as cap:
+        assert cap.read_logs() == ""
+
+
+def test_stream_from_subprocess_redirects_stderr_to_log_file(tmp_path: Path) -> None:
+    """`_stream_from_subprocess(log_file=...)` should redirect subprocess stderr to the file."""
+    log_path = tmp_path / "subprocess-stderr.log"
+    stderr_message = "this should land in the log file"
+    stdout_message = "STDOUT_LINE"
+
+    script = (
+        "import sys; "
+        f"sys.stderr.write({stderr_message!r} + chr(10)); "
+        f"sys.stdout.write({stdout_message!r} + chr(10))"
+    )
+
+    with log_path.open("w", encoding="utf-8") as log_file:
+        with _stream_from_subprocess(
+            [sys.executable, "-c", script],
+            log_file=log_file,
+        ) as line_iter:
+            stdout_lines = list(line_iter)
+
+    assert any(stdout_message in line for line in stdout_lines)
+
+    captured = log_path.read_text(encoding="utf-8")
+    assert stderr_message in captured, (
+        f"expected stderr_message in log file, got: {captured!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("log_file_path", "include_in_response", "expect_capture"),
+    [
+        pytest.param(None, False, False, id="no-capture"),
+        pytest.param("explicit", False, True, id="explicit-path-no-readback"),
+        pytest.param(None, True, True, id="temp-path-with-readback"),
+        pytest.param("explicit", True, True, id="explicit-path-with-readback"),
+    ],
+)
+def test_log_capture_file_attribute_matrix(
+    tmp_path: Path,
+    *,
+    log_file_path: str | None,
+    include_in_response: bool,
+    expect_capture: bool,
+) -> None:
+    """Matrix test: `cap.file` is a writable handle if and only if capture is requested."""
+    path: Path | None = tmp_path / "stderr.log" if log_file_path == "explicit" else None
+    with _LogCapture(
+        log_file_path=path, include_in_response=include_in_response
+    ) as cap:
+        if expect_capture:
+            assert cap.file is not None
+            cap.file.write("matrix\n")
+        else:
+            assert cap.file is None


### PR DESCRIPTION
## Summary

Closes #1019.

In MCP-server mode the connector subprocess's stderr is invisible to the
calling agent: there's no console attached, and the MCP transport only
returns the tool's structured result. That makes it hard to debug why a
read returned 0 records, surfaced an error, or behaved unexpectedly,
because all the connector's `LOG` / `TRACE` messages and any non-protocol
stderr writes are lost.

This PR adds optional stderr-capture support to the three MCP local "read"
tools so an agent (or human operator) can collect the connector logs
alongside the records:

- `read_source_stream_records`
- `get_stream_previews`
- `sync_source_to_cache`

Each tool gains two new optional parameters:

- `log_file_path: str | Path | None` — when set, the connector subprocess's
  stderr is redirected to this path. Parent dirs are created; the file is
  opened in text-mode write (overwritten on each call).
- `include_logs_in_response: bool` — when `True`, the captured stderr is
  read back and embedded in a structured Pydantic response object
  (`StreamRecordsResponse` / `StreamPreviewsResponse` / `SyncResultResponse`).
  If `log_file_path` is omitted, an internal temp file is used and removed
  on exit.

The plumbing threads a `log_file: IO[str] | None` kwarg from the MCP layer
through `Source` → `_ConnectorBase._execute()` → `Executor.execute()` down
to `_stream_from_subprocess(...)`, which already supported log-file
redirection. When both `progress_tracker` and `log_file` are set,
`log_file` takes precedence over the default progress-tracker stderr
suppression so the file actually contains the connector's stderr.

The MCP and CLI modules remain thin presentation wrappers: all the actual
plumbing lives in the public `airbyte._executors`, `airbyte._connector_base`,
and `airbyte.sources.base` modules. The MCP layer only adds a small
`_LogCapture` context manager that owns the file lifecycle.

### Files changed

- `airbyte/_executors/base.py` — add `log_file` kwarg to `Executor.execute()`.
- `airbyte/_executors/declarative.py`, `airbyte/_executors/noop.py` — match the new signature (no-ops).
- `airbyte/_connector_base.py` — accept `log_file` in `_execute()`; let `log_file` override the progress-tracker stderr suppression.
- `airbyte/sources/base.py` — accept `log_file` in `get_records`, `get_samples`, `read`, `_read_with_catalog`, `_read_to_cache`.
- `airbyte/mcp/local.py` — new `_LogCapture` helper, three new Pydantic response models, and the new params on the three read tools.
- `tests/unit_tests/test_mcp_log_capture.py` — new unit tests covering `_LogCapture` semantics and verifying that `_stream_from_subprocess(log_file=...)` actually redirects subprocess stderr to disk.

### Behavior summary

| log_file_path | include_logs_in_response | Behavior |
| --- | --- | --- |
| None | False | Existing behavior — no capture. |
| set | False | stderr written to that path; original return shape preserved. |
| None | True | stderr captured to a temp file, read back, returned in response object; file removed. |
| set | True | stderr written to that path AND read back into response object. |

## Review &amp; Testing Checklist for Human

- [ ] Smoke test from an MCP client: call `read_source_stream_records` with `log_file_path=/tmp/foo.log` and confirm the connector's LOG lines land in that file.
- [ ] Smoke test `include_logs_in_response=True` (without `log_file_path`) and confirm the response shape is the new `StreamRecordsResponse` / `StreamPreviewsResponse` / `SyncResultResponse` with populated `logs`.
- [ ] Confirm the structured-response shape change is acceptable for downstream MCP clients (it's gated behind `include_logs_in_response=True`, so default callers see no change).

### Notes

- The new params are deliberately defaulted to `None` / `False` so existing callers see zero behavior change.
- The structured response objects are only returned when `include_logs_in_response=True`; otherwise the original return types (`list[dict] | str`, `dict[str, list[dict] | str]`, `str`) are preserved.
- Implementation kept logic in core modules (`_executors`, `_connector_base`, `sources.base`); the MCP layer is just plumbing + a small `_LogCapture` context manager owning the file lifecycle.
- Requested by AJ Steers (@aaronsteers) via airbytehq/PyAirbyte#1019.

Link to Devin session: https://app.devin.ai/sessions/6de707c1cbc14134a4b90d31be77eb3b