### PR TITLE
feat(cli): add interactive cloud login

### DIFF
--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -24,6 +24,14 @@ WorkspaceIdArg = Annotated[
         help="The workspace ID.",
     ),
 ]
+OrganizationIdArg = Annotated[
+    str | None,
+    Parameter(
+        name="--organization-id",
+        env_var=["AIRBYTE_ORGANIZATION_ID", "AIRBYTE_CLOUD_ORGANIZATION_ID"],
+        help="The organization ID.",
+    ),
+]
 ClientIdArg = Annotated[
     str | None,
     Parameter(env_var=["AIRBYTE_CLIENT_ID", "AIRBYTE_CLOUD_CLIENT_ID"], help="Airbyte client ID."),

--- a/airbyte/cli/cloud/login.py
+++ b/airbyte/cli/cloud/login.py
@@ -37,9 +37,10 @@ def login(
 ) -> None:
     """Log in to Airbyte Cloud or a self-managed Airbyte server.
 
-    Providing `--client-id` and `--client-secret` performs non-interactive login and
-    stores a bearer token in `~/.airbyte/credentials`. Self-managed servers must also
-    provide `--public-api-root` and `--config-api-root`.
+    By default, this command uses browser-based login and stores shared Airbyte CLI
+    application credentials in `~/.airbyte-cli/settings.json`. Providing `--client-id`
+    and `--client-secret` performs non-interactive login. Self-managed servers must
+    also provide `--public-api-root` and `--config-api-root`.
     """
     result = CloudClient.from_explicit_credentials(
         client_id=client_id,

--- a/airbyte/cli/cloud/login.py
+++ b/airbyte/cli/cloud/login.py
@@ -12,6 +12,7 @@ from airbyte.cli._input import (  # noqa: TC001  # Cyclopts resolves aliases at 
     ClientIdArg,
     ClientSecretArg,
     ConfigApiRootArg,
+    OrganizationIdArg,
 )
 from airbyte.cli._output import json_output
 from airbyte.cli.cloud._cli import cloud_app
@@ -30,6 +31,7 @@ def login(
     ] = None,
     client_id: ClientIdArg = None,
     client_secret: ClientSecretArg = None,
+    organization_id: OrganizationIdArg = None,
     public_api_root: ApiUrlArg = None,
     config_api_root: ConfigApiRootArg = None,
 ) -> None:
@@ -39,19 +41,19 @@ def login(
     stores a bearer token in `~/.airbyte/credentials`. Self-managed servers must also
     provide `--public-api-root` and `--config-api-root`.
     """
-    result = CloudClient.from_auth(
+    result = CloudClient.from_explicit_credentials(
         client_id=client_id,
         client_secret=client_secret,
+        organization_id=organization_id,
         public_api_root=public_api_root,
         config_api_root=config_api_root,
-    ).login(
-        interactive=interactive,
-    )
+    ).login(interactive=interactive)
     json_output(
         {
             "credentials_file": str(result.credentials_file_path),
             "airbyte_api_root": result.airbyte_api_root,
             "config_api_root": result.config_api_root,
+            "organization_id": result.organization_id,
         }
     )
 

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -636,37 +636,6 @@ def _api_url(airbyte_api_root: str, path: str) -> str:
     return f"{airbyte_api_root.rstrip('/')}{path}"
 
 
-def _exchange_keycloak_token_for_fast_token(
-    *,
-    session: requests.Session,
-    keycloak_access_token: str,
-    organization_id: str | None,
-    airbyte_api_root: str,
-    timeout_seconds: int,
-) -> tuple[str, str]:
-    """Exchange a Keycloak access token for a Sonar fast token."""
-    exchange_response = _bootstrap_request(
-        session=session,
-        method="POST",
-        url=_api_url(airbyte_api_root, "/internal/auth/exchange"),
-        access_token=keycloak_access_token,
-        organization_id=organization_id,
-        operation="Airbyte Cloud token exchange request",
-        timeout_seconds=timeout_seconds,
-    )
-    fast_token = _required_string(
-        exchange_response,
-        "access_token",
-        operation="Airbyte Cloud token exchange request",
-    )
-    exchanged_organization_id = _required_string(
-        exchange_response,
-        "organization_id",
-        operation="Airbyte Cloud token exchange request",
-    )
-    return fast_token, exchanged_organization_id
-
-
 def _parse_organizations(data: Mapping[str, object]) -> list[_OrganizationItem]:
     """Parse bootstrap organization list response."""
     organizations = data.get("organizations")
@@ -747,18 +716,11 @@ def _bootstrap_airbyte_credentials(
     stdin_is_tty: bool,
 ) -> tuple[str, str, str]:
     """Bootstrap Airbyte client credentials from a Keycloak access token."""
-    fast_token, initial_organization_id = _exchange_keycloak_token_for_fast_token(
-        session=session,
-        keycloak_access_token=access_token,
-        organization_id=organization_id,
-        airbyte_api_root=airbyte_api_root,
-        timeout_seconds=timeout_seconds,
-    )
     enrollment = _bootstrap_request(
         session=session,
         method="GET",
         url=_api_url(airbyte_api_root, "/internal/account/enrollment-status"),
-        access_token=fast_token,
+        access_token=access_token,
         operation="Airbyte Cloud enrollment-status request",
         timeout_seconds=timeout_seconds,
     )
@@ -768,13 +730,18 @@ def _bootstrap_airbyte_credentials(
             guidance="Complete onboarding at https://app.airbyte.ai and retry login.",
         )
 
-    chosen_organization_id = organization_id or initial_organization_id
-    if not organization_id:
+    chosen_organization_id = organization_id
+    if not chosen_organization_id:
+        initial_organization_id = _required_string(
+            enrollment,
+            "organization_id",
+            operation="Airbyte Cloud enrollment-status request",
+        )
         organizations_response = _bootstrap_request(
             session=session,
             method="GET",
             url=_api_url(airbyte_api_root, "/internal/account/organizations"),
-            access_token=fast_token,
+            access_token=access_token,
             organization_id=initial_organization_id,
             operation="Airbyte Cloud organizations request",
             timeout_seconds=timeout_seconds,
@@ -785,20 +752,12 @@ def _bootstrap_airbyte_credentials(
             error_stream=error_stream,
             stdin_is_tty=stdin_is_tty,
         )
-        if chosen_organization_id != initial_organization_id:
-            fast_token, chosen_organization_id = _exchange_keycloak_token_for_fast_token(
-                session=session,
-                keycloak_access_token=access_token,
-                organization_id=chosen_organization_id,
-                airbyte_api_root=airbyte_api_root,
-                timeout_seconds=timeout_seconds,
-            )
 
     application = _bootstrap_request(
         session=session,
         method="POST",
         url=_api_url(airbyte_api_root, "/internal/account/applications"),
-        access_token=fast_token,
+        access_token=access_token,
         organization_id=chosen_organization_id,
         operation="Airbyte Cloud applications request",
         timeout_seconds=timeout_seconds,

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -57,6 +57,7 @@ KEYCLOAK_CALLBACK_HOST = "127.0.0.1"
 AIRBYTE_AI_API_HOST = "https://api.airbyte.ai"
 AIRBYTE_AI_API_ROOT = f"{AIRBYTE_AI_API_HOST}/api/v1"
 DEFAULT_BROWSER_LOGIN_TIMEOUT_SECONDS = 180
+PYAIRBYTE_USER_AGENT = "pyairbyte/dev"
 
 
 @dataclass(frozen=True)
@@ -565,7 +566,11 @@ def _exchange_code_for_keycloak_token(
     token_url = f"{keycloak_base_url.rstrip('/')}/protocol/openid-connect/token"
     response = session.post(
         token_url,
-        headers={"Accept": "application/json"},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": PYAIRBYTE_USER_AGENT,
+        },
         data={
             "grant_type": "authorization_code",
             "code": code,
@@ -575,7 +580,19 @@ def _exchange_code_for_keycloak_token(
         },
         timeout=timeout_seconds,
     )
-    parsed = _json_object(response, operation="Keycloak token exchange")
+    try:
+        parsed = _json_object(response, operation="Keycloak token exchange")
+    except AirbyteError as ex:
+        if response.status_code != HTTPStatus.OK.value:
+            context: dict[str, object] = {"status_code": response.status_code}
+            content_type = response.headers.get("content-type")
+            if content_type:
+                context["content_type"] = content_type
+            raise AirbyteError(
+                message="Keycloak token exchange failed.",
+                context=context,
+            ) from ex
+        raise
     if response.status_code != HTTPStatus.OK.value or parsed.get("error"):
         error = parsed.get("error")
         error_description = parsed.get("error_description")

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -3,13 +3,28 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
+import secrets
+import socket
+import sys
+import threading
+import webbrowser
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from os import environ
 from pathlib import Path
+from queue import Empty, Queue
+from typing import TextIO
+from urllib.parse import parse_qs, urlencode, urlparse
 
+import requests
 import yaml
 
-from airbyte._util.api_util import get_bearer_token
+from airbyte._util.api_util import get_bearer_token, status_ok
 from airbyte.constants import (
     CLOUD_API_ROOT,
     CLOUD_API_ROOT_ENV_VAR,
@@ -21,7 +36,7 @@ from airbyte.constants import (
     CLOUD_ORGANIZATION_ID_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
 )
-from airbyte.exceptions import PyAirbyteInputError
+from airbyte.exceptions import AirbyteError, PyAirbyteInputError
 from airbyte.secrets.base import SecretString
 
 
@@ -33,15 +48,24 @@ ORGANIZATION_ID_ENV_VAR = "AIRBYTE_ORGANIZATION_ID"
 PUBLIC_API_ROOT_ENV_VAR = "AIRBYTE_API_ROOT"
 BEARER_TOKEN_ENV_VAR = "AIRBYTE_BEARER_TOKEN"
 CONFIG_API_ROOT_ENV_VAR = "AIRBYTE_CONFIG_API_ROOT"
+KEYCLOAK_BASE_URL = "https://cloud.airbyte.com/auth/realms/_airbyte-cloud-users"
+KEYCLOAK_CLIENT_ID = "sonar-webapp"
+KEYCLOAK_SCOPES = "openid email profile offline_access"
+CALLBACK_PATH = "/callback"
+KEYCLOAK_CALLBACK_HOST = "127.0.0.1"
+AIRBYTE_AI_API_HOST = "https://api.airbyte.ai"
+AIRBYTE_AI_API_ROOT = f"{AIRBYTE_AI_API_HOST}/api/v1"
+DEFAULT_BROWSER_LOGIN_TIMEOUT_SECONDS = 180
 
 
 @dataclass(frozen=True)
 class CloudLoginResult:
-    """Result of a successful non-interactive Cloud login."""
+    """Result of a successful Cloud login."""
 
     credentials_file_path: Path
     airbyte_api_root: str
     config_api_root: str
+    organization_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -192,15 +216,94 @@ def write_credentials_file(
     credentials_file_path.chmod(0o600)
 
 
-def _raise_interactive_login_unavailable() -> None:
-    """Raise an error for the unsupported browser login flow."""
-    raise PyAirbyteInputError(
-        message="Interactive Airbyte Cloud login is not implemented.",
-        guidance=(
-            "Provide `--client-id` and `--client-secret` for non-interactive login. "
-            "The browser login protocol has not been published in repo docs."
-        ),
-    )
+@dataclass(frozen=True)
+class _OAuthCallbackResult:
+    """OAuth callback result captured by the loopback server."""
+
+    code: str | None = None
+    state: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class _OrganizationItem:
+    """Organization item returned by the bootstrap API."""
+
+    id: str
+    name: str
+
+
+class _OAuthCallbackHTTPServer(HTTPServer):
+    """Loopback OAuth server with a typed result queue."""
+
+    result_queue: Queue[_OAuthCallbackResult]
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Handle one browser OAuth redirect."""
+
+    def do_GET(self) -> None:  # noqa: N802
+        """Capture the OAuth callback and render a browser result page."""
+        server = self.server
+        if not isinstance(server, _OAuthCallbackHTTPServer):
+            self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR)
+            return
+
+        parsed_url = urlparse(self.path)
+        if parsed_url.path != CALLBACK_PATH:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+
+        query = parse_qs(parsed_url.query)
+        error = _first_query_value(query, "error")
+        error_description = _first_query_value(query, "error_description")
+        if error:
+            message = f"{error}: {error_description}" if error_description else error
+            self._write_html(
+                status=HTTPStatus.OK,
+                body=(
+                    "<!doctype html><html><body><h1>Login failed</h1>"
+                    f"<p>{message}</p><p>You can close this window.</p></body></html>"
+                ),
+            )
+            server.result_queue.put(_OAuthCallbackResult(error=message))
+            return
+
+        code = _first_query_value(query, "code")
+        state = _first_query_value(query, "state")
+        if not code or not state:
+            self._write_html(
+                status=HTTPStatus.BAD_REQUEST,
+                body=(
+                    "<!doctype html><html><body><h1>Login failed</h1>"
+                    "<p>Missing code or state in callback.</p>"
+                    "<p>You can close this window.</p></body></html>"
+                ),
+            )
+            server.result_queue.put(
+                _OAuthCallbackResult(error="Callback missing code or state.")
+            )
+            return
+
+        self._write_html(
+            status=HTTPStatus.OK,
+            body=(
+                "<!doctype html><html><body><h1>Login successful</h1>"
+                "<p>You can close this window and return to the terminal.</p>"
+                "</body></html>"
+            ),
+        )
+        server.result_queue.put(_OAuthCallbackResult(code=code, state=state))
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Suppress default loopback request logging."""
+
+    def _write_html(self, *, status: HTTPStatus, body: str) -> None:
+        """Write a minimal HTML response."""
+        self.send_response(status.value)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
 
 
 def _validate_client_credentials(
@@ -209,9 +312,6 @@ def _validate_client_credentials(
     client_secret: str | None,
 ) -> tuple[str, str]:
     """Validate and return client credentials for non-interactive login."""
-    if not client_id and not client_secret:
-        _raise_interactive_login_unavailable()
-
     if not client_id or not client_secret:
         raise PyAirbyteInputError(
             message="Client ID and client secret are both required.",
@@ -245,6 +345,427 @@ def _resolve_login_roots(
     return CLOUD_API_ROOT, CLOUD_CONFIG_API_ROOT
 
 
+def _base64_urlsafe_no_padding(raw_value: bytes) -> str:
+    """Return base64 URL-safe text without padding."""
+    return base64.urlsafe_b64encode(raw_value).rstrip(b"=").decode("ascii")
+
+
+def _generate_code_verifier() -> str:
+    """Generate a PKCE verifier."""
+    return _base64_urlsafe_no_padding(secrets.token_bytes(32))
+
+
+def _code_challenge(verifier: str) -> str:
+    """Return the S256 PKCE challenge for a verifier."""
+    return _base64_urlsafe_no_padding(hashlib.sha256(verifier.encode()).digest())
+
+
+def _generate_state() -> str:
+    """Generate an OAuth state value."""
+    return _base64_urlsafe_no_padding(secrets.token_bytes(16))
+
+
+def _first_query_value(query: Mapping[str, Sequence[str]], key: str) -> str | None:
+    """Return the first query value for a key."""
+    values = query.get(key)
+    if not values:
+        return None
+    return values[0]
+
+
+def _start_loopback_server() -> tuple[_OAuthCallbackHTTPServer, threading.Thread]:
+    """Start the one-shot loopback callback server."""
+    server = _OAuthCallbackHTTPServer(
+        (KEYCLOAK_CALLBACK_HOST, 0),
+        _OAuthCallbackHandler,
+        bind_and_activate=False,
+    )
+    server.result_queue = Queue(maxsize=1)
+    server.address_family = socket.AF_INET
+    server.server_bind()
+    server.server_activate()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def _build_authorize_url(
+    *,
+    keycloak_base_url: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    """Build the Keycloak authorization URL."""
+    query = urlencode(
+        {
+            "response_type": "code",
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": KEYCLOAK_SCOPES,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    return f"{keycloak_base_url.rstrip('/')}/protocol/openid-connect/auth?{query}"
+
+
+def _json_object(response: requests.Response, *, operation: str) -> dict[str, object]:
+    """Decode a response body as a JSON object."""
+    try:
+        parsed: object = response.json()
+    except requests.JSONDecodeError as ex:
+        raise AirbyteError(
+            message=f"{operation} returned invalid JSON.",
+            context={"status_code": response.status_code},
+        ) from ex
+
+    if not isinstance(parsed, dict):
+        raise AirbyteError(
+            message=f"{operation} returned an unexpected response shape.",
+            context={"status_code": response.status_code},
+        )
+
+    return {str(key): value for key, value in parsed.items() if isinstance(key, str)}
+
+
+def _raise_for_response_status(response: requests.Response, *, operation: str) -> None:
+    """Raise a PyAirbyte API error for an unsuccessful response."""
+    if status_ok(response.status_code):
+        return
+
+    context: dict[str, object] = {"status_code": response.status_code}
+    if response.request is not None:
+        context["url"] = response.request.url
+    raise AirbyteError(message=f"{operation} failed.", context=context)
+
+
+def _required_string(data: Mapping[str, object], key: str, *, operation: str) -> str:
+    """Return a required string field from JSON data."""
+    value = data.get(key)
+    if isinstance(value, str) and value:
+        return value
+    raise AirbyteError(
+        message=f"{operation} did not return `{key}`.",
+    )
+
+
+def _exchange_code_for_keycloak_token(
+    *,
+    session: requests.Session,
+    keycloak_base_url: str,
+    code: str,
+    code_verifier: str,
+    redirect_uri: str,
+    timeout_seconds: int,
+) -> str:
+    """Exchange an authorization code for a transient Keycloak access token."""
+    token_url = f"{keycloak_base_url.rstrip('/')}/protocol/openid-connect/token"
+    response = session.post(
+        token_url,
+        headers={"Accept": "application/json"},
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "code_verifier": code_verifier,
+        },
+        timeout=timeout_seconds,
+    )
+    parsed = _json_object(response, operation="Keycloak token exchange")
+    if response.status_code != HTTPStatus.OK.value or parsed.get("error"):
+        error = parsed.get("error")
+        error_description = parsed.get("error_description")
+        context: dict[str, object] = {"status_code": response.status_code}
+        if isinstance(error, str):
+            context["error"] = error
+        if isinstance(error_description, str):
+            context["error_description"] = error_description
+        raise AirbyteError(message="Keycloak token exchange failed.", context=context)
+
+    return _required_string(parsed, "access_token", operation="Keycloak token exchange")
+
+
+def _bootstrap_request(
+    *,
+    session: requests.Session,
+    method: str,
+    url: str,
+    access_token: str,
+    operation: str,
+    organization_id: str | None = None,
+    timeout_seconds: int,
+) -> dict[str, object]:
+    """Call an Airbyte Cloud bootstrap endpoint."""
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+        "User-Agent": "PyAirbyte Client",
+        "X-ADP-Agent-CLI": "pyairbyte",
+    }
+    if organization_id:
+        headers["X-Organization-Id"] = organization_id
+
+    response = session.request(method, url, headers=headers, timeout=timeout_seconds)
+    _raise_for_response_status(response, operation=operation)
+    return _json_object(response, operation=operation)
+
+
+def _api_url(airbyte_api_root: str, path: str) -> str:
+    """Build an Airbyte API URL."""
+    return f"{airbyte_api_root.rstrip('/')}{path}"
+
+
+def _parse_organizations(data: Mapping[str, object]) -> list[_OrganizationItem]:
+    """Parse bootstrap organization list response."""
+    organizations = data.get("organizations")
+    if not isinstance(organizations, list):
+        raise AirbyteError(message="Organization list response did not include organizations.")
+
+    result: list[_OrganizationItem] = []
+    for organization in organizations:
+        if not isinstance(organization, Mapping):
+            raise AirbyteError(message="Organization list response included an invalid item.")
+        organization_id = organization.get("id")
+        organization_name = organization.get("organization_name")
+        if not isinstance(organization_id, str) or not organization_id:
+            raise AirbyteError(message="Organization list response included an item without `id`.")
+        result.append(
+            _OrganizationItem(
+                id=organization_id,
+                name=organization_name if isinstance(organization_name, str) else "",
+            )
+        )
+    return result
+
+
+def _organization_hint(organizations: Sequence[_OrganizationItem]) -> str:
+    """Build a hint listing available organization choices."""
+    lines = ["Re-run with `--organization-id <uuid>`. Available organizations:"]
+    for organization in organizations:
+        name = f"{organization.name} " if organization.name else ""
+        lines.append(f"- {name}({organization.id})")
+    return "\n".join(lines)
+
+
+def _choose_organization(
+    *,
+    organizations: Sequence[_OrganizationItem],
+    input_stream: TextIO,
+    error_stream: TextIO,
+    stdin_is_tty: bool,
+) -> str:
+    """Choose an organization from the bootstrap API response."""
+    if not organizations:
+        raise PyAirbyteInputError(
+            message="No organizations found for this Airbyte Cloud account.",
+            guidance="Complete onboarding at https://app.airbyte.ai and retry login.",
+        )
+    if len(organizations) == 1:
+        return organizations[0].id
+    if not stdin_is_tty:
+        raise PyAirbyteInputError(
+            message="This account belongs to multiple organizations.",
+            guidance=_organization_hint(organizations),
+        )
+
+    print("You belong to multiple organizations. Choose one:", file=error_stream)
+    for index, organization in enumerate(organizations, start=1):
+        name = organization.name or organization.id
+        print(f"  {index}) {name} ({organization.id})", file=error_stream)
+    print(f"Enter choice [1-{len(organizations)}]: ", end="", file=error_stream)
+    raw_choice = input_stream.readline().strip()
+    try:
+        choice = int(raw_choice)
+    except ValueError as ex:
+        raise PyAirbyteInputError(message="Organization choice must be a number.") from ex
+    if choice < 1 or choice > len(organizations):
+        raise PyAirbyteInputError(message="Organization choice is out of range.")
+    return organizations[choice - 1].id
+
+
+def _bootstrap_airbyte_credentials(
+    *,
+    session: requests.Session,
+    access_token: str,
+    organization_id: str | None,
+    airbyte_api_root: str,
+    timeout_seconds: int,
+    input_stream: TextIO,
+    error_stream: TextIO,
+    stdin_is_tty: bool,
+) -> tuple[str, str, str]:
+    """Bootstrap Airbyte client credentials from a Keycloak access token."""
+    enrollment = _bootstrap_request(
+        session=session,
+        method="GET",
+        url=_api_url(airbyte_api_root, "/internal/account/enrollment-status"),
+        access_token=access_token,
+        operation="Airbyte Cloud enrollment-status request",
+        timeout_seconds=timeout_seconds,
+    )
+    if enrollment.get("is_enrolled") is False:
+        raise PyAirbyteInputError(
+            message="This Airbyte Cloud account is not enrolled.",
+            guidance="Complete onboarding at https://app.airbyte.ai and retry login.",
+        )
+    initial_organization_id = _required_string(
+        enrollment,
+        "organization_id",
+        operation="Airbyte Cloud enrollment-status request",
+    )
+
+    chosen_organization_id = organization_id
+    if not chosen_organization_id:
+        organizations_response = _bootstrap_request(
+            session=session,
+            method="GET",
+            url=_api_url(airbyte_api_root, "/internal/account/organizations"),
+            access_token=access_token,
+            organization_id=initial_organization_id,
+            operation="Airbyte Cloud organizations request",
+            timeout_seconds=timeout_seconds,
+        )
+        chosen_organization_id = _choose_organization(
+            organizations=_parse_organizations(organizations_response),
+            input_stream=input_stream,
+            error_stream=error_stream,
+            stdin_is_tty=stdin_is_tty,
+        )
+
+    application = _bootstrap_request(
+        session=session,
+        method="POST",
+        url=_api_url(airbyte_api_root, "/internal/account/applications"),
+        access_token=access_token,
+        organization_id=chosen_organization_id,
+        operation="Airbyte Cloud applications request",
+        timeout_seconds=timeout_seconds,
+    )
+    client_id = _required_string(
+        application,
+        "client_id",
+        operation="Airbyte Cloud applications request",
+    )
+    client_secret = _required_string(
+        application,
+        "client_secret",
+        operation="Airbyte Cloud applications request",
+    )
+    return client_id, client_secret, chosen_organization_id
+
+
+def login_with_browser(  # noqa: PLR0913, PLR0914
+    *,
+    organization_id: str | None = None,
+    credentials_file_path: Path = CREDENTIALS_FILE_PATH,
+    keycloak_base_url: str = KEYCLOAK_BASE_URL,
+    airbyte_api_root: str = AIRBYTE_AI_API_ROOT,
+    config_api_root: str = CLOUD_CONFIG_API_ROOT,
+    timeout_seconds: int = DEFAULT_BROWSER_LOGIN_TIMEOUT_SECONDS,
+    open_url: Callable[[str], object] | None = None,
+    input_stream: TextIO | None = None,
+    error_stream: TextIO | None = None,
+    stdin_is_tty: bool | None = None,
+    session: requests.Session | None = None,
+) -> CloudLoginResult:
+    """Log in with browser-based PKCE and persist Airbyte credentials."""
+    input_stream = input_stream or sys.stdin
+    error_stream = error_stream or sys.stderr
+    stdin_is_tty = input_stream.isatty() if stdin_is_tty is None else stdin_is_tty
+    session = session or requests.Session()
+    open_url = open_url or webbrowser.open
+
+    code_verifier = _generate_code_verifier()
+    state = _generate_state()
+    server, thread = _start_loopback_server()
+    try:
+        port = server.server_address[1]
+        if not isinstance(port, int):
+            raise PyAirbyteInputError(message="Loopback callback server port is invalid.")
+        redirect_uri = f"http://{KEYCLOAK_CALLBACK_HOST}:{port}{CALLBACK_PATH}"
+        authorize_url = _build_authorize_url(
+            keycloak_base_url=keycloak_base_url,
+            redirect_uri=redirect_uri,
+            state=state,
+            code_challenge=_code_challenge(code_verifier),
+        )
+        try:
+            open_result = open_url(authorize_url)
+        except Exception as ex:
+            print(
+                f"Could not open a browser automatically ({ex}).\n"
+                f"Paste this URL into a browser:\n  {authorize_url}",
+                file=error_stream,
+            )
+        else:
+            if open_result is False:
+                print(
+                    f"Paste this URL into a browser:\n  {authorize_url}",
+                    file=error_stream,
+                )
+
+        try:
+            callback = server.result_queue.get(timeout=timeout_seconds)
+        except Empty as ex:
+            raise PyAirbyteInputError(
+                message="Timed out waiting for browser login callback.",
+                guidance="Retry `airbyte-cloud login` and complete login in the browser.",
+            ) from ex
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    if callback.error:
+        raise PyAirbyteInputError(message="Interactive Airbyte Cloud login failed.")
+    if not callback.code or not callback.state:
+        raise PyAirbyteInputError(message="Interactive Airbyte Cloud login did not return a code.")
+    if not hmac.compare_digest(state, callback.state):
+        raise PyAirbyteInputError(message="OAuth state mismatch.")
+
+    access_token = _exchange_code_for_keycloak_token(
+        session=session,
+        keycloak_base_url=keycloak_base_url,
+        code=callback.code,
+        code_verifier=code_verifier,
+        redirect_uri=redirect_uri,
+        timeout_seconds=timeout_seconds,
+    )
+    client_id, client_secret, selected_organization_id = _bootstrap_airbyte_credentials(
+        session=session,
+        access_token=access_token,
+        organization_id=organization_id,
+        airbyte_api_root=airbyte_api_root,
+        timeout_seconds=timeout_seconds,
+        input_stream=input_stream,
+        error_stream=error_stream,
+        stdin_is_tty=stdin_is_tty,
+    )
+
+    credentials = read_credentials_file(credentials_file_path)
+    credentials.pop("bearer_token", None)
+    credentials.update(
+        {
+            "airbyte_api_root": airbyte_api_root,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "config_api_root": config_api_root,
+            "organization_id": selected_organization_id,
+        }
+    )
+    write_credentials_file(credentials, credentials_file_path)
+
+    return CloudLoginResult(
+        credentials_file_path=credentials_file_path,
+        airbyte_api_root=airbyte_api_root,
+        config_api_root=config_api_root,
+        organization_id=selected_organization_id,
+    )
+
+
 def login_with_client_credentials(
     *,
     client_id: str | None = None,
@@ -269,6 +790,8 @@ def login_with_client_credentials(
     )
 
     credentials = read_credentials_file(credentials_file_path)
+    credentials.pop("client_id", None)
+    credentials.pop("client_secret", None)
     credentials.update(
         {
             "airbyte_api_root": resolved_airbyte_api_root,

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -620,7 +620,7 @@ def _bootstrap_request(
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
-        "User-Agent": "PyAirbyte Client",
+        "User-Agent": PYAIRBYTE_USER_AGENT,
         "X-ADP-Agent-CLI": "pyairbyte",
     }
     if organization_id:
@@ -634,6 +634,37 @@ def _bootstrap_request(
 def _api_url(airbyte_api_root: str, path: str) -> str:
     """Build an Airbyte API URL."""
     return f"{airbyte_api_root.rstrip('/')}{path}"
+
+
+def _exchange_keycloak_token_for_fast_token(
+    *,
+    session: requests.Session,
+    keycloak_access_token: str,
+    organization_id: str | None,
+    airbyte_api_root: str,
+    timeout_seconds: int,
+) -> tuple[str, str]:
+    """Exchange a Keycloak access token for a Sonar fast token."""
+    exchange_response = _bootstrap_request(
+        session=session,
+        method="POST",
+        url=_api_url(airbyte_api_root, "/internal/auth/exchange"),
+        access_token=keycloak_access_token,
+        organization_id=organization_id,
+        operation="Airbyte Cloud token exchange request",
+        timeout_seconds=timeout_seconds,
+    )
+    fast_token = _required_string(
+        exchange_response,
+        "access_token",
+        operation="Airbyte Cloud token exchange request",
+    )
+    exchanged_organization_id = _required_string(
+        exchange_response,
+        "organization_id",
+        operation="Airbyte Cloud token exchange request",
+    )
+    return fast_token, exchanged_organization_id
 
 
 def _parse_organizations(data: Mapping[str, object]) -> list[_OrganizationItem]:
@@ -716,11 +747,18 @@ def _bootstrap_airbyte_credentials(
     stdin_is_tty: bool,
 ) -> tuple[str, str, str]:
     """Bootstrap Airbyte client credentials from a Keycloak access token."""
+    fast_token, initial_organization_id = _exchange_keycloak_token_for_fast_token(
+        session=session,
+        keycloak_access_token=access_token,
+        organization_id=organization_id,
+        airbyte_api_root=airbyte_api_root,
+        timeout_seconds=timeout_seconds,
+    )
     enrollment = _bootstrap_request(
         session=session,
         method="GET",
         url=_api_url(airbyte_api_root, "/internal/account/enrollment-status"),
-        access_token=access_token,
+        access_token=fast_token,
         operation="Airbyte Cloud enrollment-status request",
         timeout_seconds=timeout_seconds,
     )
@@ -729,19 +767,14 @@ def _bootstrap_airbyte_credentials(
             message="This Airbyte Cloud account is not enrolled.",
             guidance="Complete onboarding at https://app.airbyte.ai and retry login.",
         )
-    initial_organization_id = _required_string(
-        enrollment,
-        "organization_id",
-        operation="Airbyte Cloud enrollment-status request",
-    )
 
-    chosen_organization_id = organization_id
-    if not chosen_organization_id:
+    chosen_organization_id = organization_id or initial_organization_id
+    if not organization_id:
         organizations_response = _bootstrap_request(
             session=session,
             method="GET",
             url=_api_url(airbyte_api_root, "/internal/account/organizations"),
-            access_token=access_token,
+            access_token=fast_token,
             organization_id=initial_organization_id,
             operation="Airbyte Cloud organizations request",
             timeout_seconds=timeout_seconds,
@@ -752,12 +785,20 @@ def _bootstrap_airbyte_credentials(
             error_stream=error_stream,
             stdin_is_tty=stdin_is_tty,
         )
+        if chosen_organization_id != initial_organization_id:
+            fast_token, chosen_organization_id = _exchange_keycloak_token_for_fast_token(
+                session=session,
+                keycloak_access_token=access_token,
+                organization_id=chosen_organization_id,
+                airbyte_api_root=airbyte_api_root,
+                timeout_seconds=timeout_seconds,
+            )
 
     application = _bootstrap_request(
         session=session,
         method="POST",
         url=_api_url(airbyte_api_root, "/internal/account/applications"),
-        access_token=access_token,
+        access_token=fast_token,
         organization_id=chosen_organization_id,
         operation="Airbyte Cloud applications request",
         timeout_seconds=timeout_seconds,

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -58,6 +58,7 @@ AIRBYTE_AI_API_HOST = "https://api.airbyte.ai"
 AIRBYTE_AI_API_ROOT = f"{AIRBYTE_AI_API_HOST}/api/v1"
 DEFAULT_BROWSER_LOGIN_TIMEOUT_SECONDS = 180
 PYAIRBYTE_USER_AGENT = "pyairbyte/dev"
+MAX_ERROR_RESPONSE_BODY_CHARS = 1_000
 
 
 @dataclass(frozen=True)
@@ -532,6 +533,42 @@ def _json_object(response: requests.Response, *, operation: str) -> dict[str, ob
     return {str(key): value for key, value in parsed.items() if isinstance(key, str)}
 
 
+def _response_body_excerpt(response: requests.Response) -> str | None:
+    """Return a bounded response body excerpt for error context."""
+    response_text = response.text.strip()
+    if not response_text:
+        return None
+    if len(response_text) <= MAX_ERROR_RESPONSE_BODY_CHARS:
+        return response_text
+    return f"{response_text[:MAX_ERROR_RESPONSE_BODY_CHARS]}..."
+
+
+def _add_error_response_context(
+    response: requests.Response,
+    context: dict[str, object],
+) -> None:
+    """Add safe response details to request error context."""
+    content_type = response.headers.get("content-type")
+    if content_type:
+        context["content_type"] = content_type
+
+    if content_type and "application/json" in content_type.lower():
+        try:
+            parsed: object = response.json()
+        except requests.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            for key in ("detail", "message", "error", "error_description"):
+                value = parsed.get(key)
+                if isinstance(value, str) and value:
+                    context[key] = value
+            return
+
+    response_body = _response_body_excerpt(response)
+    if response_body:
+        context["response_body"] = response_body
+
+
 def _raise_for_response_status(response: requests.Response, *, operation: str) -> None:
     """Raise a PyAirbyte API error for an unsuccessful response."""
     if status_ok(response.status_code):
@@ -540,6 +577,7 @@ def _raise_for_response_status(response: requests.Response, *, operation: str) -
     context: dict[str, object] = {"status_code": response.status_code}
     if response.request is not None:
         context["url"] = response.request.url
+    _add_error_response_context(response, context)
     raise AirbyteError(message=f"{operation} failed.", context=context)
 
 
@@ -585,9 +623,7 @@ def _exchange_code_for_keycloak_token(
     except AirbyteError as ex:
         if response.status_code != HTTPStatus.OK.value:
             context: dict[str, object] = {"status_code": response.status_code}
-            content_type = response.headers.get("content-type")
-            if content_type:
-                context["content_type"] = content_type
+            _add_error_response_context(response, context)
             raise AirbyteError(
                 message="Keycloak token exchange failed.",
                 context=context,
@@ -597,6 +633,7 @@ def _exchange_code_for_keycloak_token(
         error = parsed.get("error")
         error_description = parsed.get("error_description")
         context: dict[str, object] = {"status_code": response.status_code}
+        _add_error_response_context(response, context)
         if isinstance(error, str):
             context["error"] = error
         if isinstance(error_description, str):

--- a/airbyte/cloud/credentials.py
+++ b/airbyte/cloud/credentials.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import json
 import secrets
 import socket
 import sys
+import tempfile
 import threading
 import webbrowser
 from collections.abc import Callable, Mapping, Sequence
@@ -22,7 +24,6 @@ from typing import TextIO
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import requests
-import yaml
 
 from airbyte._util.api_util import get_bearer_token, status_ok
 from airbyte.constants import (
@@ -40,7 +41,7 @@ from airbyte.exceptions import AirbyteError, PyAirbyteInputError
 from airbyte.secrets.base import SecretString
 
 
-CREDENTIALS_FILE_PATH = Path("~/.airbyte/credentials").expanduser()
+CREDENTIALS_FILE_PATH = Path("~/.airbyte-cli/settings.json").expanduser()
 CLIENT_ID_ENV_VAR = "AIRBYTE_CLIENT_ID"
 CLIENT_SECRET_ENV_VAR = "AIRBYTE_CLIENT_SECRET"
 WORKSPACE_ID_ENV_VAR = "AIRBYTE_WORKSPACE_ID"
@@ -81,17 +82,33 @@ class CloudCredentials:
     organization_id: str | None = None
 
 
-def _as_string_mapping(parsed: object) -> dict[str, str]:
-    """Return a string-only mapping from parsed YAML content."""
-    if not isinstance(parsed, dict):
+def _as_object_mapping(parsed: object) -> dict[str, object]:
+    """Return a string-keyed mapping from parsed JSON content."""
+    if not isinstance(parsed, Mapping):
         return {}
 
-    result: dict[str, str] = {}
-    for key, value in parsed.items():
-        if isinstance(key, str) and value is not None:
-            result[key] = str(value)
+    return {key: value for key, value in parsed.items() if isinstance(key, str)}
 
-    return result
+
+def _string_value(mapping: Mapping[str, object], key: str) -> str | None:
+    """Return a non-empty string value from a mapping."""
+    value = mapping.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _bool_value(
+    mapping: Mapping[str, object],
+    key: str,
+    *,
+    default: bool,
+) -> bool:
+    """Return a boolean value from a mapping, with a default for absent keys."""
+    value = mapping.get(key)
+    if isinstance(value, bool):
+        return value
+    return default
 
 
 def _first_value(*values: str | None) -> str | None:
@@ -111,20 +128,49 @@ def _env_value(*names: str) -> str | None:
     return None
 
 
-def read_credentials_file(
+def _read_settings_body(
     credentials_file_path: Path = CREDENTIALS_FILE_PATH,
-) -> dict[str, str]:
-    """Read Airbyte credentials from a YAML credentials file."""
+) -> dict[str, object]:
+    """Read the `settings` object from an airbyte-cli settings file."""
     if not credentials_file_path.exists():
         return {}
 
     try:
         content = credentials_file_path.read_text(encoding="utf-8").strip()
-        parsed = yaml.safe_load(content) if content else {}
-    except (OSError, yaml.YAMLError):
+        parsed: object = json.loads(content) if content else {}
+    except (OSError, json.JSONDecodeError):
         return {}
 
-    return _as_string_mapping(parsed)
+    parsed_mapping = _as_object_mapping(parsed)
+    return _as_object_mapping(parsed_mapping.get("settings"))
+
+
+def read_credentials_file(
+    credentials_file_path: Path = CREDENTIALS_FILE_PATH,
+) -> dict[str, str]:
+    """Read Airbyte credentials from the shared airbyte-cli settings file."""
+    settings = _read_settings_body(credentials_file_path)
+    settings_credentials = _as_object_mapping(settings.get("credentials"))
+
+    result: dict[str, str] = {}
+    for key in ("client_id", "client_secret"):
+        value = _string_value(settings_credentials, key)
+        if value:
+            result[key] = value
+
+    for key in (
+        "organization_id",
+        "bearer_token",
+        "airbyte_api_root",
+        "public_api_root",
+        "api_url",
+        "config_api_root",
+    ):
+        value = _string_value(settings, key)
+        if value:
+            result[key] = value
+
+    return result
 
 
 def resolve_cloud_credentials(
@@ -207,13 +253,70 @@ def write_credentials_file(
     credentials: dict[str, str],
     credentials_file_path: Path = CREDENTIALS_FILE_PATH,
 ) -> None:
-    """Write Airbyte credentials to a YAML credentials file."""
-    credentials_file_path.parent.mkdir(parents=True, exist_ok=True)
-    credentials_file_path.write_text(
-        yaml.safe_dump(dict(credentials), sort_keys=True),
-        encoding="utf-8",
+    """Write Airbyte credentials to the shared airbyte-cli settings file."""
+    existing_settings = _read_settings_body(credentials_file_path)
+    settings: dict[str, object] = {}
+
+    credentials_body: dict[str, str] = {}
+    for key in ("client_id", "client_secret"):
+        value = credentials.get(key)
+        if value:
+            credentials_body[key] = value
+    if credentials_body:
+        settings["credentials"] = credentials_body
+
+    for key in (
+        "organization_id",
+        "bearer_token",
+        "airbyte_api_root",
+        "config_api_root",
+    ):
+        value = credentials.get(key)
+        if value:
+            settings[key] = value
+
+    workspace = _string_value(existing_settings, "workspace") or "default"
+    if workspace:
+        settings["workspace"] = workspace
+
+    if _bool_value(existing_settings, "allow_destructive", default=False):
+        settings["allow_destructive"] = True
+    settings["telemetry_enabled"] = _bool_value(
+        existing_settings,
+        "telemetry_enabled",
+        default=True,
     )
-    credentials_file_path.chmod(0o600)
+    if _bool_value(existing_settings, "is_internal_user", default=False):
+        settings["is_internal_user"] = True
+    settings["version_check_enabled"] = _bool_value(
+        existing_settings,
+        "version_check_enabled",
+        default=True,
+    )
+
+    credentials_file_path.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        credentials_file_path.parent.chmod(0o700)
+
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=credentials_file_path.parent,
+            prefix=".settings-",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            json.dump({"settings": settings}, temp_file, indent=2)
+            temp_file.write("\n")
+        if sys.platform != "win32":
+            temp_path.chmod(0o600)
+        temp_path.replace(credentials_file_path)
+    except OSError:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+        raise
 
 
 @dataclass(frozen=True)
@@ -280,9 +383,7 @@ class _OAuthCallbackHandler(BaseHTTPRequestHandler):
                     "<p>You can close this window.</p></body></html>"
                 ),
             )
-            server.result_queue.put(
-                _OAuthCallbackResult(error="Callback missing code or state.")
-            )
+            server.result_queue.put(_OAuthCallbackResult(error="Callback missing code or state."))
             return
 
         self._write_html(
@@ -745,18 +846,16 @@ def login_with_browser(  # noqa: PLR0913, PLR0914
         stdin_is_tty=stdin_is_tty,
     )
 
-    credentials = read_credentials_file(credentials_file_path)
-    credentials.pop("bearer_token", None)
-    credentials.update(
+    write_credentials_file(
         {
             "airbyte_api_root": airbyte_api_root,
             "client_id": client_id,
             "client_secret": client_secret,
             "config_api_root": config_api_root,
             "organization_id": selected_organization_id,
-        }
+        },
+        credentials_file_path,
     )
-    write_credentials_file(credentials, credentials_file_path)
 
     return CloudLoginResult(
         credentials_file_path=credentials_file_path,
@@ -770,11 +869,12 @@ def login_with_client_credentials(
     *,
     client_id: str | None = None,
     client_secret: str | None = None,
+    organization_id: str | None = None,
     airbyte_api_root: str | None = None,
     config_api_root: str | None = None,
     credentials_file_path: Path = CREDENTIALS_FILE_PATH,
 ) -> CloudLoginResult:
-    """Log in using client credentials and persist a bearer token."""
+    """Log in using client credentials and persist Airbyte credentials."""
     resolved_client_id, resolved_client_secret = _validate_client_credentials(
         client_id=client_id,
         client_secret=client_secret,
@@ -783,28 +883,27 @@ def login_with_client_credentials(
         airbyte_api_root=airbyte_api_root,
         config_api_root=config_api_root,
     )
-    bearer_token = get_bearer_token(
+    get_bearer_token(
         client_id=SecretString(resolved_client_id),
         client_secret=SecretString(resolved_client_secret),
         api_root=resolved_airbyte_api_root,
     )
 
-    credentials = read_credentials_file(credentials_file_path)
-    credentials.pop("client_id", None)
-    credentials.pop("client_secret", None)
-    credentials.update(
-        {
-            "airbyte_api_root": resolved_airbyte_api_root,
-            "bearer_token": str(bearer_token),
-            "config_api_root": resolved_config_api_root,
-        }
-    )
+    credentials = {
+        "airbyte_api_root": resolved_airbyte_api_root,
+        "client_id": resolved_client_id,
+        "client_secret": resolved_client_secret,
+        "config_api_root": resolved_config_api_root,
+    }
+    if organization_id:
+        credentials["organization_id"] = organization_id
     write_credentials_file(credentials, credentials_file_path)
 
     return CloudLoginResult(
         credentials_file_path=credentials_file_path,
         airbyte_api_root=resolved_airbyte_api_root,
         config_api_root=resolved_config_api_root,
+        organization_id=organization_id,
     )
 
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -156,14 +156,16 @@ class CloudClient:
             return login_with_client_credentials(
                 client_id=str(self.client_id),
                 client_secret=str(self.client_secret),
+                organization_id=self.organization_id,
                 airbyte_api_root=self.public_api_root,
                 config_api_root=self.config_api_root,
                 credentials_file_path=credentials_file_path,
             )
 
-        custom_cloud_roots = self.public_api_root.rstrip("/") != api_util.CLOUD_API_ROOT.rstrip(
-            "/"
-        ) or self.config_api_root is not None
+        custom_cloud_roots = (
+            self.public_api_root.rstrip("/") != api_util.CLOUD_API_ROOT.rstrip("/")
+            or self.config_api_root is not None
+        )
         if interactive is False or custom_cloud_roots:
             raise exc.PyAirbyteInputError(
                 message="Client ID and client secret are both required.",

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -56,6 +56,7 @@ from airbyte.cloud.credentials import (
     CREDENTIALS_FILE_PATH,
     CloudCredentials,
     CloudLoginResult,
+    login_with_browser,
     login_with_client_credentials,
     resolve_cloud_credentials,
 )
@@ -145,9 +146,12 @@ class CloudClient:
         credentials_file_path: Path = CREDENTIALS_FILE_PATH,
     ) -> CloudLoginResult:
         """Log in to Airbyte and persist local credentials."""
-        if interactive is True:
-            # TK-TODO: Implement and verify interactive browser login before merging this PR.
-            raise NotImplementedError("Interactive Airbyte Cloud login is not implemented.")
+        if bool(self.client_id) != bool(self.client_secret):
+            raise exc.PyAirbyteInputError(
+                message="Client ID and client secret are both required.",
+                guidance="Provide both client ID and client secret for non-interactive login.",
+            )
+
         if self.client_id is not None and self.client_secret is not None:
             return login_with_client_credentials(
                 client_id=str(self.client_id),
@@ -156,14 +160,23 @@ class CloudClient:
                 config_api_root=self.config_api_root,
                 credentials_file_path=credentials_file_path,
             )
-        if interactive is False:
+
+        custom_cloud_roots = self.public_api_root.rstrip("/") != api_util.CLOUD_API_ROOT.rstrip(
+            "/"
+        ) or self.config_api_root is not None
+        if interactive is False or custom_cloud_roots:
             raise exc.PyAirbyteInputError(
                 message="Client ID and client secret are both required.",
-                guidance="Provide both client ID and client secret for non-interactive login.",
+                guidance=(
+                    "Provide both client ID and client secret for non-interactive login. "
+                    "Self-managed servers do not support browser login."
+                ),
             )
 
-        # TK-TODO: Implement and verify interactive browser login before merging this PR.
-        raise NotImplementedError("Interactive Airbyte Cloud login is not implemented.")
+        return login_with_browser(
+            organization_id=self.organization_id,
+            credentials_file_path=credentials_file_path,
+        )
 
     def logout(
         self,

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -521,6 +521,7 @@ class CloudWorkspace:
 
     def __init__(
         self,
+        *,
         workspace_id: str | None = None,
         client_id: str | SecretString | None = None,
         client_secret: str | SecretString | None = None,

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+from urllib.parse import parse_qs, urlparse
+from urllib.request import urlopen
 
 import pytest
+import responses
 import yaml
 
 from airbyte.cloud import credentials as cloud_credentials
@@ -54,8 +57,123 @@ def test_login_with_client_credentials_writes_bearer_token(
         assert credentials_file_path.stat().st_mode & 0o777 == 0o600
 
 
-def test_login_without_client_credentials_raises_interactive_flow_error() -> None:
-    with pytest.raises(PyAirbyteInputError, match="Interactive Airbyte Cloud login"):
+def _simulate_keycloak_redirect(url: str) -> bool:
+    parsed_url = urlparse(url)
+    query = parse_qs(parsed_url.query)
+    redirect_uri = query["redirect_uri"][0]
+    state = query["state"][0]
+    with urlopen(f"{redirect_uri}?code=test-auth-code&state={state}", timeout=5) as response:
+        assert response.status == 200
+    return True
+
+
+def _request_body(call_index: int) -> str:
+    body = responses.calls[call_index].request.body
+    if isinstance(body, bytes):
+        return body.decode()
+    if isinstance(body, str):
+        return body
+    raise AssertionError("Expected request body.")
+
+
+@responses.activate
+def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
+    credentials_file_path = tmp_path / "credentials"
+    api_root = cloud_credentials.AIRBYTE_AI_API_ROOT
+    responses.add(
+        responses.POST,
+        f"{cloud_credentials.KEYCLOAK_BASE_URL}/protocol/openid-connect/token",
+        json={"access_token": "keycloak-access-token"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{api_root}/internal/account/enrollment-status",
+        json={"is_enrolled": True, "organization_id": "initial-org-id"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{api_root}/internal/account/organizations",
+        json={
+            "organizations": [
+                {"id": "selected-org-id", "organization_name": "Selected Org"}
+            ]
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{api_root}/internal/account/applications",
+        json={"client_id": "airbyte-client-id", "client_secret": "airbyte-client-secret"},
+        status=200,
+    )
+
+    result = cloud_credentials.login_with_browser(
+        credentials_file_path=credentials_file_path,
+        open_url=_simulate_keycloak_redirect,
+        timeout_seconds=5,
+    )
+
+    saved_credentials = yaml.safe_load(
+        credentials_file_path.read_text(encoding="utf-8")
+    )
+    assert result.credentials_file_path == credentials_file_path
+    assert result.airbyte_api_root == api_root
+    assert result.organization_id == "selected-org-id"
+    assert saved_credentials == {
+        "airbyte_api_root": api_root,
+        "client_id": "airbyte-client-id",
+        "client_secret": "airbyte-client-secret",
+        "config_api_root": cloud_credentials.CLOUD_CONFIG_API_ROOT,
+        "organization_id": "selected-org-id",
+    }
+    token_request = parse_qs(_request_body(0))
+    assert token_request["client_id"] == [cloud_credentials.KEYCLOAK_CLIENT_ID]
+    assert token_request["grant_type"] == ["authorization_code"]
+    assert token_request["code"] == ["test-auth-code"]
+    assert "code_verifier" in token_request
+    assert responses.calls[2].request.headers["X-Organization-Id"] == "initial-org-id"
+    assert responses.calls[3].request.headers["X-Organization-Id"] == "selected-org-id"
+
+
+@responses.activate
+def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
+    credentials_file_path = tmp_path / "credentials"
+    api_root = cloud_credentials.AIRBYTE_AI_API_ROOT
+    responses.add(
+        responses.POST,
+        f"{cloud_credentials.KEYCLOAK_BASE_URL}/protocol/openid-connect/token",
+        json={"access_token": "keycloak-access-token"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{api_root}/internal/account/enrollment-status",
+        json={"is_enrolled": True, "organization_id": "initial-org-id"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{api_root}/internal/account/applications",
+        json={"client_id": "airbyte-client-id", "client_secret": "airbyte-client-secret"},
+        status=200,
+    )
+
+    result = cloud_credentials.login_with_browser(
+        organization_id="override-org-id",
+        credentials_file_path=credentials_file_path,
+        open_url=_simulate_keycloak_redirect,
+        timeout_seconds=5,
+    )
+
+    assert result.organization_id == "override-org-id"
+    assert len(responses.calls) == 3
+    assert responses.calls[2].request.headers["X-Organization-Id"] == "override-org-id"
+
+
+def test_login_without_client_credentials_raises_client_credentials_error() -> None:
+    with pytest.raises(PyAirbyteInputError, match="Client ID and client secret"):
         cloud_credentials.login_with_client_credentials()
 
 

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -171,6 +171,12 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
         status=200,
     )
     responses.add(
+        responses.POST,
+        f"{api_root}/internal/auth/exchange",
+        json={"access_token": "fast-token", "organization_id": "initial-org-id"},
+        status=200,
+    )
+    responses.add(
         responses.GET,
         f"{api_root}/internal/account/enrollment-status",
         json={"is_enrolled": True, "organization_id": "initial-org-id"},
@@ -183,6 +189,15 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
             "organizations": [
                 {"id": "selected-org-id", "organization_name": "Selected Org"}
             ]
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{api_root}/internal/auth/exchange",
+        json={
+            "access_token": "selected-fast-token",
+            "organization_id": "selected-org-id",
         },
         status=200,
     )
@@ -228,8 +243,22 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
     assert "code_verifier" in token_request
     assert token_headers["Content-Type"] == "application/x-www-form-urlencoded"
     assert token_headers["User-Agent"] == cloud_credentials.PYAIRBYTE_USER_AGENT
-    assert responses.calls[2].request.headers["X-Organization-Id"] == "initial-org-id"
-    assert responses.calls[3].request.headers["X-Organization-Id"] == "selected-org-id"
+    assert (
+        responses.calls[1].request.headers["Authorization"]
+        == "Bearer keycloak-access-token"
+    )
+    assert responses.calls[2].request.headers["Authorization"] == "Bearer fast-token"
+    assert responses.calls[3].request.headers["X-Organization-Id"] == "initial-org-id"
+    assert (
+        responses.calls[4].request.headers["Authorization"]
+        == "Bearer keycloak-access-token"
+    )
+    assert responses.calls[4].request.headers["X-Organization-Id"] == "selected-org-id"
+    assert (
+        responses.calls[5].request.headers["Authorization"]
+        == "Bearer selected-fast-token"
+    )
+    assert responses.calls[5].request.headers["X-Organization-Id"] == "selected-org-id"
 
 
 @responses.activate
@@ -262,9 +291,15 @@ def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
         status=200,
     )
     responses.add(
+        responses.POST,
+        f"{api_root}/internal/auth/exchange",
+        json={"access_token": "fast-token", "organization_id": "override-org-id"},
+        status=200,
+    )
+    responses.add(
         responses.GET,
         f"{api_root}/internal/account/enrollment-status",
-        json={"is_enrolled": True, "organization_id": "initial-org-id"},
+        json={"is_enrolled": True, "organization_id": "override-org-id"},
         status=200,
     )
     responses.add(
@@ -285,8 +320,10 @@ def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
     )
 
     assert result.organization_id == "override-org-id"
-    assert len(responses.calls) == 3
-    assert responses.calls[2].request.headers["X-Organization-Id"] == "override-org-id"
+    assert len(responses.calls) == 4
+    assert responses.calls[1].request.headers["X-Organization-Id"] == "override-org-id"
+    assert responses.calls[3].request.headers["Authorization"] == "Bearer fast-token"
+    assert responses.calls[3].request.headers["X-Organization-Id"] == "override-org-id"
 
 
 def test_login_without_client_credentials_raises_client_credentials_error() -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -171,12 +171,6 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
         status=200,
     )
     responses.add(
-        responses.POST,
-        f"{api_root}/internal/auth/exchange",
-        json={"access_token": "fast-token", "organization_id": "initial-org-id"},
-        status=200,
-    )
-    responses.add(
         responses.GET,
         f"{api_root}/internal/account/enrollment-status",
         json={"is_enrolled": True, "organization_id": "initial-org-id"},
@@ -189,15 +183,6 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
             "organizations": [
                 {"id": "selected-org-id", "organization_name": "Selected Org"}
             ]
-        },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        f"{api_root}/internal/auth/exchange",
-        json={
-            "access_token": "selected-fast-token",
-            "organization_id": "selected-org-id",
         },
         status=200,
     )
@@ -247,18 +232,16 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
         responses.calls[1].request.headers["Authorization"]
         == "Bearer keycloak-access-token"
     )
-    assert responses.calls[2].request.headers["Authorization"] == "Bearer fast-token"
-    assert responses.calls[3].request.headers["X-Organization-Id"] == "initial-org-id"
     assert (
-        responses.calls[4].request.headers["Authorization"]
+        responses.calls[2].request.headers["Authorization"]
         == "Bearer keycloak-access-token"
     )
-    assert responses.calls[4].request.headers["X-Organization-Id"] == "selected-org-id"
+    assert responses.calls[2].request.headers["X-Organization-Id"] == "initial-org-id"
     assert (
-        responses.calls[5].request.headers["Authorization"]
-        == "Bearer selected-fast-token"
+        responses.calls[3].request.headers["Authorization"]
+        == "Bearer keycloak-access-token"
     )
-    assert responses.calls[5].request.headers["X-Organization-Id"] == "selected-org-id"
+    assert responses.calls[3].request.headers["X-Organization-Id"] == "selected-org-id"
 
 
 @responses.activate
@@ -291,15 +274,9 @@ def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
         status=200,
     )
     responses.add(
-        responses.POST,
-        f"{api_root}/internal/auth/exchange",
-        json={"access_token": "fast-token", "organization_id": "override-org-id"},
-        status=200,
-    )
-    responses.add(
         responses.GET,
         f"{api_root}/internal/account/enrollment-status",
-        json={"is_enrolled": True, "organization_id": "override-org-id"},
+        json={"is_enrolled": True, "organization_id": "initial-org-id"},
         status=200,
     )
     responses.add(
@@ -320,10 +297,13 @@ def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
     )
 
     assert result.organization_id == "override-org-id"
-    assert len(responses.calls) == 4
-    assert responses.calls[1].request.headers["X-Organization-Id"] == "override-org-id"
-    assert responses.calls[3].request.headers["Authorization"] == "Bearer fast-token"
-    assert responses.calls[3].request.headers["X-Organization-Id"] == "override-org-id"
+    assert len(responses.calls) == 3
+    assert "X-Organization-Id" not in responses.calls[1].request.headers
+    assert (
+        responses.calls[2].request.headers["Authorization"]
+        == "Bearer keycloak-access-token"
+    )
+    assert responses.calls[2].request.headers["X-Organization-Id"] == "override-org-id"
 
 
 def test_login_without_client_credentials_raises_client_credentials_error() -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -11,7 +11,7 @@ import pytest
 import responses
 
 from airbyte.cloud import credentials as cloud_credentials
-from airbyte.exceptions import PyAirbyteInputError
+from airbyte.exceptions import AirbyteError, PyAirbyteInputError
 from airbyte.secrets.base import SecretString
 
 
@@ -221,12 +221,34 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
         "version_check_enabled": False,
     }
     token_request = parse_qs(_request_body(0))
+    token_headers = responses.calls[0].request.headers
     assert token_request["client_id"] == [cloud_credentials.KEYCLOAK_CLIENT_ID]
     assert token_request["grant_type"] == ["authorization_code"]
     assert token_request["code"] == ["test-auth-code"]
     assert "code_verifier" in token_request
+    assert token_headers["Content-Type"] == "application/x-www-form-urlencoded"
+    assert token_headers["User-Agent"] == cloud_credentials.PYAIRBYTE_USER_AGENT
     assert responses.calls[2].request.headers["X-Organization-Id"] == "initial-org-id"
     assert responses.calls[3].request.headers["X-Organization-Id"] == "selected-org-id"
+
+
+@responses.activate
+def test_login_with_browser_token_exchange_non_json_error(tmp_path: Path) -> None:
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
+    responses.add(
+        responses.POST,
+        f"{cloud_credentials.KEYCLOAK_BASE_URL}/protocol/openid-connect/token",
+        body="<!doctype html><title>403</title>",
+        content_type="text/html; charset=UTF-8",
+        status=403,
+    )
+
+    with pytest.raises(AirbyteError, match="Keycloak token exchange failed"):
+        cloud_credentials.login_with_browser(
+            credentials_file_path=credentials_file_path,
+            open_url=_simulate_keycloak_redirect,
+            timeout_seconds=5,
+        )
 
 
 @responses.activate

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -255,12 +255,57 @@ def test_login_with_browser_token_exchange_non_json_error(tmp_path: Path) -> Non
         status=403,
     )
 
-    with pytest.raises(AirbyteError, match="Keycloak token exchange failed"):
+    with pytest.raises(
+        AirbyteError, match="Keycloak token exchange failed"
+    ) as exc_info:
         cloud_credentials.login_with_browser(
             credentials_file_path=credentials_file_path,
             open_url=_simulate_keycloak_redirect,
             timeout_seconds=5,
         )
+
+    assert exc_info.value.context == {
+        "status_code": 403,
+        "content_type": "text/html; charset=UTF-8",
+        "response_body": "<!doctype html><title>403</title>",
+    }
+
+
+@responses.activate
+def test_login_with_browser_bootstrap_error_includes_response_detail(
+    tmp_path: Path,
+) -> None:
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
+    api_root = cloud_credentials.AIRBYTE_AI_API_ROOT
+    responses.add(
+        responses.POST,
+        f"{cloud_credentials.KEYCLOAK_BASE_URL}/protocol/openid-connect/token",
+        json={"access_token": "keycloak-access-token"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{api_root}/internal/account/enrollment-status",
+        json={"detail": "Not authenticated"},
+        status=401,
+    )
+
+    with pytest.raises(
+        AirbyteError,
+        match="Airbyte Cloud enrollment-status request failed",
+    ) as exc_info:
+        cloud_credentials.login_with_browser(
+            credentials_file_path=credentials_file_path,
+            open_url=_simulate_keycloak_redirect,
+            timeout_seconds=5,
+        )
+
+    assert exc_info.value.context == {
+        "status_code": 401,
+        "url": f"{api_root}/internal/account/enrollment-status",
+        "content_type": "application/json",
+        "detail": "Not authenticated",
+    }
 
 
 @responses.activate

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
 from urllib.parse import parse_qs, urlparse
@@ -8,18 +9,44 @@ from urllib.request import urlopen
 
 import pytest
 import responses
-import yaml
 
 from airbyte.cloud import credentials as cloud_credentials
 from airbyte.exceptions import PyAirbyteInputError
 from airbyte.secrets.base import SecretString
 
 
-def test_login_with_client_credentials_writes_bearer_token(
+def _read_saved_settings(credentials_file_path: Path) -> dict[str, object]:
+    parsed = json.loads(credentials_file_path.read_text(encoding="utf-8"))
+    settings = parsed["settings"]
+    assert isinstance(settings, dict)
+    return settings
+
+
+def _clear_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var in (
+        cloud_credentials.BEARER_TOKEN_ENV_VAR,
+        cloud_credentials.CLOUD_BEARER_TOKEN_ENV_VAR,
+        cloud_credentials.CLIENT_ID_ENV_VAR,
+        cloud_credentials.CLOUD_CLIENT_ID_ENV_VAR,
+        cloud_credentials.CLIENT_SECRET_ENV_VAR,
+        cloud_credentials.CLOUD_CLIENT_SECRET_ENV_VAR,
+        cloud_credentials.PUBLIC_API_ROOT_ENV_VAR,
+        cloud_credentials.CLOUD_API_ROOT_ENV_VAR,
+        cloud_credentials.CONFIG_API_ROOT_ENV_VAR,
+        cloud_credentials.CLOUD_CONFIG_API_ROOT_ENV_VAR,
+        cloud_credentials.WORKSPACE_ID_ENV_VAR,
+        cloud_credentials.CLOUD_WORKSPACE_ID_ENV_VAR,
+        cloud_credentials.ORGANIZATION_ID_ENV_VAR,
+        cloud_credentials.CLOUD_ORGANIZATION_ID_ENV_VAR,
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_login_with_client_credentials_writes_shared_settings(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    credentials_file_path = tmp_path / "credentials"
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
 
     def fake_get_bearer_token(
         *,
@@ -37,24 +64,61 @@ def test_login_with_client_credentials_writes_bearer_token(
     result = cloud_credentials.login_with_client_credentials(
         client_id="test-client-id",
         client_secret="test-client-secret",
+        organization_id="test-org-id",
         airbyte_api_root="https://api.example.com/v1",
         config_api_root="https://config.example.com/api/v1",
         credentials_file_path=credentials_file_path,
     )
 
-    saved_credentials = yaml.safe_load(
-        credentials_file_path.read_text(encoding="utf-8")
-    )
+    saved_settings = _read_saved_settings(credentials_file_path)
     assert result.credentials_file_path == credentials_file_path
     assert result.airbyte_api_root == "https://api.example.com/v1"
     assert result.config_api_root == "https://config.example.com/api/v1"
-    assert saved_credentials == {
+    assert result.organization_id == "test-org-id"
+    assert saved_settings == {
+        "credentials": {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+        },
+        "organization_id": "test-org-id",
         "airbyte_api_root": "https://api.example.com/v1",
-        "bearer_token": "test-bearer-token",
         "config_api_root": "https://config.example.com/api/v1",
+        "workspace": "default",
+        "telemetry_enabled": True,
+        "version_check_enabled": True,
     }
     if sys.platform != "win32":
         assert credentials_file_path.stat().st_mode & 0o777 == 0o600
+        assert credentials_file_path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_resolve_cloud_credentials_reads_shared_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_cloud_env(monkeypatch)
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
+    credentials_file_path.parent.mkdir()
+    credentials_file_path.write_text(
+        json.dumps({
+            "settings": {
+                "credentials": {
+                    "client_id": "file-client-id",
+                    "client_secret": "file-client-secret",
+                },
+                "organization_id": "file-org-id",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    credentials = cloud_credentials.resolve_cloud_credentials(
+        credentials_file_path=credentials_file_path,
+    )
+
+    assert str(credentials.client_id) == "file-client-id"
+    assert str(credentials.client_secret) == "file-client-secret"
+    assert credentials.organization_id == "file-org-id"
 
 
 def _simulate_keycloak_redirect(url: str) -> bool:
@@ -62,7 +126,9 @@ def _simulate_keycloak_redirect(url: str) -> bool:
     query = parse_qs(parsed_url.query)
     redirect_uri = query["redirect_uri"][0]
     state = query["state"][0]
-    with urlopen(f"{redirect_uri}?code=test-auth-code&state={state}", timeout=5) as response:
+    with urlopen(
+        f"{redirect_uri}?code=test-auth-code&state={state}", timeout=5
+    ) as response:
         assert response.status == 200
     return True
 
@@ -78,7 +144,25 @@ def _request_body(call_index: int) -> str:
 
 @responses.activate
 def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
-    credentials_file_path = tmp_path / "credentials"
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
+    credentials_file_path.parent.mkdir()
+    credentials_file_path.write_text(
+        json.dumps({
+            "settings": {
+                "credentials": {
+                    "client_id": "previous-client-id",
+                    "client_secret": "previous-client-secret",
+                },
+                "organization_id": "previous-org-id",
+                "workspace": "Existing Workspace",
+                "allow_destructive": True,
+                "telemetry_enabled": False,
+                "is_internal_user": True,
+                "version_check_enabled": False,
+            }
+        }),
+        encoding="utf-8",
+    )
     api_root = cloud_credentials.AIRBYTE_AI_API_ROOT
     responses.add(
         responses.POST,
@@ -105,7 +189,10 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
     responses.add(
         responses.POST,
         f"{api_root}/internal/account/applications",
-        json={"client_id": "airbyte-client-id", "client_secret": "airbyte-client-secret"},
+        json={
+            "client_id": "airbyte-client-id",
+            "client_secret": "airbyte-client-secret",
+        },
         status=200,
     )
 
@@ -115,18 +202,23 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
         timeout_seconds=5,
     )
 
-    saved_credentials = yaml.safe_load(
-        credentials_file_path.read_text(encoding="utf-8")
-    )
+    saved_settings = _read_saved_settings(credentials_file_path)
     assert result.credentials_file_path == credentials_file_path
     assert result.airbyte_api_root == api_root
     assert result.organization_id == "selected-org-id"
-    assert saved_credentials == {
-        "airbyte_api_root": api_root,
-        "client_id": "airbyte-client-id",
-        "client_secret": "airbyte-client-secret",
-        "config_api_root": cloud_credentials.CLOUD_CONFIG_API_ROOT,
+    assert saved_settings == {
+        "credentials": {
+            "client_id": "airbyte-client-id",
+            "client_secret": "airbyte-client-secret",
+        },
         "organization_id": "selected-org-id",
+        "airbyte_api_root": api_root,
+        "config_api_root": cloud_credentials.CLOUD_CONFIG_API_ROOT,
+        "workspace": "Existing Workspace",
+        "allow_destructive": True,
+        "telemetry_enabled": False,
+        "is_internal_user": True,
+        "version_check_enabled": False,
     }
     token_request = parse_qs(_request_body(0))
     assert token_request["client_id"] == [cloud_credentials.KEYCLOAK_CLIENT_ID]
@@ -139,7 +231,7 @@ def test_login_with_browser_bootstraps_credentials(tmp_path: Path) -> None:
 
 @responses.activate
 def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
-    credentials_file_path = tmp_path / "credentials"
+    credentials_file_path = tmp_path / ".airbyte-cli" / "settings.json"
     api_root = cloud_credentials.AIRBYTE_AI_API_ROOT
     responses.add(
         responses.POST,
@@ -156,7 +248,10 @@ def test_login_with_browser_uses_organization_override(tmp_path: Path) -> None:
     responses.add(
         responses.POST,
         f"{api_root}/internal/account/applications",
-        json={"client_id": "airbyte-client-id", "client_secret": "airbyte-client-secret"},
+        json={
+            "client_id": "airbyte-client-id",
+            "client_secret": "airbyte-client-secret",
+        },
         status=200,
     )
 


### PR DESCRIPTION
## Summary

Adds browser-based interactive login for `airbyte cloud login` / `CloudClient.login(interactive=True)`.

This replaces the previous interactive-login stub with a PKCE OAuth flow against the Airbyte Cloud Keycloak realm. The flow exchanges the transient authorization code for a Keycloak access token, then matches the production airbyte-cli bootstrap path by using that transient token directly with the internal account bootstrap endpoints:

- `GET /internal/account/enrollment-status`
- `GET /internal/account/organizations`
- `POST /internal/account/applications`

Keycloak access and refresh tokens are not persisted.

Persisted login now uses the shared airbyte-cli settings file so PyAirbyte and airbyte-cli behave as one shared login experience:

- Reads and writes `~/.airbyte-cli/settings.json`.
- Stores Airbyte application `client_id`, `client_secret`, and `organization_id` in the airbyte-cli JSON shape.
- Preserves existing airbyte-cli settings such as `workspace`, `allow_destructive`, `telemetry_enabled`, `is_internal_user`, and `version_check_enabled`.
- Writes the settings file atomically with `0600` file permissions and `0700` directory permissions on POSIX platforms.
- Does not persist Keycloak access tokens or Keycloak refresh tokens.

Also adds:

- `--organization-id` CLI input support for choosing an org without prompting.
- `organization_id` in the login command JSON output.
- Unit tests that mock the loopback redirect, Keycloak token exchange, and Airbyte bootstrap endpoints.
- Unit coverage for reading/writing the shared airbyte-cli settings file.
- Non-interactive login persistence of Airbyte client credentials into the shared settings file after validating the credentials can mint a bearer token.
- Safer auth/bootstrap error context so failed login responses include status, URL, content type, and server-provided error details when available.
- A small constructor fix so `CloudWorkspace(...)` enforces keyword-only arguments when using its custom initializer.

## Install & Test This Branch

Install the branch into a uv-managed tool environment for manual testing:

```bash
uv tool install \
  --python-preference only-managed \
  --from 'git+https://github.com/airbytehq/PyAirbyte.git@devin/1779151296-interactive-cloud-login' \
  airbyte
```

Then verify the Cloud login flows:

```bash
airbyte-cloud login
airbyte-cloud logout

airbyte-cloud login \
  --client-id ... \
  --client-secret ...

airbyte-cloud login \
  --public-api-root ... \
  --config-api-root ... \
  --client-id ... \
  --client-secret ...
```

## Review & Testing Checklist for Human

- [ ] Test real `airbyte-cloud login` in a browser with a normal Cloud user, including a user with multiple organizations.
- [ ] Confirm the shared `~/.airbyte-cli/settings.json` shape and preserved fields are compatible with airbyte-cli expectations, including cross-CLI reuse.
- [ ] Verify the Keycloak PKCE parameters, callback URL, direct account bootstrap endpoints, and request headers match current production expectations.
- [ ] Test that non-interactive login still works with `--client-id`, `--client-secret`, `--public-api-root`, and `--config-api-root` for Cloud and self-managed flows.

### Notes

Local validation was run after the shared settings-file update, keyword-only constructor fix, Keycloak token request header fix, direct-bootstrap alignment with airbyte-cli, and auth/bootstrap error-detail update:

- `uv run pytest tests/unit_tests/test_cloud_api_roots.py::test_cloud_workspace_constructor_requires_keyword_arguments`
- `uv run pytest tests/unit_tests/test_cloud_api_roots.py tests/unit_tests/test_cloud_credentials.py`
- `uv run pytest tests/unit_tests/test_cloud_credentials.py`
- `uv run ruff check airbyte/cloud airbyte/cli airbyte/mcp`
- `uv run ruff check airbyte/cloud/credentials.py tests/unit_tests/test_cloud_credentials.py`
- `uv run ruff format --check airbyte/cloud/credentials.py tests/unit_tests/test_cloud_credentials.py`
- `uv run pyrefly check`
- `uv run poe docs-generate`
- `uv run airbyte-cloud login --help`
- `uv run airbyte-cloud logout --help`

Real browser login was not completed end-to-end in this session; the new coverage uses mocked loopback, Keycloak, and bootstrap endpoints. AJ’s local retries confirmed the previous Keycloak 403 was bypassed, then exposed production 401s from Sonar bootstrap/token-exchange paths. The latest revision removes the `/internal/auth/exchange` step because airbyte-cli does not use it and production rejected it for this flow, and adds response-detail surfacing to make future real-login failures easier to diagnose.

Link to Devin session: https://app.devin.ai/sessions/c342a0f82dc1427391956983258547cf
Requested by: @aaronsteers