### PR TITLE
feat(cloud): allow config API root override

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -96,16 +96,33 @@ def _wrap_sdk_error(error: SDKError, base_context: dict[str, Any] | None = None)
     )
 
 
-def get_config_api_root(api_root: str) -> str:
-    """Get the configuration API root from the main API root.
+def _infer_config_api_root(api_root: str) -> str | None:
+    """Infer the configuration API root from a public API root."""
+    normalized_api_root = api_root.rstrip("/")
+    public_api_suffix = "/api/public/v1"
+    if normalized_api_root.endswith(public_api_suffix):
+        return normalized_api_root[: -len(public_api_suffix)] + "/api/v1"
+
+    return None
+
+
+def get_config_api_root(
+    api_root: str,
+    *,
+    config_api_root: str | None = None,
+) -> str:
+    """Get the configuration API root from the public API root.
 
     Resolution order:
-    1. If `AIRBYTE_CLOUD_CONFIG_API_URL` environment variable is set, use that value.
-    2. If `api_root` matches the default Cloud API root, return the default Config API root.
-    3. Otherwise, raise NotImplementedError (cannot derive Config API from custom API root).
+    1. If `config_api_root` is provided, use that value.
+    2. If `AIRBYTE_CLOUD_CONFIG_API_URL` environment variable is set, use that value.
+    3. If `api_root` matches the default Cloud API root, return the default Config API root.
+    4. If `api_root` looks like a self-managed public API root, infer the Config API root.
+    5. Otherwise, raise NotImplementedError (cannot derive Config API from custom API root).
 
     Args:
-        api_root: The main API root URL being used.
+        api_root: The public API root URL being used.
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         The configuration API root URL.
@@ -113,20 +130,27 @@ def get_config_api_root(api_root: str) -> str:
     Raises:
         NotImplementedError: If the Config API root cannot be determined.
     """
-    # First, check if the Config API URL is explicitly set via environment variable
+    if config_api_root:
+        return config_api_root.rstrip("/")
+
+    # Next, check if the Config API URL is explicitly set via environment variable
     config_api_override = try_get_secret(CLOUD_CONFIG_API_ROOT_ENV_VAR, default=None)
     if config_api_override:
-        return str(config_api_override)
+        return str(config_api_override).rstrip("/")
 
     # Fall back to deriving from the main API root
     # Normalize URLs by stripping trailing slashes to handle common variants
     if api_root.rstrip("/") == CLOUD_API_ROOT.rstrip("/"):
         return CLOUD_CONFIG_API_ROOT
 
+    inferred_config_api_root = _infer_config_api_root(api_root)
+    if inferred_config_api_root:
+        return inferred_config_api_root
+
     raise NotImplementedError(
         f"Configuration API root not implemented for api_root='{api_root}'. "
-        f"Set the '{CLOUD_CONFIG_API_ROOT_ENV_VAR}' environment variable "
-        "to specify the Config API URL."
+        "Provide the 'config_api_root' argument or set the "
+        f"'{CLOUD_CONFIG_API_ROOT_ENV_VAR}' environment variable to specify the Config API URL."
     )
 
 
@@ -1443,8 +1467,9 @@ def _make_config_api_request(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
-    config_api_root = get_config_api_root(api_root)
+    config_api_root = get_config_api_root(api_root, config_api_root=config_api_root)
 
     # Use provided bearer token or generate one from client credentials
     if bearer_token is None:
@@ -1502,6 +1527,7 @@ def check_connector(
     bearer_token: SecretString | None,
     workspace_id: str | None = None,
     api_root: str = CLOUD_API_ROOT,
+    config_api_root: str | None = None,
 ) -> tuple[bool, str | None]:
     """Check a source.
 
