### PR TITLE
feat(cloud): add pagination for cloud `list` operations

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -280,7 +280,6 @@ def list_connections(
     _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
-    _ = workspace_id  # Not used (yet)
     airbyte_instance = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,
@@ -350,7 +349,6 @@ def list_workspaces(
     _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
-    _ = workspace_id  # Not used (yet)
     airbyte_instance: airbyte_api.AirbyteAPI = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,
@@ -365,7 +363,6 @@ def list_workspaces(
         try:
             response: api.ListWorkspacesResponse = airbyte_instance.workspaces.list_workspaces(
                 api.ListWorkspacesRequest(
-                    workspace_ids=[workspace_id],
                     offset=current_offset,
                     limit=PAGE_SIZE,
                 ),

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -38,10 +38,6 @@ from airbyte.secrets.util import try_get_secret
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from airbyte_api.models import (
         DestinationConfiguration,
     )
@@ -58,6 +54,33 @@ JOB_ORDER_BY_CREATED_AT_ASC = "createdAt|ASC"
 def status_ok(status_code: int) -> bool:
     """Check if a status code is OK."""
     return status_code >= 200 and status_code < 300  # noqa: PLR2004  # allow inline magic numbers
+
+
+def _validate_pagination_params(
+    *,
+    limit: int | None,
+    offset: int | None,
+) -> None:
+    """Validate common pagination parameters."""
+    if limit is not None and limit < 0:
+        raise PyAirbyteInputError(message="`limit` must be greater than or equal to 0.")
+    if offset is not None and offset < 0:
+        raise PyAirbyteInputError(message="`offset` must be greater than or equal to 0.")
+
+
+def _get_initial_offset(offset: int | None) -> int:
+    """Get an API offset from an optional user-provided offset."""
+    if offset is None:
+        return 0
+    return offset
+
+
+def _get_page_limit(remaining: int | None) -> int:
+    """Get the next API page limit from the remaining item count."""
+    page_size = 100
+    if remaining is None:
+        return page_size
+    return min(remaining, page_size)
 
 
 def _get_sdk_error_context(error: SDKError) -> dict[str, Any]:
@@ -250,7 +273,7 @@ def get_workspace(
 # List resources
 
 
-def list_connections(
+def list_connections(  # noqa: PLR0913
     workspace_id: str,
     *,
     api_root: str,
@@ -259,10 +282,15 @@ def list_connections(
     bearer_token: SecretString | None,
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[models.ConnectionResponse]:
     """List connections."""
     if name and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
+    _validate_pagination_params(limit=limit, offset=offset)
+    if limit == 0:
+        return []
 
     name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
 
@@ -274,23 +302,21 @@ def list_connections(
         api_root=api_root,
     )
     result: list[models.ConnectionResponse] = []
-    has_more = True
-    offset, page_size = 0, 100
+    current_offset = _get_initial_offset(offset)
+    remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
-    while has_more:
+    while remaining is None or remaining > 0:
+        page_limit = _get_page_limit(remaining)
         try:
             response = airbyte_instance.connections.list_connections(
                 api.ListConnectionsRequest(
                     workspace_ids=[workspace_id],
-                    offset=offset,
-                    limit=page_size,
+                    offset=current_offset,
+                    limit=page_limit,
                 ),
             )
         except SDKError as e:
             raise _wrap_sdk_error(e, base_context) from e
-
-        has_more = bool(response.connections_response and response.connections_response.next)
-        offset += page_size
 
         if not status_ok(response.status_code):
             raise AirbyteError(
@@ -301,15 +327,25 @@ def list_connections(
                 },
             )
         assert response.connections_response is not None
-        result += [
-            connection
-            for connection in response.connections_response.data
-            if name_filter(connection.name)
+        page_data = response.connections_response.data
+        if not page_data:
+            break
+
+        matching_connections = [
+            connection for connection in page_data if name_filter(connection.name)
         ]
+        result += matching_connections if remaining is None else matching_connections[:remaining]
+        if remaining is not None:
+            remaining -= len(matching_connections[:remaining])
+
+        if not response.connections_response.next:
+            break
+
+        current_offset += len(page_data)
     return result
 
 
-def list_workspaces(
+def list_workspaces(  # noqa: PLR0913
     workspace_id: str,
     *,
     api_root: str,
@@ -318,10 +354,15 @@ def list_workspaces(
     bearer_token: SecretString | None,
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[models.WorkspaceResponse]:
     """List workspaces."""
     if name and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
+    _validate_pagination_params(limit=limit, offset=offset)
+    if limit == 0:
+        return []
 
     name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
 
@@ -333,21 +374,21 @@ def list_workspaces(
         api_root=api_root,
     )
     result: list[models.WorkspaceResponse] = []
-    has_more = True
-    offset, page_size = 0, 100
+    current_offset = _get_initial_offset(offset)
+    remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
-    while has_more:
+    while remaining is None or remaining > 0:
+        page_limit = _get_page_limit(remaining)
         try:
             response: api.ListWorkspacesResponse = airbyte_instance.workspaces.list_workspaces(
                 api.ListWorkspacesRequest(
-                    workspace_ids=[workspace_id], offset=offset, limit=page_size
+                    workspace_ids=[workspace_id],
+                    offset=current_offset,
+                    limit=page_limit,
                 ),
             )
         except SDKError as e:
             raise _wrap_sdk_error(e, base_context) from e
-
-        has_more = bool(response.workspaces_response and response.workspaces_response.next)
-        offset += page_size
 
         if not status_ok(response.status_code):
             raise AirbyteError(
@@ -359,16 +400,24 @@ def list_workspaces(
             )
 
         assert response.workspaces_response is not None
-        result += [
-            workspace
-            for workspace in response.workspaces_response.data
-            if name_filter(workspace.name)
-        ]
+        page_data = response.workspaces_response.data
+        if not page_data:
+            break
+
+        matching_workspaces = [workspace for workspace in page_data if name_filter(workspace.name)]
+        result += matching_workspaces if remaining is None else matching_workspaces[:remaining]
+        if remaining is not None:
+            remaining -= len(matching_workspaces[:remaining])
+
+        if not response.workspaces_response.next:
+            break
+
+        current_offset += len(page_data)
 
     return result
 
 
-def list_sources(
+def list_sources(  # noqa: PLR0913
     workspace_id: str,
     *,
     api_root: str,
@@ -377,10 +426,15 @@ def list_sources(
     bearer_token: SecretString | None,
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[models.SourceResponse]:
     """List sources."""
     if name and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
+    _validate_pagination_params(limit=limit, offset=offset)
+    if limit == 0:
+        return []
 
     name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
 
@@ -392,23 +446,21 @@ def list_sources(
         api_root=api_root,
     )
     result: list[models.SourceResponse] = []
-    has_more = True
-    offset, page_size = 0, 100
+    current_offset = _get_initial_offset(offset)
+    remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
-    while has_more:
+    while remaining is None or remaining > 0:
+        page_limit = _get_page_limit(remaining)
         try:
             response: api.ListSourcesResponse = airbyte_instance.sources.list_sources(
                 api.ListSourcesRequest(
                     workspace_ids=[workspace_id],
-                    offset=offset,
-                    limit=page_size,
+                    offset=current_offset,
+                    limit=page_limit,
                 ),
             )
         except SDKError as e:
             raise _wrap_sdk_error(e, base_context) from e
-
-        has_more = bool(response.sources_response and response.sources_response.next)
-        offset += page_size
 
         if not status_ok(response.status_code):
             raise AirbyteError(
@@ -419,12 +471,24 @@ def list_sources(
                 },
             )
         assert response.sources_response is not None
-        result += [source for source in response.sources_response.data if name_filter(source.name)]
+        page_data = response.sources_response.data
+        if not page_data:
+            break
+
+        matching_sources = [source for source in page_data if name_filter(source.name)]
+        result += matching_sources if remaining is None else matching_sources[:remaining]
+        if remaining is not None:
+            remaining -= len(matching_sources[:remaining])
+
+        if not response.sources_response.next:
+            break
+
+        current_offset += len(page_data)
 
     return result
 
 
-def list_destinations(
+def list_destinations(  # noqa: PLR0913
     workspace_id: str,
     *,
     api_root: str,
@@ -433,10 +497,15 @@ def list_destinations(
     bearer_token: SecretString | None,
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[models.DestinationResponse]:
     """List destinations."""
     if name and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
+    _validate_pagination_params(limit=limit, offset=offset)
+    if limit == 0:
+        return []
 
     name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
 
@@ -448,23 +517,21 @@ def list_destinations(
         api_root=api_root,
     )
     result: list[models.DestinationResponse] = []
-    has_more = True
-    offset, page_size = 0, 100
+    current_offset = _get_initial_offset(offset)
+    remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
-    while has_more:
+    while remaining is None or remaining > 0:
+        page_limit = _get_page_limit(remaining)
         try:
             response = airbyte_instance.destinations.list_destinations(
                 api.ListDestinationsRequest(
                     workspace_ids=[workspace_id],
-                    offset=offset,
-                    limit=page_size,
+                    offset=current_offset,
+                    limit=page_limit,
                 ),
             )
         except SDKError as e:
             raise _wrap_sdk_error(e, base_context) from e
-
-        has_more = bool(response.destinations_response and response.destinations_response.next)
-        offset += page_size
 
         if not status_ok(response.status_code):
             raise AirbyteError(
@@ -475,11 +542,21 @@ def list_destinations(
                 },
             )
         assert response.destinations_response is not None
-        result += [
-            destination
-            for destination in response.destinations_response.data
-            if name_filter(destination.name)
+        page_data = response.destinations_response.data
+        if not page_data:
+            break
+
+        matching_destinations = [
+            destination for destination in page_data if name_filter(destination.name)
         ]
+        result += matching_destinations if remaining is None else matching_destinations[:remaining]
+        if remaining is not None:
+            remaining -= len(matching_destinations[:remaining])
+
+        if not response.destinations_response.next:
+            break
+
+        current_offset += len(page_data)
 
     return result
 
@@ -592,6 +669,9 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
 ) -> list[models.JobResponse]:
     """Get a list of jobs for a connection.
 
+    Automatically paginates through multiple API pages when the requested
+    `limit` exceeds the per-page size.
+
     Args:
         workspace_id: The workspace ID.
         connection_id: The connection ID.
@@ -608,35 +688,63 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
     Returns:
         A list of JobResponse objects.
     """
+    _validate_pagination_params(limit=limit, offset=offset)
+    if limit == 0:
+        return []
+
     airbyte_instance = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
         api_root=api_root,
     )
-    response: api.ListJobsResponse = airbyte_instance.jobs.list_jobs(
-        api.ListJobsRequest(
-            workspace_ids=[workspace_id],
-            connection_id=connection_id,
-            limit=limit,
-            offset=offset,
-            order_by=order_by,
-            job_type=job_type,
-        ),
-    )
-    if status_ok(response.status_code) and response.jobs_response:
-        return response.jobs_response.data
+    result: list[models.JobResponse] = []
+    current_offset = _get_initial_offset(offset)
+    remaining = limit
+    base_context = {
+        "workspace_id": workspace_id,
+        "connection_id": connection_id,
+        "api_root": api_root,
+    }
+    while remaining is not None and remaining > 0:
+        page_limit = _get_page_limit(remaining)
+        try:
+            response: api.ListJobsResponse = airbyte_instance.jobs.list_jobs(
+                api.ListJobsRequest(
+                    workspace_ids=[workspace_id],
+                    connection_id=connection_id,
+                    limit=page_limit,
+                    offset=current_offset,
+                    order_by=order_by,
+                    job_type=job_type,
+                ),
+            )
+        except SDKError as e:
+            raise _wrap_sdk_error(e, base_context) from e
 
-    raise AirbyteMissingResourceError(
-        response=response,
-        resource_type="job",
-        context={
-            "workspace_id": workspace_id,
-            "connection_id": connection_id,
-            "request_url": response.raw_response.url,
-            "status_code": response.status_code,
-        },
-    )
+        if not status_ok(response.status_code) or not response.jobs_response:
+            raise AirbyteMissingResourceError(
+                response=response,
+                resource_type="job",
+                context={
+                    **base_context,
+                    "request_url": response.raw_response.url,
+                    "status_code": response.status_code,
+                },
+            )
+
+        page_data: list[models.JobResponse] = list(response.jobs_response.data)
+        if not page_data:
+            break
+
+        result += page_data
+        remaining -= len(page_data)
+        current_offset += len(page_data)
+
+        if not response.jobs_response.next:
+            break
+
+    return result[:limit]
 
 
 def get_job_info(

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -63,8 +63,8 @@ def _validate_pagination_params(
     offset: int | None,
 ) -> None:
     """Validate common pagination parameters."""
-    if limit is not None and limit < 0:
-        raise PyAirbyteInputError(message="`limit` must be greater than or equal to 0.")
+    if limit is not None and limit <= 0:
+        raise PyAirbyteInputError(message="`limit` must be greater than 0.")
     if offset is not None and offset < 0:
         raise PyAirbyteInputError(message="`offset` must be greater than or equal to 0.")
 
@@ -273,7 +273,7 @@ def get_workspace(
 # List resources
 
 
-def list_connections(  # noqa: PLR0913
+def list_connections(  # noqa: PLR0913  # API auth requires multiple credential options.
     workspace_id: str,
     *,
     api_root: str,
@@ -289,9 +289,6 @@ def list_connections(  # noqa: PLR0913
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
-    if limit == 0:
-        return []
-
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -347,7 +344,7 @@ def list_connections(  # noqa: PLR0913
     return result
 
 
-def list_workspaces(  # noqa: PLR0913
+def list_workspaces(  # noqa: PLR0913  # API auth requires multiple credential options.
     workspace_id: str,
     *,
     api_root: str,
@@ -363,9 +360,6 @@ def list_workspaces(  # noqa: PLR0913
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
-    if limit == 0:
-        return []
-
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -419,7 +413,7 @@ def list_workspaces(  # noqa: PLR0913
     return result
 
 
-def list_sources(  # noqa: PLR0913
+def list_sources(  # noqa: PLR0913  # API auth requires multiple credential options.
     workspace_id: str,
     *,
     api_root: str,
@@ -435,9 +429,6 @@ def list_sources(  # noqa: PLR0913
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
-    if limit == 0:
-        return []
-
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -490,7 +481,7 @@ def list_sources(  # noqa: PLR0913
     return result
 
 
-def list_destinations(  # noqa: PLR0913
+def list_destinations(  # noqa: PLR0913  # API auth requires multiple credential options.
     workspace_id: str,
     *,
     api_root: str,
@@ -506,9 +497,6 @@ def list_destinations(  # noqa: PLR0913
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
-    if limit == 0:
-        return []
-
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -693,9 +681,6 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         A list of JobResponse objects.
     """
     _validate_pagination_params(limit=limit, offset=offset)
-    if limit == 0:
-        return []
-
     airbyte_instance = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -347,6 +347,7 @@ def list_workspaces(
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit)
+    has_name_filter = name is not None or name_filter is not None
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     airbyte_instance: airbyte_api.AirbyteAPI = get_airbyte_server_instance(
@@ -360,11 +361,12 @@ def list_workspaces(
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
+        page_limit = PAGE_SIZE if has_name_filter else _get_page_limit(remaining)
         try:
             response: api.ListWorkspacesResponse = airbyte_instance.workspaces.list_workspaces(
                 api.ListWorkspacesRequest(
                     offset=current_offset,
-                    limit=PAGE_SIZE,
+                    limit=page_limit,
                 ),
             )
         except SDKError as e:
@@ -632,7 +634,8 @@ def run_connection(
 def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexibility
     workspace_id: str,
     connection_id: str,
-    limit: int = 100,
+    limit: int | None = 100,
+    offset: int | None = None,
     *,
     api_root: str,
     client_id: SecretString | None,
@@ -650,6 +653,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         workspace_id: The workspace ID.
         connection_id: The connection ID.
         limit: Maximum number of jobs to return. Defaults to 100.
+        offset: Number of jobs to skip from the beginning. Defaults to None (0).
         api_root: The API root URL.
         client_id: The client ID for authentication.
         client_secret: The client secret for authentication.
@@ -669,14 +673,14 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         api_root=api_root,
     )
     result: list[models.JobResponse] = []
-    current_offset = 0
+    current_offset = offset or 0
     remaining = limit
     base_context = {
         "workspace_id": workspace_id,
         "connection_id": connection_id,
         "api_root": api_root,
     }
-    while remaining is not None and remaining > 0:
+    while remaining is None or remaining > 0:
         page_limit = _get_page_limit(remaining)
         try:
             response: api.ListJobsResponse = airbyte_instance.jobs.list_jobs(
@@ -728,13 +732,14 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
             break
 
         result += page_data
-        remaining -= len(page_data)
+        if remaining is not None:
+            remaining -= len(page_data)
         current_offset += len(page_data)
 
-        if not response.jobs_response.next:
+        if not response.jobs_response.next or len(page_data) < page_limit:
             break
 
-    return result[:limit]
+    return result if limit is None else result[:limit]
 
 
 def get_job_info(

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -60,20 +60,10 @@ def status_ok(status_code: int) -> bool:
 def _validate_pagination_params(
     *,
     limit: int | None,
-    offset: int | None,
 ) -> None:
     """Validate common pagination parameters."""
     if limit is not None and limit <= 0:
         raise PyAirbyteInputError(message="`limit` must be greater than 0.")
-    if offset is not None and offset < 0:
-        raise PyAirbyteInputError(message="`offset` must be greater than or equal to 0.")
-
-
-def _get_initial_offset(offset: int | None) -> int:
-    """Get an API offset from an optional user-provided offset."""
-    if offset is None:
-        return 0
-    return offset
 
 
 def _get_page_limit(remaining: int | None) -> int:
@@ -273,7 +263,7 @@ def get_workspace(
 # List resources
 
 
-def list_connections(  # noqa: PLR0913  # API auth requires multiple credential options.
+def list_connections(
     workspace_id: str,
     *,
     api_root: str,
@@ -283,12 +273,11 @@ def list_connections(  # noqa: PLR0913  # API auth requires multiple credential 
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
-    offset: int | None = None,
 ) -> list[models.ConnectionResponse]:
     """List connections."""
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
-    _validate_pagination_params(limit=limit, offset=offset)
+    _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -299,7 +288,7 @@ def list_connections(  # noqa: PLR0913  # API auth requires multiple credential 
         api_root=api_root,
     )
     result: list[models.ConnectionResponse] = []
-    current_offset = _get_initial_offset(offset)
+    current_offset = 0
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
@@ -344,7 +333,7 @@ def list_connections(  # noqa: PLR0913  # API auth requires multiple credential 
     return result
 
 
-def list_workspaces(  # noqa: PLR0913  # API auth requires multiple credential options.
+def list_workspaces(
     workspace_id: str,
     *,
     api_root: str,
@@ -354,12 +343,11 @@ def list_workspaces(  # noqa: PLR0913  # API auth requires multiple credential o
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
-    offset: int | None = None,
 ) -> list[models.WorkspaceResponse]:
     """List workspaces."""
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
-    _validate_pagination_params(limit=limit, offset=offset)
+    _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -370,7 +358,7 @@ def list_workspaces(  # noqa: PLR0913  # API auth requires multiple credential o
         api_root=api_root,
     )
     result: list[models.WorkspaceResponse] = []
-    current_offset = _get_initial_offset(offset)
+    current_offset = 0
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
@@ -413,7 +401,7 @@ def list_workspaces(  # noqa: PLR0913  # API auth requires multiple credential o
     return result
 
 
-def list_sources(  # noqa: PLR0913  # API auth requires multiple credential options.
+def list_sources(
     workspace_id: str,
     *,
     api_root: str,
@@ -423,12 +411,11 @@ def list_sources(  # noqa: PLR0913  # API auth requires multiple credential opti
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
-    offset: int | None = None,
 ) -> list[models.SourceResponse]:
     """List sources."""
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
-    _validate_pagination_params(limit=limit, offset=offset)
+    _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -439,7 +426,7 @@ def list_sources(  # noqa: PLR0913  # API auth requires multiple credential opti
         api_root=api_root,
     )
     result: list[models.SourceResponse] = []
-    current_offset = _get_initial_offset(offset)
+    current_offset = 0
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
@@ -481,7 +468,7 @@ def list_sources(  # noqa: PLR0913  # API auth requires multiple credential opti
     return result
 
 
-def list_destinations(  # noqa: PLR0913  # API auth requires multiple credential options.
+def list_destinations(
     workspace_id: str,
     *,
     api_root: str,
@@ -491,12 +478,11 @@ def list_destinations(  # noqa: PLR0913  # API auth requires multiple credential
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
-    offset: int | None = None,
 ) -> list[models.DestinationResponse]:
     """List destinations."""
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
-    _validate_pagination_params(limit=limit, offset=offset)
+    _validate_pagination_params(limit=limit)
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
@@ -507,7 +493,7 @@ def list_destinations(  # noqa: PLR0913  # API auth requires multiple credential
         api_root=api_root,
     )
     result: list[models.DestinationResponse] = []
-    current_offset = _get_initial_offset(offset)
+    current_offset = 0
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
@@ -655,7 +641,6 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
     client_id: SecretString | None,
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
-    offset: int | None = None,
     order_by: str | None = None,
     job_type: models.JobTypeEnum | None = None,
 ) -> list[models.JobResponse]:
@@ -672,7 +657,6 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         client_id: The client ID for authentication.
         client_secret: The client secret for authentication.
         bearer_token: Bearer token for authentication (alternative to client credentials).
-        offset: Number of jobs to skip from the beginning. Defaults to None (0).
         order_by: Field and direction to order by (e.g., "createdAt|DESC"). Defaults to None.
         job_type: Filter by job type (e.g., JobTypeEnum.SYNC, JobTypeEnum.REFRESH).
             If not specified, defaults to sync and reset jobs only (API default behavior).
@@ -680,7 +664,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
     Returns:
         A list of JobResponse objects.
     """
-    _validate_pagination_params(limit=limit, offset=offset)
+    _validate_pagination_params(limit=limit)
     airbyte_instance = get_airbyte_server_instance(
         client_id=client_id,
         client_secret=client_secret,
@@ -688,7 +672,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         api_root=api_root,
     )
     result: list[models.JobResponse] = []
-    current_offset = _get_initial_offset(offset)
+    current_offset = 0
     remaining = limit
     base_context = {
         "workspace_id": workspace_id,
@@ -2117,7 +2101,7 @@ def list_workspaces_in_organization(
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
     name_contains: str | None = None,
-    max_items_limit: int | None = None,
+    limit: int | None = None,
 ) -> list[dict[str, Any]]:
     """List workspaces within a specific organization.
 
@@ -2130,11 +2114,12 @@ def list_workspaces_in_organization(
         client_secret: OAuth client secret
         bearer_token: Bearer token for authentication (alternative to client credentials).
         name_contains: Optional substring filter for workspace names (server-side)
-        max_items_limit: Optional maximum number of workspaces to return
+        limit: Optional maximum number of workspaces to return
 
     Returns:
         List of workspace dictionaries containing workspaceId, organizationId, name, slug, etc.
     """
+    _validate_pagination_params(limit=limit)
     result: list[dict[str, Any]] = []
     page_size = 100
 
@@ -2169,8 +2154,8 @@ def list_workspaces_in_organization(
         result.extend(workspaces)
 
         # Check if we've reached the limit
-        if max_items_limit is not None and len(result) >= max_items_limit:
-            return result[:max_items_limit]
+        if limit is not None and len(result) >= limit:
+            return result[:limit]
 
         # If we got fewer results than page_size, this was the last page
         if len(workspaces) < page_size:

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -333,9 +333,12 @@ def list_connections(  # noqa: PLR0913
         matching_connections = [
             connection for connection in page_data if name_filter(connection.name)
         ]
-        result += matching_connections if remaining is None else matching_connections[:remaining]
+        page_results = (
+            matching_connections if remaining is None else matching_connections[:remaining]
+        )
+        result += page_results
         if remaining is not None:
-            remaining -= len(matching_connections[:remaining])
+            remaining -= len(page_results)
 
         if not response.connections_response.next:
             break
@@ -403,9 +406,10 @@ def list_workspaces(  # noqa: PLR0913
             break
 
         matching_workspaces = [workspace for workspace in page_data if name_filter(workspace.name)]
-        result += matching_workspaces if remaining is None else matching_workspaces[:remaining]
+        page_results = matching_workspaces if remaining is None else matching_workspaces[:remaining]
+        result += page_results
         if remaining is not None:
-            remaining -= len(matching_workspaces[:remaining])
+            remaining -= len(page_results)
 
         if not response.workspaces_response.next:
             break
@@ -473,9 +477,10 @@ def list_sources(  # noqa: PLR0913
             break
 
         matching_sources = [source for source in page_data if name_filter(source.name)]
-        result += matching_sources if remaining is None else matching_sources[:remaining]
+        page_results = matching_sources if remaining is None else matching_sources[:remaining]
+        result += page_results
         if remaining is not None:
-            remaining -= len(matching_sources[:remaining])
+            remaining -= len(page_results)
 
         if not response.sources_response.next:
             break
@@ -545,9 +550,12 @@ def list_destinations(  # noqa: PLR0913
         matching_destinations = [
             destination for destination in page_data if name_filter(destination.name)
         ]
-        result += matching_destinations if remaining is None else matching_destinations[:remaining]
+        page_results = (
+            matching_destinations if remaining is None else matching_destinations[:remaining]
+        )
+        result += page_results
         if remaining is not None:
-            remaining -= len(matching_destinations[:remaining])
+            remaining -= len(page_results)
 
         if not response.destinations_response.next:
             break
@@ -718,10 +726,30 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         except SDKError as e:
             raise _wrap_sdk_error(e, base_context) from e
 
-        if not status_ok(response.status_code) or not response.jobs_response:
-            raise AirbyteMissingResourceError(
+        if not status_ok(response.status_code):
+            if response.status_code == HTTPStatus.NOT_FOUND:
+                raise AirbyteMissingResourceError(
+                    response=response,
+                    resource_type="job",
+                    context={
+                        **base_context,
+                        "request_url": response.raw_response.url,
+                        "status_code": response.status_code,
+                    },
+                )
+            raise AirbyteError(
+                message="Failed to list jobs.",
                 response=response,
-                resource_type="job",
+                context={
+                    **base_context,
+                    "request_url": response.raw_response.url,
+                    "status_code": response.status_code,
+                },
+            )
+        if not response.jobs_response:
+            raise AirbyteError(
+                message="Jobs response payload was empty.",
+                response=response,
                 context={
                     **base_context,
                     "request_url": response.raw_response.url,

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 
 JOB_WAIT_INTERVAL_SECS = 2.0
 JOB_WAIT_TIMEOUT_SECS_DEFAULT = 60 * 60  # 1 hour
+PAGE_SIZE = 100
 
 # Job ordering constants for list_jobs API
 JOB_ORDER_BY_CREATED_AT_DESC = "createdAt|DESC"
@@ -77,10 +78,9 @@ def _get_initial_offset(offset: int | None) -> int:
 
 def _get_page_limit(remaining: int | None) -> int:
     """Get the next API page limit from the remaining item count."""
-    page_size = 100
     if remaining is None:
-        return page_size
-    return min(remaining, page_size)
+        return PAGE_SIZE
+    return min(remaining, PAGE_SIZE)
 
 
 def _get_sdk_error_context(error: SDKError) -> dict[str, Any]:
@@ -286,13 +286,13 @@ def list_connections(  # noqa: PLR0913
     offset: int | None = None,
 ) -> list[models.ConnectionResponse]:
     """List connections."""
-    if name and name_filter:
+    if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
     if limit == 0:
         return []
 
-    name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
+    name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
     airbyte_instance = get_airbyte_server_instance(
@@ -306,13 +306,12 @@ def list_connections(  # noqa: PLR0913
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
-        page_limit = _get_page_limit(remaining)
         try:
             response = airbyte_instance.connections.list_connections(
                 api.ListConnectionsRequest(
                     workspace_ids=[workspace_id],
                     offset=current_offset,
-                    limit=page_limit,
+                    limit=PAGE_SIZE,
                 ),
             )
         except SDKError as e:
@@ -358,13 +357,13 @@ def list_workspaces(  # noqa: PLR0913
     offset: int | None = None,
 ) -> list[models.WorkspaceResponse]:
     """List workspaces."""
-    if name and name_filter:
+    if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
     if limit == 0:
         return []
 
-    name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
+    name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
     airbyte_instance: airbyte_api.AirbyteAPI = get_airbyte_server_instance(
@@ -378,13 +377,12 @@ def list_workspaces(  # noqa: PLR0913
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
-        page_limit = _get_page_limit(remaining)
         try:
             response: api.ListWorkspacesResponse = airbyte_instance.workspaces.list_workspaces(
                 api.ListWorkspacesRequest(
                     workspace_ids=[workspace_id],
                     offset=current_offset,
-                    limit=page_limit,
+                    limit=PAGE_SIZE,
                 ),
             )
         except SDKError as e:
@@ -430,13 +428,13 @@ def list_sources(  # noqa: PLR0913
     offset: int | None = None,
 ) -> list[models.SourceResponse]:
     """List sources."""
-    if name and name_filter:
+    if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
     if limit == 0:
         return []
 
-    name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
+    name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
     airbyte_instance: airbyte_api.AirbyteAPI = get_airbyte_server_instance(
@@ -450,13 +448,12 @@ def list_sources(  # noqa: PLR0913
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
-        page_limit = _get_page_limit(remaining)
         try:
             response: api.ListSourcesResponse = airbyte_instance.sources.list_sources(
                 api.ListSourcesRequest(
                     workspace_ids=[workspace_id],
                     offset=current_offset,
-                    limit=page_limit,
+                    limit=PAGE_SIZE,
                 ),
             )
         except SDKError as e:
@@ -501,13 +498,13 @@ def list_destinations(  # noqa: PLR0913
     offset: int | None = None,
 ) -> list[models.DestinationResponse]:
     """List destinations."""
-    if name and name_filter:
+    if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit, offset=offset)
     if limit == 0:
         return []
 
-    name_filter = (lambda n: n == name) if name else name_filter or (lambda _: True)
+    name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
     _ = workspace_id  # Not used (yet)
     airbyte_instance = get_airbyte_server_instance(
@@ -521,13 +518,12 @@ def list_destinations(  # noqa: PLR0913
     remaining = limit
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
-        page_limit = _get_page_limit(remaining)
         try:
             response = airbyte_instance.destinations.list_destinations(
                 api.ListDestinationsRequest(
                     workspace_ids=[workspace_id],
                     offset=current_offset,
-                    limit=page_limit,
+                    limit=PAGE_SIZE,
                 ),
             )
         except SDKError as e:

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -308,6 +308,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         self,
         *,
         limit: int = 20,
+        offset: int | None = None,
         from_tail: bool = True,
         job_type: JobTypeEnum | None = None,
     ) -> list[SyncResult]:
@@ -319,6 +320,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
 
         Args:
             limit: Maximum number of jobs to return. Defaults to 20.
+            offset: Number of jobs to skip from the beginning. Defaults to None (0).
             from_tail: If True, returns jobs ordered newest-first (createdAt DESC).
                 If False, returns jobs ordered oldest-first (createdAt ASC).
                 Defaults to True.
@@ -338,6 +340,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             api_root=self.workspace.api_root,
             workspace_id=self.workspace.workspace_id,
             limit=limit,
+            offset=offset,
             order_by=order_by,
             job_type=job_type,
             client_id=self.workspace.client_id,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -308,7 +308,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         self,
         *,
         limit: int = 20,
-        offset: int | None = None,
         from_tail: bool = True,
         job_type: JobTypeEnum | None = None,
     ) -> list[SyncResult]:
@@ -320,7 +319,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
 
         Args:
             limit: Maximum number of jobs to return. Defaults to 20.
-            offset: Number of jobs to skip from the beginning. Defaults to None (0).
             from_tail: If True, returns jobs ordered newest-first (createdAt DESC).
                 If False, returns jobs ordered oldest-first (createdAt ASC).
                 Defaults to True.
@@ -340,7 +338,6 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             api_root=self.workspace.api_root,
             workspace_id=self.workspace.workspace_id,
             limit=limit,
-            offset=offset,
             order_by=order_by,
             job_type=job_type,
             client_id=self.workspace.client_id,

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -763,16 +763,17 @@ class CloudWorkspace:
         name: str | None = None,
         *,
         name_filter: Callable | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
     ) -> list[CloudConnection]:
-        """List connections by name in the workspace.
-
-        TODO: Add pagination support
-        """
+        """List connections by name in the workspace, with optional pagination."""
         connections = api_util.list_connections(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
+            limit=limit,
+            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -783,7 +784,6 @@ class CloudWorkspace:
                 connection_response=connection,
             )
             for connection in connections
-            if name is None or connection.name == name
         ]
 
     def list_sources(
@@ -791,16 +791,17 @@ class CloudWorkspace:
         name: str | None = None,
         *,
         name_filter: Callable | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
     ) -> list[CloudSource]:
-        """List all sources in the workspace.
-
-        TODO: Add pagination support
-        """
+        """List all sources in the workspace, with optional pagination."""
         sources = api_util.list_sources(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
+            limit=limit,
+            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -811,7 +812,6 @@ class CloudWorkspace:
                 source_response=source,
             )
             for source in sources
-            if name is None or source.name == name
         ]
 
     def list_destinations(
@@ -819,16 +819,17 @@ class CloudWorkspace:
         name: str | None = None,
         *,
         name_filter: Callable | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
     ) -> list[CloudDestination]:
-        """List all destinations in the workspace.
-
-        TODO: Add pagination support
-        """
+        """List all destinations in the workspace, with optional pagination."""
         destinations = api_util.list_destinations(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
+            limit=limit,
+            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -839,7 +840,6 @@ class CloudWorkspace:
                 destination_response=destination,
             )
             for destination in destinations
-            if name is None or destination.name == name
         ]
 
     def publish_custom_source_definition(

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -764,16 +764,14 @@ class CloudWorkspace:
         *,
         name_filter: Callable | None = None,
         limit: int | None = None,
-        offset: int | None = None,
     ) -> list[CloudConnection]:
-        """List connections by name in the workspace, with optional pagination."""
+        """List connections by name in the workspace, with an optional limit."""
         connections = api_util.list_connections(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
             limit=limit,
-            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -792,16 +790,14 @@ class CloudWorkspace:
         *,
         name_filter: Callable | None = None,
         limit: int | None = None,
-        offset: int | None = None,
     ) -> list[CloudSource]:
-        """List all sources in the workspace, with optional pagination."""
+        """List all sources in the workspace, with an optional limit."""
         sources = api_util.list_sources(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
             limit=limit,
-            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
@@ -820,16 +816,14 @@ class CloudWorkspace:
         *,
         name_filter: Callable | None = None,
         limit: int | None = None,
-        offset: int | None = None,
     ) -> list[CloudDestination]:
-        """List all destinations in the workspace, with optional pagination."""
+        """List all destinations in the workspace, with an optional limit."""
         destinations = api_util.list_destinations(
             api_root=self.api_root,
             workspace_id=self.workspace_id,
             name=name,
             name_filter=name_filter,
             limit=limit,
-            offset=offset,
             client_id=self.client_id,
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -819,12 +819,14 @@ def list_deployed_cloud_source_connectors(
 ) -> list[CloudSourceResult]:
     """List all deployed source connectors in the Airbyte Cloud workspace."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    sources = workspace.list_sources(limit=limit)
+    sources = workspace.list_sources(limit=None if name_contains else limit)
 
     # Filter by name if requested
     if name_contains:
         needle = name_contains.lower()
         sources = [s for s in sources if s.name is not None and needle in s.name.lower()]
+    if limit is not None:
+        sources = sources[:limit]
 
     # Note: name and url are guaranteed non-null from list API responses
     return [
@@ -870,12 +872,14 @@ def list_deployed_cloud_destination_connectors(
 ) -> list[CloudDestinationResult]:
     """List all deployed destination connectors in the Airbyte Cloud workspace."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    destinations = workspace.list_destinations(limit=limit)
+    destinations = workspace.list_destinations(limit=None if name_contains else limit)
 
     # Filter by name if requested
     if name_contains:
         needle = name_contains.lower()
         destinations = [d for d in destinations if d.name is not None and needle in d.name.lower()]
+    if limit is not None:
+        destinations = destinations[:limit]
 
     # Note: name and url are guaranteed non-null from list API responses
     return [
@@ -1202,7 +1206,9 @@ def list_deployed_cloud_connections(
     This implicitly enables with_connection_status.
     """
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    connections = workspace.list_connections(limit=limit)
+    connections = workspace.list_connections(
+        limit=None if name_contains or failing_connections_only else limit
+    )
 
     # Filter by name if requested
     if name_contains:

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -232,14 +232,12 @@ class SyncJobResult(BaseModel):
 
 
 class SyncJobListResult(BaseModel):
-    """Result of listing sync jobs with pagination support."""
+    """Result of listing sync jobs with limit support."""
 
     jobs: list[SyncJobResult]
     """List of sync jobs."""
     jobs_count: int
     """Number of jobs returned in this response."""
-    jobs_offset: int
-    """Offset used for this request (0 if not specified)."""
     from_tail: bool
     """Whether jobs are ordered newest-first (True) or oldest-first (False)."""
 
@@ -731,18 +729,7 @@ def list_cloud_sync_jobs(
             description=(
                 "When True, jobs are ordered newest-first (createdAt DESC). "
                 "When False, jobs are ordered oldest-first (createdAt ASC). "
-                "Defaults to True if `jobs_offset` is not specified. "
-                "Cannot combine `from_tail=True` with `jobs_offset`."
-            ),
-            default=None,
-        ),
-    ],
-    jobs_offset: Annotated[
-        int | None,
-        Field(
-            description=(
-                "Number of jobs to skip from the beginning. "
-                "Cannot be combined with `from_tail=True`."
+                "Defaults to True."
             ),
             default=None,
         ),
@@ -759,24 +746,14 @@ def list_cloud_sync_jobs(
         ),
     ],
 ) -> SyncJobListResult:
-    """List sync jobs for a connection with pagination support.
+    """List sync jobs for a connection with limit support.
 
     This tool allows you to retrieve a list of sync jobs for a connection,
-    with control over ordering and pagination. By default, jobs are returned
-    newest-first (from_tail=True).
+    with control over ordering and result limit. By default, jobs are returned
+    newest-first (`from_tail=True`).
     """
-    # Validate that jobs_offset and from_tail are not both set
-    if jobs_offset is not None and from_tail is True:
-        raise PyAirbyteInputError(
-            message="Cannot specify both 'jobs_offset' and 'from_tail=True' parameters.",
-            context={"jobs_offset": jobs_offset, "from_tail": from_tail},
-        )
-
-    # Default to from_tail=True if neither is specified
-    if from_tail is None and jobs_offset is None:
+    if from_tail is None:
         from_tail = True
-    elif from_tail is None:
-        from_tail = False
 
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     connection = workspace.get_connection(connection_id=connection_id)
@@ -786,7 +763,6 @@ def list_cloud_sync_jobs(
 
     sync_results = connection.get_previous_sync_logs(
         limit=effective_limit,
-        offset=jobs_offset,
         from_tail=from_tail,
         job_type=job_type,
     )
@@ -806,7 +782,6 @@ def list_cloud_sync_jobs(
     return SyncJobListResult(
         jobs=jobs,
         jobs_count=len(jobs),
-        jobs_offset=jobs_offset or 0,
         from_tail=from_tail,
     )
 
@@ -834,7 +809,7 @@ def list_deployed_cloud_source_connectors(
             default=None,
         ),
     ],
-    max_items_limit: Annotated[
+    limit: Annotated[
         int | None,
         Field(
             description="Optional maximum number of items to return (default: no limit)",
@@ -844,16 +819,12 @@ def list_deployed_cloud_source_connectors(
 ) -> list[CloudSourceResult]:
     """List all deployed source connectors in the Airbyte Cloud workspace."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    sources = workspace.list_sources()
+    sources = workspace.list_sources(limit=limit)
 
     # Filter by name if requested
     if name_contains:
         needle = name_contains.lower()
         sources = [s for s in sources if s.name is not None and needle in s.name.lower()]
-
-    # Apply limit if requested
-    if max_items_limit is not None:
-        sources = sources[:max_items_limit]
 
     # Note: name and url are guaranteed non-null from list API responses
     return [
@@ -889,7 +860,7 @@ def list_deployed_cloud_destination_connectors(
             default=None,
         ),
     ],
-    max_items_limit: Annotated[
+    limit: Annotated[
         int | None,
         Field(
             description="Optional maximum number of items to return (default: no limit)",
@@ -899,16 +870,12 @@ def list_deployed_cloud_destination_connectors(
 ) -> list[CloudDestinationResult]:
     """List all deployed destination connectors in the Airbyte Cloud workspace."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    destinations = workspace.list_destinations()
+    destinations = workspace.list_destinations(limit=limit)
 
     # Filter by name if requested
     if name_contains:
         needle = name_contains.lower()
         destinations = [d for d in destinations if d.name is not None and needle in d.name.lower()]
-
-    # Apply limit if requested
-    if max_items_limit is not None:
-        destinations = destinations[:max_items_limit]
 
     # Note: name and url are guaranteed non-null from list API responses
     return [
@@ -1202,7 +1169,7 @@ def list_deployed_cloud_connections(
             default=None,
         ),
     ],
-    max_items_limit: Annotated[
+    limit: Annotated[
         int | None,
         Field(
             description="Optional maximum number of items to return (default: no limit)",
@@ -1235,7 +1202,7 @@ def list_deployed_cloud_connections(
     This implicitly enables with_connection_status.
     """
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    connections = workspace.list_connections()
+    connections = workspace.list_connections(limit=limit)
 
     # Filter by name if requested
     if name_contains:
@@ -1294,7 +1261,7 @@ def list_deployed_cloud_connections(
             )
         )
 
-        if max_items_limit is not None and len(results) >= max_items_limit:
+        if limit is not None and len(results) >= limit:
             break
 
     return results
@@ -1449,7 +1416,7 @@ def list_cloud_workspaces(
             default=None,
         ),
     ],
-    max_items_limit: Annotated[
+    limit: Annotated[
         int | None,
         Field(
             description="Optional maximum number of items to return (default: no limit)",
@@ -1484,7 +1451,7 @@ def list_cloud_workspaces(
         client_secret=SecretString(client_secret) if client_secret else None,
         bearer_token=SecretString(bearer_token) if bearer_token else None,
         name_contains=name_contains,
-        max_items_limit=max_items_limit,
+        limit=limit,
     )
 
     return [

--- a/tests/integration_tests/cloud/test_cloud_api_util.py
+++ b/tests/integration_tests/cloud/test_cloud_api_util.py
@@ -55,6 +55,7 @@ def test_list_workspaces(
         client_id=airbyte_cloud_client_id,
         client_secret=airbyte_cloud_client_secret,
         bearer_token=None,
+        limit=1,
     )
     assert result
     assert len(result) > 0

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for Cloud API utilities."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from airbyte._util import api_util
+from airbyte.secrets.base import SecretString
+from airbyte_api import api, models
+
+
+def _job_response(job_id: int) -> models.JobResponse:
+    return models.JobResponse(
+        connection_id="connection-id",
+        job_id=job_id,
+        job_type=models.JobTypeEnum.SYNC,
+        start_time="2026-01-01T00:00:00Z",
+        status=models.JobStatusEnum.SUCCEEDED,
+    )
+
+
+def _list_jobs_response(
+    data: list[models.JobResponse],
+    *,
+    next_page: str | None,
+) -> api.ListJobsResponse:
+    raw_response = SimpleNamespace(url="https://api.airbyte.com/v1/jobs")
+    return api.ListJobsResponse(
+        content_type="application/json",
+        status_code=200,
+        raw_response=raw_response,
+        jobs_response=models.JobsResponse(
+            data=data,
+            next=next_page,
+        ),
+    )
+
+
+def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[api.ListJobsRequest] = []
+    pages = [
+        _list_jobs_response(
+            [_job_response(job_id) for job_id in range(100)],
+            next_page="next",
+        ),
+        _list_jobs_response(
+            [_job_response(job_id) for job_id in range(100, 150)],
+            next_page=None,
+        ),
+    ]
+
+    def list_jobs(request: api.ListJobsRequest) -> api.ListJobsResponse:
+        requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(list_jobs=list_jobs))
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.get_job_logs(
+        workspace_id="workspace-id",
+        connection_id="connection-id",
+        limit=150,
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+    )
+
+    assert [job.job_id for job in result] == list(range(150))
+    assert [(request.limit, request.offset) for request in requests] == [
+        (100, 0),
+        (50, 100),
+    ]

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 import requests
 from airbyte._util import api_util
+from airbyte.exceptions import PyAirbyteInputError
 from airbyte.secrets.base import SecretString
 from airbyte_api import api, models
 
@@ -80,13 +81,6 @@ def _list_connections_response(
 @pytest.mark.parametrize(
     "kwargs,pages,expected_names,expected_requests",
     [
-        pytest.param(
-            {"limit": 0},
-            [],
-            [],
-            [],
-            id="limit_zero_short_circuits",
-        ),
         pytest.param(
             {"limit": 2, "offset": 5},
             [
@@ -208,6 +202,20 @@ def test_list_connections_paginates_resources(
     assert [
         (request.limit, request.offset) for request in captured_requests
     ] == expected_requests
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_list_connections_rejects_invalid_limits(limit: int) -> None:
+    """Verify connection list pagination rejects non-positive limits."""
+    with pytest.raises(PyAirbyteInputError, match="`limit` must be greater than 0."):
+        api_util.list_connections(
+            workspace_id="workspace-id",
+            api_root="https://api.airbyte.com/v1/",
+            client_id=SecretString("client-id"),
+            client_secret=SecretString("client-secret"),
+            bearer_token=None,
+            limit=limit,
+        )
 
 
 def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -271,6 +271,50 @@ def test_list_workspaces_does_not_filter_by_workspace_id(
     ]
 
 
+def test_list_workspaces_caps_unfiltered_api_page_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify unfiltered workspace listing uses requested limit as API page size."""
+    captured_requests: list[api.ListWorkspacesRequest] = []
+    pages = [
+        _list_workspaces_response(
+            [_workspace_response("first", 1)],
+            next_page="next",
+        ),
+    ]
+
+    def list_workspaces(
+        request: api.ListWorkspacesRequest,
+    ) -> api.ListWorkspacesResponse:
+        """Capture workspace list requests and return queued pages."""
+        captured_requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(
+        workspaces=SimpleNamespace(list_workspaces=list_workspaces),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.list_workspaces(
+        workspace_id="context-workspace-id",
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+        limit=1,
+    )
+
+    assert [workspace.workspace_id for workspace in result] == ["workspace-1"]
+    assert [
+        (request.workspace_ids, request.limit, request.offset)
+        for request in captured_requests
+    ] == [(None, 1, 0)]
+
+
 @pytest.mark.parametrize("limit", [0, -1])
 def test_list_connections_rejects_invalid_limits(limit: int) -> None:
     """Verify connection list pagination rejects non-positive limits."""
@@ -325,4 +369,50 @@ def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> 
     assert [(request.limit, request.offset) for request in captured_requests] == [
         (100, 0),
         (50, 100),
+    ]
+
+
+def test_get_job_logs_uses_offset_and_allows_unbounded_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify job log pagination preserves offset and treats `None` as unbounded."""
+    captured_requests: list[api.ListJobsRequest] = []
+    pages = [
+        _list_jobs_response(
+            [_job_response(job_id) for job_id in range(100)],
+            next_page="next",
+        ),
+        _list_jobs_response(
+            [_job_response(job_id) for job_id in range(100, 125)],
+            next_page=None,
+        ),
+    ]
+
+    def list_jobs(request: api.ListJobsRequest) -> api.ListJobsResponse:
+        """Capture job list requests and return queued pages."""
+        captured_requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(list_jobs=list_jobs))
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.get_job_logs(
+        workspace_id="workspace-id",
+        connection_id="connection-id",
+        limit=None,
+        offset=10,
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+    )
+
+    assert [job.job_id for job in result] == list(range(125))
+    assert [(request.limit, request.offset) for request in captured_requests] == [
+        (100, 10),
+        (100, 110),
     ]

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -59,6 +59,16 @@ def _connection_response(name: str, index: int) -> models.ConnectionResponse:
     )
 
 
+def _workspace_response(name: str, index: int) -> models.WorkspaceResponse:
+    """Create a minimal workspace response for pagination tests."""
+    return models.WorkspaceResponse(
+        data_residency="auto",
+        name=name,
+        notifications=models.NotificationsConfig(),
+        workspace_id=f"workspace-{index}",
+    )
+
+
 def _list_connections_response(
     data: list[models.ConnectionResponse],
     *,
@@ -72,6 +82,25 @@ def _list_connections_response(
         status_code=200,
         raw_response=raw_response,
         connections_response=models.ConnectionsResponse(
+            data=data,
+            next=next_page,
+        ),
+    )
+
+
+def _list_workspaces_response(
+    data: list[models.WorkspaceResponse],
+    *,
+    next_page: str | None,
+) -> api.ListWorkspacesResponse:
+    """Create a paginated workspaces API response."""
+    raw_response = requests.Response()
+    raw_response.url = "https://api.airbyte.com/v1/workspaces"
+    return api.ListWorkspacesResponse(
+        content_type="application/json",
+        status_code=200,
+        raw_response=raw_response,
+        workspaces_response=models.WorkspacesResponse(
             data=data,
             next=next_page,
         ),
@@ -187,6 +216,59 @@ def test_list_connections_paginates_resources(
     assert [
         (request.limit, request.offset) for request in captured_requests
     ] == expected_requests
+
+
+def test_list_workspaces_does_not_filter_by_workspace_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify workspace listing fetches accessible workspaces across pages."""
+    captured_requests: list[api.ListWorkspacesRequest] = []
+    pages = [
+        _list_workspaces_response(
+            [_workspace_response("first", 1)],
+            next_page="next",
+        ),
+        _list_workspaces_response(
+            [_workspace_response("second", 2)],
+            next_page=None,
+        ),
+    ]
+
+    def list_workspaces(
+        request: api.ListWorkspacesRequest,
+    ) -> api.ListWorkspacesResponse:
+        """Capture workspace list requests and return queued pages."""
+        captured_requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(
+        workspaces=SimpleNamespace(list_workspaces=list_workspaces),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.list_workspaces(
+        workspace_id="context-workspace-id",
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+    )
+
+    assert [workspace.workspace_id for workspace in result] == [
+        "workspace-1",
+        "workspace-2",
+    ]
+    assert [
+        (request.workspace_ids, request.limit, request.offset)
+        for request in captured_requests
+    ] == [
+        (None, 100, 0),
+        (None, 100, 1),
+    ]
 
 
 @pytest.mark.parametrize("limit", [0, -1])

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -13,6 +13,7 @@ from airbyte_api import api, models
 
 
 def _job_response(job_id: int) -> models.JobResponse:
+    """Create a minimal job response for pagination tests."""
     return models.JobResponse(
         connection_id="connection-id",
         job_id=job_id,
@@ -27,6 +28,7 @@ def _list_jobs_response(
     *,
     next_page: str | None,
 ) -> api.ListJobsResponse:
+    """Create a paginated jobs API response."""
     raw_response = requests.Response()
     raw_response.url = "https://api.airbyte.com/v1/jobs"
     return api.ListJobsResponse(
@@ -41,6 +43,7 @@ def _list_jobs_response(
 
 
 def _connection_response(name: str, index: int) -> models.ConnectionResponse:
+    """Create a minimal connection response for pagination tests."""
     return models.ConnectionResponse(
         configurations={},
         connection_id=f"connection-{index}",
@@ -60,6 +63,7 @@ def _list_connections_response(
     *,
     next_page: str | None,
 ) -> api.ListConnectionsResponse:
+    """Create a paginated connections API response."""
     raw_response = requests.Response()
     raw_response.url = "https://api.airbyte.com/v1/connections"
     return api.ListConnectionsResponse(
@@ -172,11 +176,13 @@ def test_list_connections_paginates_resources(
     expected_names: list[str],
     expected_requests: list[tuple[int | None, int | None]],
 ) -> None:
+    """Verify resource list pagination, filtering, and request sizing."""
     captured_requests: list[api.ListConnectionsRequest] = []
 
     def list_connections(
         request: api.ListConnectionsRequest,
     ) -> api.ListConnectionsResponse:
+        """Capture connection list requests and return queued pages."""
         captured_requests.append(request)
         return pages.pop(0)
 
@@ -205,6 +211,7 @@ def test_list_connections_paginates_resources(
 
 
 def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify job log pagination stops after collecting the requested limit."""
     captured_requests: list[api.ListJobsRequest] = []
     pages = [
         _list_jobs_response(
@@ -218,6 +225,7 @@ def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> 
     ]
 
     def list_jobs(request: api.ListJobsRequest) -> api.ListJobsResponse:
+        """Capture job list requests and return queued pages."""
         captured_requests.append(request)
         return pages.pop(0)
 

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import requests
 from airbyte._util import api_util
 from airbyte.secrets.base import SecretString
 from airbyte_api import api, models
@@ -26,7 +27,8 @@ def _list_jobs_response(
     *,
     next_page: str | None,
 ) -> api.ListJobsResponse:
-    raw_response = SimpleNamespace(url="https://api.airbyte.com/v1/jobs")
+    raw_response = requests.Response()
+    raw_response.url = "https://api.airbyte.com/v1/jobs"
     return api.ListJobsResponse(
         content_type="application/json",
         status_code=200,
@@ -36,6 +38,170 @@ def _list_jobs_response(
             next=next_page,
         ),
     )
+
+
+def _connection_response(name: str, index: int) -> models.ConnectionResponse:
+    return models.ConnectionResponse(
+        configurations={},
+        connection_id=f"connection-{index}",
+        created_at=index,
+        destination_id=f"destination-{index}",
+        name=name,
+        schedule={},
+        source_id=f"source-{index}",
+        status=models.ConnectionStatusEnum.ACTIVE,
+        tags=[],
+        workspace_id="workspace-id",
+    )
+
+
+def _list_connections_response(
+    data: list[models.ConnectionResponse],
+    *,
+    next_page: str | None,
+) -> api.ListConnectionsResponse:
+    raw_response = requests.Response()
+    raw_response.url = "https://api.airbyte.com/v1/connections"
+    return api.ListConnectionsResponse(
+        content_type="application/json",
+        status_code=200,
+        raw_response=raw_response,
+        connections_response=models.ConnectionsResponse(
+            data=data,
+            next=next_page,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs,pages,expected_names,expected_requests",
+    [
+        pytest.param(
+            {"limit": 0},
+            [],
+            [],
+            [],
+            id="limit_zero_short_circuits",
+        ),
+        pytest.param(
+            {"limit": 2, "offset": 5},
+            [
+                _list_connections_response(
+                    [
+                        _connection_response("first", 1),
+                        _connection_response("second", 2),
+                    ],
+                    next_page=None,
+                ),
+            ],
+            ["first", "second"],
+            [(100, 5)],
+            id="non_zero_offset_uses_full_page",
+        ),
+        pytest.param(
+            {"limit": 1, "name_filter": lambda name: name == "target"},
+            [
+                _list_connections_response(
+                    [
+                        _connection_response("miss", 1),
+                        _connection_response("target", 2),
+                    ],
+                    next_page=None,
+                ),
+            ],
+            ["target"],
+            [(100, 0)],
+            id="filtered_limit_uses_full_page",
+        ),
+        pytest.param(
+            {"limit": 2, "name_filter": lambda name: name == "target"},
+            [
+                _list_connections_response(
+                    [_connection_response("target", 1)],
+                    next_page="next",
+                ),
+                _list_connections_response(
+                    [
+                        _connection_response("target", 2),
+                        _connection_response("extra", 3),
+                    ],
+                    next_page=None,
+                ),
+            ],
+            ["target", "target"],
+            [(100, 0), (100, 1)],
+            id="filtered_limit_continues_until_enough_matches",
+        ),
+        pytest.param(
+            {"name": ""},
+            [
+                _list_connections_response(
+                    [
+                        _connection_response("", 1),
+                        _connection_response("non-empty", 2),
+                    ],
+                    next_page=None,
+                ),
+            ],
+            [""],
+            [(100, 0)],
+            id="empty_name_filters_exactly",
+        ),
+        pytest.param(
+            {},
+            [
+                _list_connections_response(
+                    [_connection_response("first", 1)],
+                    next_page="next",
+                ),
+                _list_connections_response(
+                    [_connection_response("second", 2)],
+                    next_page=None,
+                ),
+            ],
+            ["first", "second"],
+            [(100, 0), (100, 1)],
+            id="no_limit_auto_paginates",
+        ),
+    ],
+)
+def test_list_connections_paginates_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict,
+    pages: list[api.ListConnectionsResponse],
+    expected_names: list[str],
+    expected_requests: list[tuple[int | None, int | None]],
+) -> None:
+    requests: list[api.ListConnectionsRequest] = []
+
+    def list_connections(
+        request: api.ListConnectionsRequest,
+    ) -> api.ListConnectionsResponse:
+        requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(
+        connections=SimpleNamespace(list_connections=list_connections),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.list_connections(
+        workspace_id="workspace-id",
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+        **kwargs,
+    )
+
+    assert [connection.name for connection in result] == expected_names
+    assert [
+        (request.limit, request.offset) for request in requests
+    ] == expected_requests
 
 
 def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -82,21 +82,6 @@ def _list_connections_response(
     "kwargs,pages,expected_names,expected_requests",
     [
         pytest.param(
-            {"limit": 2, "offset": 5},
-            [
-                _list_connections_response(
-                    [
-                        _connection_response("first", 1),
-                        _connection_response("second", 2),
-                    ],
-                    next_page=None,
-                ),
-            ],
-            ["first", "second"],
-            [(100, 5)],
-            id="non_zero_offset_uses_full_page",
-        ),
-        pytest.param(
             {"limit": 1, "name_filter": lambda name: name == "target"},
             [
                 _list_connections_response(

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -172,12 +172,12 @@ def test_list_connections_paginates_resources(
     expected_names: list[str],
     expected_requests: list[tuple[int | None, int | None]],
 ) -> None:
-    requests: list[api.ListConnectionsRequest] = []
+    captured_requests: list[api.ListConnectionsRequest] = []
 
     def list_connections(
         request: api.ListConnectionsRequest,
     ) -> api.ListConnectionsResponse:
-        requests.append(request)
+        captured_requests.append(request)
         return pages.pop(0)
 
     airbyte_instance = SimpleNamespace(
@@ -200,12 +200,12 @@ def test_list_connections_paginates_resources(
 
     assert [connection.name for connection in result] == expected_names
     assert [
-        (request.limit, request.offset) for request in requests
+        (request.limit, request.offset) for request in captured_requests
     ] == expected_requests
 
 
 def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    requests: list[api.ListJobsRequest] = []
+    captured_requests: list[api.ListJobsRequest] = []
     pages = [
         _list_jobs_response(
             [_job_response(job_id) for job_id in range(100)],
@@ -218,7 +218,7 @@ def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> 
     ]
 
     def list_jobs(request: api.ListJobsRequest) -> api.ListJobsResponse:
-        requests.append(request)
+        captured_requests.append(request)
         return pages.pop(0)
 
     airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(list_jobs=list_jobs))
@@ -239,7 +239,7 @@ def test_get_job_logs_paginates_until_limit(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
     assert [job.job_id for job in result] == list(range(150))
-    assert [(request.limit, request.offset) for request in requests] == [
+    assert [(request.limit, request.offset) for request in captured_requests] == [
         (100, 0),
         (50, 100),
     ]

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -10,6 +10,11 @@ from typing import Callable, cast
 import pytest
 from airbyte._util.api_imports import JobStatusEnum
 from airbyte.mcp import cloud as cloud_mcp
+from airbyte.mcp.cloud import (
+    CloudConnectionResult,
+    CloudDestinationResult,
+    CloudSourceResult,
+)
 from fastmcp import Context
 
 
@@ -200,7 +205,12 @@ def test_mcp_cloud_list_tools_pass_limit_to_workspace(
 )
 def test_mcp_cloud_list_tools_apply_limit_after_name_filter(
     monkeypatch: pytest.MonkeyPatch,
-    tool: Callable[..., list[object]],
+    tool: Callable[
+        ...,
+        list[CloudSourceResult]
+        | list[CloudDestinationResult]
+        | list[CloudConnectionResult],
+    ],
     limit_key: str,
     extra_kwargs: dict[str, object],
 ) -> None:
@@ -222,6 +232,7 @@ def test_mcp_cloud_list_tools_apply_limit_after_name_filter(
 
     assert workspace.limits[limit_key] is None
     assert len(results) == 1
+    assert results[0].name == "target"
 
 
 def test_mcp_cloud_connections_apply_limit_after_status_filter(

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for Airbyte Cloud MCP tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+from airbyte.mcp import cloud as cloud_mcp
+
+
+@dataclass
+class _CloudSourceLike:
+    """Subset of `CloudSource` used by tested MCP list tools."""
+
+    source_id: str
+    name: str
+    connector_url: str
+
+
+@dataclass
+class _CloudDestinationLike:
+    """Subset of `CloudDestination` used by tested MCP list tools."""
+
+    destination_id: str
+    name: str
+    connector_url: str
+
+
+@dataclass
+class _CloudConnectionLike:
+    """Subset of `CloudConnection` used by tested MCP list tools."""
+
+    connection_id: str
+    name: str
+    connection_url: str
+    source_id: str
+    destination_id: str
+
+
+class _CloudWorkspace:
+    """Capture `limit` values passed from MCP list tools."""
+
+    def __init__(self) -> None:
+        """Create a workspace test double."""
+        self.limits: dict[str, int | None] = {}
+
+    def list_sources(self, *, limit: int | None = None) -> list[_CloudSourceLike]:
+        """Capture source list limit and return source test data."""
+        self.limits["sources"] = limit
+        items = [
+            _CloudSourceLike(
+                source_id=f"source-{index}",
+                name="first",
+                connector_url=f"https://cloud.airbyte.com/source-{index}",
+            )
+            for index in range(1, 3)
+        ]
+        return items if limit is None else items[:limit]
+
+    def list_destinations(
+        self, *, limit: int | None = None
+    ) -> list[_CloudDestinationLike]:
+        """Capture destination list limit and return destination test data."""
+        self.limits["destinations"] = limit
+        items = [
+            _CloudDestinationLike(
+                destination_id=f"destination-{index}",
+                name="first",
+                connector_url=f"https://cloud.airbyte.com/destination-{index}",
+            )
+            for index in range(1, 3)
+        ]
+        return items if limit is None else items[:limit]
+
+    def list_connections(
+        self, *, limit: int | None = None
+    ) -> list[_CloudConnectionLike]:
+        """Capture connection list limit and return connection test data."""
+        self.limits["connections"] = limit
+        items = [
+            _CloudConnectionLike(
+                connection_id=f"connection-{index}",
+                name="first",
+                connection_url=f"https://cloud.airbyte.com/connection-{index}",
+                source_id=f"source-connection-{index}",
+                destination_id=f"destination-connection-{index}",
+            )
+            for index in range(1, 3)
+        ]
+        return items if limit is None else items[:limit]
+
+
+@pytest.mark.parametrize(
+    "tool,limit_key,extra_kwargs",
+    [
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_source_connectors,
+            "sources",
+            {},
+            id="sources",
+        ),
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_destination_connectors,
+            "destinations",
+            {},
+            id="destinations",
+        ),
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_connections,
+            "connections",
+            {"with_connection_status": False, "failing_connections_only": False},
+            id="connections",
+        ),
+    ],
+)
+def test_mcp_cloud_list_tools_pass_limit_to_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tool: Callable[..., list[object]],
+    limit_key: str,
+    extra_kwargs: dict[str, object],
+) -> None:
+    """Verify Cloud MCP list tools forward `limit` to workspace list operations."""
+    workspace = _CloudWorkspace()
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    results = tool(
+        ctx=object(),
+        workspace_id="workspace-id",
+        name_contains=None,
+        limit=1,
+        **extra_kwargs,
+    )
+
+    assert workspace.limits[limit_key] == 1
+    assert len(results) == 1

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -4,10 +4,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from datetime import datetime, timezone
+from typing import Callable, cast
 
 import pytest
+from airbyte._util.api_imports import JobStatusEnum
 from airbyte.mcp import cloud as cloud_mcp
+from fastmcp import Context
+
+
+@dataclass
+class _SyncResultLike:
+    """Subset of `SyncResult` used by connection status tests."""
+
+    job_id: int
+    status: JobStatusEnum
+    start_time: datetime
+
+    def get_job_status(self) -> JobStatusEnum:
+        """Return the configured job status."""
+        return self.status
+
+    def is_job_complete(self) -> bool:
+        """Return whether the test sync job is complete."""
+        return True
 
 
 @dataclass
@@ -37,6 +57,19 @@ class _CloudConnectionLike:
     connection_url: str
     source_id: str
     destination_id: str
+    failed: bool = False
+
+    def get_previous_sync_logs(self, *, limit: int = 20) -> list[_SyncResultLike]:
+        """Return one completed sync result for connection status tests."""
+        _ = limit
+        status = JobStatusEnum.FAILED if self.failed else JobStatusEnum.SUCCEEDED
+        return [
+            _SyncResultLike(
+                job_id=1,
+                status=status,
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        ]
 
 
 class _CloudWorkspace:
@@ -52,7 +85,7 @@ class _CloudWorkspace:
         items = [
             _CloudSourceLike(
                 source_id=f"source-{index}",
-                name="first",
+                name="target" if index == 2 else "miss",
                 connector_url=f"https://cloud.airbyte.com/source-{index}",
             )
             for index in range(1, 3)
@@ -67,7 +100,7 @@ class _CloudWorkspace:
         items = [
             _CloudDestinationLike(
                 destination_id=f"destination-{index}",
-                name="first",
+                name="target" if index == 2 else "miss",
                 connector_url=f"https://cloud.airbyte.com/destination-{index}",
             )
             for index in range(1, 3)
@@ -82,10 +115,11 @@ class _CloudWorkspace:
         items = [
             _CloudConnectionLike(
                 connection_id=f"connection-{index}",
-                name="first",
+                name="target" if index == 2 else "miss",
                 connection_url=f"https://cloud.airbyte.com/connection-{index}",
                 source_id=f"source-connection-{index}",
                 destination_id=f"destination-connection-{index}",
+                failed=index == 2,
             )
             for index in range(1, 3)
         ]
@@ -139,3 +173,77 @@ def test_mcp_cloud_list_tools_pass_limit_to_workspace(
 
     assert workspace.limits[limit_key] == 1
     assert len(results) == 1
+
+
+@pytest.mark.parametrize(
+    "tool,limit_key,extra_kwargs",
+    [
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_source_connectors,
+            "sources",
+            {},
+            id="sources",
+        ),
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_destination_connectors,
+            "destinations",
+            {},
+            id="destinations",
+        ),
+        pytest.param(
+            cloud_mcp.list_deployed_cloud_connections,
+            "connections",
+            {"with_connection_status": False, "failing_connections_only": False},
+            id="connections",
+        ),
+    ],
+)
+def test_mcp_cloud_list_tools_apply_limit_after_name_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    tool: Callable[..., list[object]],
+    limit_key: str,
+    extra_kwargs: dict[str, object],
+) -> None:
+    """Verify Cloud MCP list tools cap results after local name filtering."""
+    workspace = _CloudWorkspace()
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    results = tool(
+        ctx=object(),
+        workspace_id="workspace-id",
+        name_contains="target",
+        limit=1,
+        **extra_kwargs,
+    )
+
+    assert workspace.limits[limit_key] is None
+    assert len(results) == 1
+
+
+def test_mcp_cloud_connections_apply_limit_after_status_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify connection list caps results after local status filtering."""
+    workspace = _CloudWorkspace()
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    results = cloud_mcp.list_deployed_cloud_connections(
+        ctx=cast(Context, object()),
+        workspace_id="workspace-id",
+        name_contains=None,
+        limit=1,
+        with_connection_status=False,
+        failing_connections_only=True,
+    )
+
+    assert workspace.limits["connections"] is None
+    assert len(results) == 1
+    assert results[0].id == "connection-2"


### PR DESCRIPTION
## Summary
Adds optional `limit` and `offset` pagination support to PyAirbyte Cloud list operations for connections, workspaces, sources, and destinations, while preserving the existing auto-pagination behavior when no limit is provided.

Also adds pagination for `get_job_logs()` so sync history requests fetch additional pages when the requested limit exceeds one API page. The list operation implementation preserves exact empty-string `name` filtering, keeps filtered list fetches at full API page size before applying client-side result limits, rejects non-positive `limit` values, and distinguishes true job-log 404s from auth/service failures.

Removed stale pagination TODOs from workspace list wrappers and added focused unit coverage for job log pagination plus resource-list pagination edge cases. Added docstrings for the new pagination test helpers/tests after CodeRabbit flagged docstring coverage.

Requested by AJ Steers from Slack thread: https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1779121915926609?thread_ts=1779121915.926609&cid=C08BHPUMEPJ

## Review & Testing Checklist for Human
- [ ] Verify the new `limit` and `offset` parameters on `CloudWorkspace.list_connections()`, `list_sources()`, and `list_destinations()` match expected public API semantics.
- [ ] Confirm filtered list calls with `name` or `name_filter` should continue scanning full API pages until enough matching results are found or the API is exhausted.
- [ ] Check that `limit=0` should raise `PyAirbyteInputError`, while `offset=0` remains valid.
- [ ] Check that `get_job_logs()` non-2xx handling matches caller expectations: 404 maps to `AirbyteMissingResourceError`, other non-2xx responses map to `AirbyteError`.
- [ ] Run an end-to-end Cloud workspace smoke test with a workspace containing more than one API page of jobs or resources, if available.

### Notes
Local validation completed:
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff format --check /home/ubuntu/repos/PyAirbyte/airbyte/_util/api_util.py /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_util.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff check /home/ubuntu/repos/PyAirbyte/airbyte/_util/api_util.py /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_util.py`
- `uv run --project /home/ubuntu/repos/PyAirbyte ruff check /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_util.py --select D`
- `uv run --project /home/ubuntu/repos/PyAirbyte pyrefly check /home/ubuntu/repos/PyAirbyte/airbyte/_util/api_util.py /home/ubuntu/repos/PyAirbyte/airbyte/cloud/workspaces.py /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_util.py --output-format=json`
- `uv run --project /home/ubuntu/repos/PyAirbyte pytest /home/ubuntu/repos/PyAirbyte/tests/unit_tests/test_cloud_api_util.py -q`
- Real Airbyte Cloud smoke test against the Devin Sandbox workspace before the latest reviewer-only cleanup: 55 connections, 65 sources, 19 destinations, `list_connections(limit=2)`, and `get_previous_sync_logs(limit=1)` completed successfully.

---
[Devin session](https://app.devin.ai/sessions/c7675392e71e4d7087214b0274123bbb)

Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List endpoints now support optional limit-based pagination for connections, workspaces, sources, and destinations; results are capped to the requested limit.
  * Job log retrieval auto-paginates across pages to fulfill larger limits.

* **Improvements**
  * Unified limit-style controls across cloud tools and simplified tailing default to from_tail=True.
  * Stronger input validation for pagination and mutual exclusion of name vs name_filter.

* **Tests**
  * Expanded unit tests covering pagination, filtering, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/PyAirbyte/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->