@@ -1518,6 +1544,7 @@ def check_connector(
             f"{connector_type}Id": actor_id,
         },
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -1825,6 +1852,7 @@ def get_connector_builder_project_for_definition_id(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Get the connector builder project info for a declarative source definition.
 
@@ -1840,6 +1868,7 @@ def get_connector_builder_project_for_definition_id(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         A dict containing 'builderProjectId' and 'workspaceId' (the workspace that
@@ -1852,6 +1881,7 @@ def get_connector_builder_project_for_definition_id(
             "workspaceId": workspace_id,
         },
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -1866,6 +1896,7 @@ def get_connector_builder_project(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Get a connector builder project, including the draft manifest if one exists.
 
@@ -1881,6 +1912,7 @@ def get_connector_builder_project(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         A dictionary containing the builder project details. Key fields include:
@@ -1895,13 +1927,14 @@ def get_connector_builder_project(
             "builderProjectId": builder_project_id,
         },
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
     )
 
 
-def update_connector_builder_project_testing_values(
+def update_connector_builder_project_testing_values(  # noqa: PLR0913
     *,
     workspace_id: str,
     builder_project_id: str,
@@ -1911,6 +1944,7 @@ def update_connector_builder_project_testing_values(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Update the testing values for a connector builder project.
 
@@ -1930,6 +1964,7 @@ def update_connector_builder_project_testing_values(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         The updated testing values from the API response
@@ -1943,6 +1978,7 @@ def update_connector_builder_project_testing_values(
             "spec": spec,
         },
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -1968,6 +2004,7 @@ def list_organizations_for_user(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         List of OrganizationResponse objects containing organization_id, organization_name, email
@@ -1999,6 +2036,7 @@ def list_workspaces_in_organization(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
     name_contains: str | None = None,
     max_items_limit: int | None = None,
 ) -> list[dict[str, Any]]:
@@ -2012,6 +2050,7 @@ def list_workspaces_in_organization(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
         name_contains: Optional substring filter for workspace names (server-side)
         max_items_limit: Optional maximum number of workspaces to return
 
@@ -2038,6 +2077,7 @@ def list_workspaces_in_organization(
             path="/workspaces/list_by_organization_id",
             json=payload,
             api_root=api_root,
+            config_api_root=config_api_root,
             client_id=client_id,
             client_secret=client_secret,
             bearer_token=bearer_token,
@@ -2072,6 +2112,7 @@ def get_workspace_organization_info(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Get organization info for a workspace.
 
@@ -2086,6 +2127,7 @@ def get_workspace_organization_info(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing organization info:
@@ -2098,6 +2140,7 @@ def get_workspace_organization_info(
         path="/workspaces/get_organization_info",
         json={"workspaceId": workspace_id},
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -2111,6 +2154,7 @@ def get_connection_state(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Get the state for a connection.
 
@@ -2122,6 +2166,7 @@ def get_connection_state(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing the connection state.
@@ -2130,6 +2175,7 @@ def get_connection_state(
         path="/state/get",
         json={"connectionId": connection_id},
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -2144,6 +2190,7 @@ def replace_connection_state(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Replace the state for a connection.
 
@@ -2171,6 +2218,7 @@ def replace_connection_state(
         client_id: OAuth client ID.
         client_secret: OAuth client secret.
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing the updated ConnectionState object.
@@ -2186,6 +2234,7 @@ def replace_connection_state(
                 },
             },
             api_root=api_root,
+            config_api_root=config_api_root,
             client_id=client_id,
             client_secret=client_secret,
             bearer_token=bearer_token,
@@ -2207,6 +2256,7 @@ def get_connection_catalog(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
+    config_api_root: str | None = None,
 ) -> dict[str, Any]:
     """Get the configured catalog for a connection.
 
@@ -2221,6 +2271,7 @@ def get_connection_catalog(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing the connection info with syncCatalog.
@@ -2229,6 +2280,7 @@ def get_connection_catalog(
         path="/web_backend/connections/get",
         json={"connectionId": connection_id, "withRefreshedCatalog": False},
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -2240,6 +2292,7 @@ def replace_connection_catalog(
     configured_catalog_dict: dict[str, Any],
     *,
     api_root: str,
+    config_api_root: str | None = None,
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
@@ -2258,6 +2311,7 @@ def replace_connection_catalog(
         client_id: OAuth client ID.
         client_secret: OAuth client secret.
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing the updated WebBackendConnectionRead response.
@@ -2272,6 +2326,7 @@ def replace_connection_catalog(
             "skipReset": True,
         },
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -2282,6 +2337,7 @@ def get_organization_info(
     organization_id: str,
     *,
     api_root: str,
+    config_api_root: str | None = None,
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
@@ -2296,6 +2352,7 @@ def get_organization_info(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         Dictionary containing organization info:
@@ -2308,6 +2365,7 @@ def get_organization_info(
         path="/organizations/get_organization_info",
         json={"organizationId": organization_id},
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2004,7 +2004,6 @@ def list_organizations_for_user(
         client_id: OAuth client ID
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
-        config_api_root: Optional explicit Config API root URL.
 
     Returns:
         List of OrganizationResponse objects containing organization_id, organization_name, email

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -141,7 +141,7 @@ def get_config_api_root(
     # Fall back to deriving from the main API root
     # Normalize URLs by stripping trailing slashes to handle common variants
     if api_root.rstrip("/") == CLOUD_API_ROOT.rstrip("/"):
-        return CLOUD_CONFIG_API_ROOT
+        return CLOUD_CONFIG_API_ROOT.rstrip("/")
 
     inferred_config_api_root = _infer_config_api_root(api_root)
     if inferred_config_api_root:

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -3,6 +3,37 @@
 
 You can use this module to interact with Airbyte Cloud, OSS, and Enterprise.
 
+## Self-managed Airbyte instances
+
+For self-managed Airbyte instances, set `api_root` to the Public API root for your
+deployment. For the default self-managed route, that usually ends in `/api/public/v1`.
+PyAirbyte uses the Public API for workspace and organization discovery.
+
+Some Cloud module methods also call the Config API, including methods such as
+`CloudConnection.dump_raw_catalog()`, which reads the configured catalog directly
+from Airbyte. For documented self-managed deployments where the Public API root ends in
+`/api/public/v1`, PyAirbyte infers the Config API root by replacing that suffix with
+`/api/v1`.
+
+If your deployment uses custom ingress or a nonstandard reverse proxy, pass
+`config_api_root` explicitly or set the `AIRBYTE_CLOUD_CONFIG_API_URL` environment
+variable.
+
+```python
+from airbyte import cloud
+
+workspace = cloud.CloudWorkspace(
+    workspace_id="...",
+    client_id="...",
+    client_secret="...",
+    api_root="https://airbyte.example.com/api/public/v1",
+    config_api_root="https://airbyte.example.com/api/v1",
+)
+
+connection = workspace.get_connection(connection_id="...")
+raw_catalog = connection.dump_raw_catalog()
+```
+
 ## Examples
 
 ### Basic Sync Example:

--- a/airbyte/cloud/client_config.py
+++ b/airbyte/cloud/client_config.py
@@ -33,7 +33,8 @@ Example using environment variables:
     from airbyte.cloud.client_config import CloudClientConfig
 
     # Resolves from AIRBYTE_CLOUD_CLIENT_ID, AIRBYTE_CLOUD_CLIENT_SECRET,
-    # AIRBYTE_CLOUD_BEARER_TOKEN, and AIRBYTE_CLOUD_API_URL environment variables
+    # AIRBYTE_CLOUD_BEARER_TOKEN, AIRBYTE_CLOUD_API_URL, and
+    # AIRBYTE_CLOUD_CONFIG_API_URL environment variables
     config = CloudClientConfig.from_env()
     ```
 """
@@ -48,6 +49,7 @@ from airbyte.cloud.auth import (
     resolve_cloud_bearer_token,
     resolve_cloud_client_id,
     resolve_cloud_client_secret,
+    resolve_cloud_config_api_url,
 )
 from airbyte.exceptions import PyAirbyteInputError
 from airbyte.secrets.base import SecretString
@@ -72,6 +74,7 @@ class CloudClientConfig:
         client_secret: OAuth2 client secret for client credentials flow.
         bearer_token: Pre-generated bearer token for direct authentication.
         api_root: The API root URL. Defaults to Airbyte Cloud API.
+        config_api_root: The Config API root URL.
     """
 
     client_id: SecretString | None = None
@@ -85,6 +88,9 @@ class CloudClientConfig:
 
     api_root: str = api_util.CLOUD_API_ROOT
     """The API root URL. Defaults to Airbyte Cloud API."""
+
+    config_api_root: str | None = None
+    """The Config API root URL."""
 
     def __post_init__(self) -> None:
         """Validate credentials and ensure secrets are properly wrapped."""
@@ -143,6 +149,7 @@ class CloudClientConfig:
         cls,
         *,
         api_root: str | None = None,
+        config_api_root: str | None = None,
     ) -> CloudClientConfig:
         """Create CloudClientConfig from environment variables.
 
@@ -155,6 +162,7 @@ class CloudClientConfig:
             - `AIRBYTE_CLOUD_CLIENT_SECRET`: OAuth client secret (for client credentials flow).
             - `AIRBYTE_CLOUD_BEARER_TOKEN`: Bearer token (alternative to client credentials).
             - `AIRBYTE_CLOUD_API_URL`: Optional. The API root URL (defaults to Airbyte Cloud).
+            - `AIRBYTE_CLOUD_CONFIG_API_URL`: Optional. The Config API root URL.
 
         The method will first check for a bearer token. If not found, it will
         attempt to use client credentials.
@@ -163,6 +171,8 @@ class CloudClientConfig:
             api_root: The API root URL. If not provided, will be resolved from
                 the `AIRBYTE_CLOUD_API_URL` environment variable, or default to
                 the Airbyte Cloud API.
+            config_api_root: The Config API root URL. If not provided, will be resolved
+                from the `AIRBYTE_CLOUD_CONFIG_API_URL` environment variable.
 
         Returns:
             A CloudClientConfig instance configured with credentials from the environment.
@@ -172,6 +182,7 @@ class CloudClientConfig:
                 the environment.
         """
         resolved_api_root = resolve_cloud_api_url(api_root)
+        resolved_config_api_root = resolve_cloud_config_api_url(config_api_root)
 
         # Try bearer token first
         bearer_token = resolve_cloud_bearer_token()
@@ -179,6 +190,7 @@ class CloudClientConfig:
             return cls(
                 bearer_token=bearer_token,
                 api_root=resolved_api_root,
+                config_api_root=resolved_config_api_root,
             )
 
         # Fall back to client credentials
@@ -186,4 +198,5 @@ class CloudClientConfig:
             client_id=resolve_cloud_client_id(),
             client_secret=resolve_cloud_client_secret(),
             api_root=resolved_api_root,
+            config_api_root=resolved_config_api_root,
         )

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -395,6 +395,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         if state_response.get("stateType") == "not_set":
             return None
@@ -434,6 +435,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         if normalize:
             return _normalize_state_to_protocol(raw)
@@ -503,6 +505,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
 
     def get_stream_state(
@@ -687,6 +690,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         raw = connection_response.get("syncCatalog")
         if raw is None:
@@ -724,6 +728,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
 
     def rename(self, name: str) -> CloudConnection:

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -166,6 +166,7 @@ class CloudConnector(abc.ABC):
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         check_result = CheckResult(
             success=result[0],
@@ -474,6 +475,7 @@ class CustomCloudSourceDefinition:
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         self._connector_builder_project_id = result.get("builderProjectId")
         self._connector_builder_project_id_fetched = True
@@ -546,6 +548,7 @@ class CustomCloudSourceDefinition:
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
         return self._builder_project_data
 
@@ -874,6 +877,7 @@ class CustomCloudSourceDefinition:
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
+            config_api_root=self.workspace.config_api_root,
         )
 
         return self

--- a/airbyte/cloud/sync_results.py
+++ b/airbyte/cloud/sync_results.py
@@ -312,6 +312,7 @@ class SyncResult:
             if "Invalid isoformat string" in str(e):
                 job_info_raw = api_util._make_config_api_request(  # noqa: SLF001
                     api_root=self.workspace.api_root,
+                    config_api_root=self.workspace.config_api_root,
                     path="/jobs/get",
                     json={"id": self.job_id},
                     client_id=self.workspace.client_id,
@@ -330,6 +331,7 @@ class SyncResult:
 
         self._job_with_attempts_info = api_util._make_config_api_request(  # noqa: SLF001  # Config API helper
             api_root=self.workspace.api_root,
+            config_api_root=self.workspace.config_api_root,
             path="/jobs/get",
             json={
                 "id": self.job_id,

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -244,9 +244,9 @@ class CloudWorkspace:
     client_id: SecretString | None = None
     client_secret: SecretString | None = None
     api_root: str = api_util.CLOUD_API_ROOT
-    bearer_token: SecretString | None = None
     config_api_root: str | None = None
     """The Config API root URL."""
+    bearer_token: SecretString | None = None
 
     # Internal credentials object (set in __post_init__, excluded from __init__)
     _credentials: CloudClientConfig | None = field(default=None, init=False, repr=False)

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -50,6 +50,7 @@ from airbyte.cloud.auth import (
     resolve_cloud_bearer_token,
     resolve_cloud_client_id,
     resolve_cloud_client_secret,
+    resolve_cloud_config_api_url,
     resolve_cloud_workspace_id,
 )
 from airbyte.cloud.client_config import CloudClientConfig
@@ -87,6 +88,7 @@ class CloudOrganization:
         client_id: SecretString | None = None,
         client_secret: SecretString | None = None,
         bearer_token: SecretString | None = None,
+        config_api_root: str | None = None,
     ) -> None:
         """Initialize a CloudOrganization.
 
@@ -98,6 +100,7 @@ class CloudOrganization:
             client_id: OAuth client ID for authentication.
             client_secret: OAuth client secret for authentication.
             bearer_token: Bearer token for authentication (alternative to client credentials).
+            config_api_root: Optional Config API root URL.
         """
         self.organization_id = organization_id
         """The organization ID."""
@@ -109,6 +112,7 @@ class CloudOrganization:
         """Email associated with the organization."""
 
         self._api_root = api_root
+        self._config_api_root = config_api_root
         self._client_id = client_id
         self._client_secret = client_secret
         self._bearer_token = bearer_token
@@ -146,6 +150,7 @@ class CloudOrganization:
             self._organization_info = api_util.get_organization_info(
                 organization_id=self.organization_id,
                 api_root=self._api_root,
+                config_api_root=self._config_api_root,
                 client_id=self._client_id,
                 client_secret=self._client_secret,
                 bearer_token=self._bearer_token,
@@ -239,6 +244,9 @@ class CloudWorkspace:
     client_id: SecretString | None = None
     client_secret: SecretString | None = None
     api_root: str = api_util.CLOUD_API_ROOT
+    config_api_root: str | None = None
+    """The Config API root URL."""
+
     bearer_token: SecretString | None = None
 
     # Internal credentials object (set in __post_init__, excluded from __init__)
@@ -260,6 +268,7 @@ class CloudWorkspace:
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
             api_root=self.api_root,
+            config_api_root=self.config_api_root,
         )
 
     @classmethod
@@ -268,6 +277,7 @@ class CloudWorkspace:
         workspace_id: str | None = None,
         *,
         api_root: str | None = None,
+        config_api_root: str | None = None,
     ) -> CloudWorkspace:
         """Create a CloudWorkspace using credentials from environment variables.
 
@@ -285,6 +295,7 @@ class CloudWorkspace:
             - `AIRBYTE_CLOUD_CLIENT_SECRET`: OAuth client secret (for client credentials flow).
             - `AIRBYTE_CLOUD_WORKSPACE_ID`: The workspace ID (if not passed as argument).
             - `AIRBYTE_CLOUD_API_URL`: Optional. The API root URL (defaults to Airbyte Cloud).
+            - `AIRBYTE_CLOUD_CONFIG_API_URL`: Optional. The Config API root URL.
 
         Args:
             workspace_id: The workspace ID. If not provided, will be resolved from
@@ -292,6 +303,8 @@ class CloudWorkspace:
             api_root: The API root URL. If not provided, will be resolved from
                 the `AIRBYTE_CLOUD_API_URL` environment variable, or default to
                 the Airbyte Cloud API.
+            config_api_root: The Config API root URL. If not provided, will be resolved
+                from the `AIRBYTE_CLOUD_CONFIG_API_URL` environment variable.
 
         Returns:
             A CloudWorkspace instance configured with credentials from the environment.
@@ -310,6 +323,7 @@ class CloudWorkspace:
             ```
         """
         resolved_api_root = resolve_cloud_api_url(api_root)
+        resolved_config_api_root = resolve_cloud_config_api_url(config_api_root)
 
         # Try bearer token first
         bearer_token = resolve_cloud_bearer_token()
@@ -318,6 +332,7 @@ class CloudWorkspace:
                 workspace_id=resolve_cloud_workspace_id(workspace_id),
                 bearer_token=bearer_token,
                 api_root=resolved_api_root,
+                config_api_root=resolved_config_api_root,
             )
 
         # Fall back to client credentials
@@ -326,6 +341,7 @@ class CloudWorkspace:
             client_id=resolve_cloud_client_id(),
             client_secret=resolve_cloud_client_secret(),
             api_root=resolved_api_root,
+            config_api_root=resolved_config_api_root,
         )
 
     @property
@@ -343,6 +359,7 @@ class CloudWorkspace:
         return api_util.get_workspace_organization_info(
             workspace_id=self.workspace_id,
             api_root=self.api_root,
+            config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -413,6 +430,7 @@ class CloudWorkspace:
             organization_id=organization_id,
             organization_name=organization_name,
             api_root=self.api_root,
+            config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -211,7 +211,7 @@ class CloudOrganization:
         return api_util.is_account_locked(self.payment_status, self.subscription_status)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CloudWorkspace:
     """A remote workspace on the Airbyte Cloud.
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -244,10 +244,9 @@ class CloudWorkspace:
     client_id: SecretString | None = None
     client_secret: SecretString | None = None
     api_root: str = api_util.CLOUD_API_ROOT
+    bearer_token: SecretString | None = None
     config_api_root: str | None = None
     """The Config API root URL."""
-
-    bearer_token: SecretString | None = None
 
     # Internal credentials object (set in __post_init__, excluded from __init__)
     _credentials: CloudClientConfig | None = field(default=None, init=False, repr=False)

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -310,6 +310,9 @@ MCP_CONFIG_CLIENT_SECRET: str = "client_secret"
 MCP_CONFIG_API_URL: str = "api_url"
 """Config arg name for the API URL setting."""
 
+MCP_CONFIG_CONFIG_API_URL: str = "config_api_url"
+"""Config arg name for the Config API URL setting."""
+
 # MCP HTTP Header Keys for credentials
 
 MCP_BEARER_TOKEN_HEADER: str = "Authorization"
@@ -323,3 +326,6 @@ MCP_CLIENT_SECRET_HEADER: str = "X-Airbyte-Cloud-Client-Secret"
 
 MCP_API_URL_HEADER: str = "X-Airbyte-Cloud-Api-Url"
 """HTTP header key for API URL."""
+
+MCP_CONFIG_API_URL_HEADER: str = "X-Airbyte-Cloud-Config-Api-Url"
+"""HTTP header key for Config API URL."""

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -24,15 +24,18 @@ from airbyte.constants import (
     CLOUD_BEARER_TOKEN_ENV_VAR,
     CLOUD_CLIENT_ID_ENV_VAR,
     CLOUD_CLIENT_SECRET_ENV_VAR,
+    CLOUD_CONFIG_API_ROOT_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
     MCP_API_URL_HEADER,
     MCP_BEARER_TOKEN_HEADER,
     MCP_CLIENT_ID_HEADER,
     MCP_CLIENT_SECRET_HEADER,
     MCP_CONFIG_API_URL,
+    MCP_CONFIG_API_URL_HEADER,
     MCP_CONFIG_BEARER_TOKEN,
     MCP_CONFIG_CLIENT_ID,
     MCP_CONFIG_CLIENT_SECRET,
+    MCP_CONFIG_CONFIG_API_URL,
     MCP_CONFIG_EXCLUDE_MODULES,
     MCP_CONFIG_INCLUDE_MODULES,
     MCP_CONFIG_READONLY_MODE,
@@ -179,6 +182,15 @@ API_URL_CONFIG_ARG = MCPServerConfigArg(
     sensitive=False,
 )
 """Config arg for API URL, supporting HTTP header and env var."""
+
+CONFIG_API_URL_CONFIG_ARG = MCPServerConfigArg(
+    name=MCP_CONFIG_CONFIG_API_URL,
+    http_header_key=MCP_CONFIG_API_URL_HEADER,
+    env_var=CLOUD_CONFIG_API_ROOT_ENV_VAR,
+    required=False,
+    sensitive=False,
+)
+"""Config arg for Config API URL, supporting HTTP header and env var."""
 
 
 # =============================================================================

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -28,6 +28,7 @@ from airbyte.constants import (
     MCP_CONFIG_BEARER_TOKEN,
     MCP_CONFIG_CLIENT_ID,
     MCP_CONFIG_CLIENT_SECRET,
+    MCP_CONFIG_CONFIG_API_URL,
     MCP_CONFIG_WORKSPACE_ID,
 )
 from airbyte.destinations.util import get_noop_destination
@@ -269,6 +270,7 @@ def _get_cloud_workspace(
     client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID)
     client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET)
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL) or api_util.CLOUD_API_ROOT
+    config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
 
     return CloudWorkspace(
         workspace_id=resolved_workspace_id,
@@ -276,6 +278,7 @@ def _get_cloud_workspace(
         client_secret=SecretString(client_secret) if client_secret else None,
         bearer_token=SecretString(bearer_token) if bearer_token else None,
         api_root=api_url,
+        config_api_root=config_api_url,
     )
 
 
@@ -1308,6 +1311,7 @@ def _resolve_organization(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None = None,
+    config_api_root: str | None = None,
 ) -> CloudOrganization:
     """Resolve organization from either ID or exact name match.
 
@@ -1318,6 +1322,7 @@ def _resolve_organization(
         client_id: OAuth client ID (optional if bearer_token is provided)
         client_secret: OAuth client secret (optional if bearer_token is provided)
         bearer_token: Bearer token for authentication (optional if client credentials provided)
+        config_api_root: Optional Config API root URL.
 
     Returns:
         A CloudOrganization object with credentials for lazy loading of billing info.
@@ -1387,6 +1392,7 @@ def _resolve_organization(
         organization_name=org_response.organization_name,
         email=org_response.email,
         api_root=api_root,
+        config_api_root=config_api_root,
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
@@ -1401,6 +1407,7 @@ def _resolve_organization_id(
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None = None,
+    config_api_root: str | None = None,
 ) -> str:
     """Resolve organization ID from either ID or exact name match.
 
@@ -1413,6 +1420,7 @@ def _resolve_organization_id(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
+        config_api_root=config_api_root,
     )
     return org.organization_id
 
@@ -1467,6 +1475,7 @@ def list_cloud_workspaces(
     client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID)
     client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET)
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL) or api_util.CLOUD_API_ROOT
+    config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
 
     resolved_org_id = _resolve_organization_id(
         organization_id=organization_id,
@@ -1475,6 +1484,7 @@ def list_cloud_workspaces(
         client_id=SecretString(client_id) if client_id else None,
         client_secret=SecretString(client_secret) if client_secret else None,
         bearer_token=SecretString(bearer_token) if bearer_token else None,
+        config_api_root=config_api_url,
     )
 
     workspaces = api_util.list_workspaces_in_organization(
@@ -1483,6 +1493,7 @@ def list_cloud_workspaces(
         client_id=SecretString(client_id) if client_id else None,
         client_secret=SecretString(client_secret) if client_secret else None,
         bearer_token=SecretString(bearer_token) if bearer_token else None,
+        config_api_root=config_api_url,
         name_contains=name_contains,
         max_items_limit=max_items_limit,
     )
@@ -1532,6 +1543,7 @@ def describe_cloud_organization(
     client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID)
     client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET)
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL) or api_util.CLOUD_API_ROOT
+    config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
 
     org = _resolve_organization(
         organization_id=organization_id,
@@ -1540,6 +1552,7 @@ def describe_cloud_organization(
         client_id=SecretString(client_id) if client_id else None,
         client_secret=SecretString(client_secret) if client_secret else None,
         bearer_token=SecretString(bearer_token) if bearer_token else None,
+        config_api_root=config_api_url,
     )
 
     # CloudOrganization has lazy loading of billing properties

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -18,6 +18,7 @@ from airbyte.mcp._tool_utils import (
     BEARER_TOKEN_CONFIG_ARG,
     CLIENT_ID_CONFIG_ARG,
     CLIENT_SECRET_CONFIG_ARG,
+    CONFIG_API_URL_CONFIG_ARG,
     WORKSPACE_ID_CONFIG_ARG,
     airbyte_module_filter,
     airbyte_readonly_mode_filter,
@@ -79,6 +80,7 @@ app = mcp_server(
         CLIENT_ID_CONFIG_ARG,
         CLIENT_SECRET_CONFIG_ARG,
         API_URL_CONFIG_ARG,
+        CONFIG_API_URL_CONFIG_ARG,
     ],
     tool_filters=[
         airbyte_readonly_mode_filter,

--- a/tests/unit_tests/test_cloud_api_roots.py
+++ b/tests/unit_tests/test_cloud_api_roots.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import pytest
 
 from airbyte._util import api_util
+from airbyte.cloud import CloudWorkspace
+from airbyte.secrets.base import SecretString
 
 
 @pytest.mark.parametrize(
@@ -80,3 +82,14 @@ def test_get_config_api_root_unresolved(monkeypatch: pytest.MonkeyPatch) -> None
 
     with pytest.raises(NotImplementedError):
         api_util.get_config_api_root("https://example.airbyte.com/custom/public")
+
+
+def test_cloud_workspace_constructor_requires_keyword_arguments() -> None:
+    with pytest.raises(TypeError, match="positional"):
+        CloudWorkspace("workspace-id", bearer_token=SecretString("token"))  # type: ignore[misc]
+
+    workspace = CloudWorkspace(
+        workspace_id="workspace-id", bearer_token=SecretString("token")
+    )
+
+    assert workspace.workspace_id == "workspace-id"

--- a/tests/unit_tests/test_cloud_api_roots.py
+++ b/tests/unit_tests/test_cloud_api_roots.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Unit tests for cloud API root resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from airbyte._util import api_util
+
+
+@pytest.mark.parametrize(
+    "api_root,config_api_root,expected",
+    [
+        pytest.param(
+            api_util.CLOUD_API_ROOT,
+            None,
+            api_util.CLOUD_CONFIG_API_ROOT,
+            id="default_cloud_root",
+        ),
+        pytest.param(
+            "https://example.airbyte.com/api/public/v1",
+            None,
+            "https://example.airbyte.com/api/v1",
+            id="infer_self_managed_root",
+        ),
+        pytest.param(
+            "https://example.airbyte.com/airbyte/api/public/v1/",
+            None,
+            "https://example.airbyte.com/airbyte/api/v1",
+            id="infer_self_managed_root_with_prefix",
+        ),
+        pytest.param(
+            "http://localhost:8000/api/public/v1",
+            None,
+            "http://localhost:8000/api/v1",
+            id="infer_local_self_managed_root",
+        ),
+        pytest.param(
+            "https://example.airbyte.com/custom/public",
+            "https://example.airbyte.com/custom/config",
+            "https://example.airbyte.com/custom/config",
+            id="explicit_config_root",
+        ),
+        pytest.param(
+            "https://example.airbyte.com/custom/public",
+            "https://example.airbyte.com/custom/config/",
+            "https://example.airbyte.com/custom/config",
+            id="explicit_config_root_trailing_slash",
+        ),
+    ],
+)
+def test_get_config_api_root(
+    monkeypatch: pytest.MonkeyPatch,
+    api_root: str,
+    config_api_root: str | None,
+    expected: str,
+) -> None:
+    monkeypatch.delenv(api_util.CLOUD_CONFIG_API_ROOT_ENV_VAR, raising=False)
+
+    assert (
+        api_util.get_config_api_root(api_root, config_api_root=config_api_root)
+        == expected
+    )
+
+
+def test_get_config_api_root_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        api_util.CLOUD_CONFIG_API_ROOT_ENV_VAR,
+        "https://example.airbyte.com/env/config/",
+    )
+
+    assert (
+        api_util.get_config_api_root("https://example.airbyte.com/custom/public")
+        == "https://example.airbyte.com/env/config"
+    )
+
+
+def test_get_config_api_root_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(api_util.CLOUD_CONFIG_API_ROOT_ENV_VAR, raising=False)
+
+    with pytest.raises(NotImplementedError):
+        api_util.get_config_api_root("https://example.airbyte.com/custom/public")


### PR DESCRIPTION
## Summary
- `CloudConnection.dump_raw_catalog()` did not work reliably for self-managed Airbyte instances with a custom public `api_root`, because Config API calls could only derive the Config API root for Airbyte Cloud or an env-var override.
- Adds optional `config_api_root` plumbing through `CloudWorkspace`, `CloudClientConfig`, Config API helper functions, connection/catalog/state helpers, connector builder helpers, sync result job helpers, and MCP cloud config.
- Infers the Config API root for documented self-managed public API roots ending in `/api/public/v1` by converting them to `/api/v1`, while still allowing explicit `config_api_root` overrides via argument, `AIRBYTE_CLOUD_CONFIG_API_URL`, or MCP config/header.
- Makes `CloudWorkspace` keyword-only so future optional constructor fields do not destabilize positional argument ordering.
- Adds an L2 Cloud module documentation section showing how to configure self-managed Airbyte with `api_root` and `config_api_root`.
- Adds unit coverage for default Cloud behavior, self-managed inference, explicit override, env override, trailing slash normalization, unresolved custom roots, and keyword-only `CloudWorkspace` construction.

## Review & Testing Checklist for Human
- [ ] Verify the proposed self-managed inference (`/api/public/v1` -> `/api/v1`) matches expected OSS/Enterprise deployments behind any path prefixes.
- [ ] Verify explicitly passing `config_api_root` to `CloudWorkspace` works against a real self-managed instance for `dump_raw_catalog()`.
- [ ] Verify making `CloudWorkspace` keyword-only is acceptable for public API consumers.
- [ ] Verify MCP config/header naming (`config_api_url` / `X-Airbyte-Cloud-Config-Api-Url`) matches expected consumer conventions.
- [ ] Review the new Cloud module docs section for self-managed Airbyte wording and example clarity.

### Notes
Evidence that `/api/public/v1` -> `/api/v1` is a decent default for documented self-managed deployments:
- Airbyte docs say self-managed Public API calls use `<YOUR_AIRBYTE_URL>/api/public/v1/`: https://github.com/airbytehq/airbyte/blob/master/docs/developers/api-documentation.md#use-the-right-base-url
- Airbyte docs use `/api/public/v1/applications/token` for self-managed token requests: https://github.com/airbytehq/airbyte/blob/master/docs/platform/using-airbyte/configuring-api-access.md#step-2-get-an-access-token
- Public API OpenAPI servers include `/api/public/v1`: https://github.com/airbytehq/airbyte-platform/blob/main/oss/airbyte-api/server-api/src/main/openapi/public_api.yaml#L47-L61
- Config API OpenAPI defines endpoints under `/v1/...`, e.g. connection/state endpoints used by this codepath: https://github.com/airbytehq/airbyte-platform/blob/main/oss/airbyte-api/server-api/src/main/openapi/config.yaml#L2913-L2917 and https://github.com/airbytehq/airbyte-platform/blob/main/oss/airbyte-api/server-api/src/main/openapi/config.yaml#L3051-L3055
- Platform controllers back those Config API paths for `/v1/connections/*` and `/v1/state/*`: https://github.com/airbytehq/airbyte-platform/blob/main/oss/airbyte-server/src/main/kotlin/io/airbyte/server/apis/controllers/ConnectionApiController.kt#L75 and https://github.com/airbytehq/airbyte-platform/blob/main/oss/airbyte-server/src/main/kotlin/io/airbyte/server/apis/controllers/StateApiController.kt#L22
- Helm chart defaults route the Config API at `/api/v1` and Public API at `/api/public`: https://github.com/airbytehq/airbyte-platform/blob/main/oss/charts/v2/airbyte/templates/config/_common.tpl#L130-L132 and https://github.com/airbytehq/airbyte-platform/blob/main/oss/charts/v2/airbyte/templates/config/_webapp.tpl#L11-L13
- The inference and keyword-only constructor behavior are covered by tests: https://github.com/airbytehq/PyAirbyte/blob/devin/1779122008-config-api-root-override/tests/unit_tests/test_cloud_api_roots.py

Local checks run:
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff format --check /home/ubuntu/repos/PyAirbyte/airbyte/_util/api_util.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff check /home/ubuntu/repos/PyAirbyte/airbyte/_util/api_util.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte pyrefly check`
- `uv run --project /home/ubuntu/repos/PyAirbyte pytest /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff format --check /home/ubuntu/repos/PyAirbyte/airbyte/cloud/__init__.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff check /home/ubuntu/repos/PyAirbyte/airbyte/cloud/__init__.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte poe -C /home/ubuntu/repos/PyAirbyte docs-generate`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff format --check /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff check /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte pyrefly check /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte pytest /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_roots.py`

Link to Devin session: https://app.devin.ai/sessions/cc23474934e64bd79c12748baf72dfe0
Requested by: @aaronsteers