### PR TITLE
feat(cli): add reusable JSON input wrapper

### DIFF
--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -112,7 +112,7 @@ def parse_json_input_options(
     if not json_input and not json_file:
         return {}
 
-    if json_input and json_input[0] in {"@", ".", "/"}:
+    if json_input and (json_input[0] in {"@", ".", "/"} or Path(json_input).is_absolute()):
         json_file = Path(json_input.removeprefix("@"))
         json_input = None
 

--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -6,9 +6,21 @@ from __future__ import annotations
 import functools
 import inspect
 import json
+import types
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, ParamSpec, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    ParamSpec,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+)
 
+import typing_extensions
 import yaml
 from cyclopts import Parameter
 
@@ -148,6 +160,49 @@ def _json_string_values_match(named_value: object, json_value: object) -> bool:
         return False
 
 
+def _annotation_allows_none(annotation: object) -> bool:
+    """Return `True` when an annotation accepts `None`."""
+    if annotation is inspect.Parameter.empty:
+        return False
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        annotation = get_args(annotation)[0]
+        origin = get_origin(annotation)
+    return annotation is None or (
+        (origin is types.UnionType or str(origin) == "typing.Union")
+        and type(None) in get_args(annotation)
+    )
+
+
+def _make_annotation_optional(annotation: object) -> object:
+    """Return an annotation that accepts `None`."""
+    if annotation is inspect.Parameter.empty:
+        return annotation
+    if _annotation_allows_none(annotation):
+        return annotation
+    typed_annotation = cast("type[object]", annotation)
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        inner_annotation, *metadata = get_args(annotation)
+        return _make_annotated_optional(cast("type[object]", inner_annotation), metadata)
+    return typed_annotation | None
+
+
+def _make_annotated_optional(
+    inner_annotation: type[object],
+    metadata: list[object],
+) -> object:
+    """Return an `Annotated` annotation that accepts `None`."""
+    return typing_extensions.Annotated[(inner_annotation | None, *metadata)]
+
+
+def _is_default_cli_value(value: object, parameter: inspect.Parameter) -> bool:
+    """Return `True` when a CLI value matches the wrapped command default."""
+    if parameter.default is inspect.Parameter.empty:
+        return value is None
+    return value == parameter.default
+
+
 def resolve_json_input(
     json_values: dict[str, object],
     named_values: dict[str, object],
@@ -219,6 +274,7 @@ def with_json_input(
     def decorate(command: Callable[_P, _R]) -> Callable[_P, _R]:
         """Decorate a command with JSON input support."""
         signature = inspect.signature(command)
+        resolved_annotations = get_type_hints(command, include_extras=True)
 
         @functools.wraps(command)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
@@ -239,7 +295,11 @@ def with_json_input(
                     continue
                 if parameter.default is inspect.Parameter.empty:
                     required_fields.add(name)
-                named_values[name] = kwargs.get(name, _MISSING)
+                named_value = kwargs.get(name, _MISSING)
+                if named_value is _MISSING or _is_default_cli_value(named_value, parameter):
+                    named_values[name] = _MISSING
+                else:
+                    named_values[name] = named_value
 
             resolved_values = resolve_json_input(
                 json_values,
@@ -252,12 +312,17 @@ def with_json_input(
 
         parameters = []
         for parameter in signature.parameters.values():
-            resolved_parameter = parameter
+            resolved_parameter = parameter.replace(
+                annotation=resolved_annotations.get(parameter.name, parameter.annotation)
+            )
             if (
                 parameter.kind is inspect.Parameter.KEYWORD_ONLY
                 and parameter.default is inspect.Parameter.empty
             ):
-                resolved_parameter = parameter.replace(default=None)
+                resolved_parameter = resolved_parameter.replace(
+                    annotation=_make_annotation_optional(resolved_parameter.annotation),
+                    default=None,
+                )
             parameters.append(resolved_parameter)
 
         parameters.extend(
@@ -277,6 +342,9 @@ def with_json_input(
             ]
         )
         wrapper.__signature__ = signature.replace(parameters=parameters)  # type: ignore[attr-defined]
+        wrapper.__annotations__ = {parameter.name: parameter.annotation for parameter in parameters}
+        if hasattr(wrapper, "__wrapped__"):
+            delattr(wrapper, "__wrapped__")
         return wrapper  # type: ignore[return-value]
 
     if command is None:

--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -262,11 +262,11 @@ def resolve_json_input(
 
 
 @overload
-def with_json_input(command: Callable[_P, _R]) -> Callable[_P, _R]: ...
+def wrapped_cli(command: Callable[_P, _R]) -> Callable[_P, _R]: ...
 
 
 @overload
-def with_json_input(
+def wrapped_cli(
     *,
     comma_list_fields: set[str] | None = None,
     field_aliases: Mapping[str, str] | None = None,
@@ -274,7 +274,7 @@ def with_json_input(
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
-def with_json_input(
+def wrapped_cli(
     command: Callable[_P, _R] | None = None,
     *,
     comma_list_fields: set[str] | None = None,

--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -81,7 +81,7 @@ JsonInputArg = Annotated[
     str | None,
     Parameter(
         name="--json",
-        help="Inline JSON object containing command input values.",
+        help="Inline JSON object, or file path prefixed with @, ., or /.",
     ),
 ]
 JsonFileInputArg = Annotated[
@@ -112,9 +112,16 @@ def parse_json_input_options(
     if not json_input and not json_file:
         return {}
 
+    if json_input and json_input[0] in {"@", ".", "/"}:
+        json_file = Path(json_input.removeprefix("@"))
+        json_input = None
+
     if json_file:
-        if not json_file.exists():
-            raise PyAirbyteInputError(message="JSON input file does not exist.")
+        if not json_file.is_file():
+            raise PyAirbyteInputError(
+                message="JSON input file does not exist.",
+                context={"path": str(json_file)},
+            )
         json_input = json_file.read_text(encoding="utf-8")
 
     if not json_input:

--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -112,9 +112,17 @@ def parse_json_input_options(
     if not json_input and not json_file:
         return {}
 
-    if json_input and (json_input[0] in {"@", ".", "/"} or Path(json_input).is_absolute()):
-        json_file = Path(json_input.removeprefix("@"))
-        json_input = None
+    if json_input:
+        stripped_json_input = json_input.lstrip()
+        if (
+            stripped_json_input
+            and stripped_json_input[0] not in {"{", "["}
+            and (
+                stripped_json_input[0] in {"@", ".", "/"} or Path(stripped_json_input).is_absolute()
+            )
+        ):
+            json_file = Path(stripped_json_input.removeprefix("@"))
+            json_input = None
 
     if json_file:
         if not json_file.is_file():

--- a/airbyte/cli/_input.py
+++ b/airbyte/cli/_input.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import functools
+import inspect
 import json
-from typing import TYPE_CHECKING, Annotated
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, ParamSpec, TypeVar, overload
 
 import yaml
 from cyclopts import Parameter
@@ -13,7 +16,7 @@ from airbyte.exceptions import PyAirbyteInputError
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Callable, Mapping
 
 
 WorkspaceIdArg = Annotated[
@@ -61,6 +64,224 @@ DestinationIdArg = Annotated[
 ]
 JobIdArg = Annotated[int | None, Parameter(name="--job-id", help="The job ID.")]
 PositionalIdArg = Annotated[str, Parameter(show=False, consume_multiple=True)]
+
+JsonInputArg = Annotated[
+    str | None,
+    Parameter(
+        name="--json",
+        help="Inline JSON object containing command input values.",
+    ),
+]
+JsonFileInputArg = Annotated[
+    Path | None,
+    Parameter(
+        name="--json-file",
+        help="Path to a JSON file containing command input values.",
+    ),
+]
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_MISSING = object()
+
+
+def parse_json_input_options(
+    *,
+    json_input: str | None = None,
+    json_file: Path | None = None,
+) -> dict[str, object]:
+    """Parse command input from an inline JSON object or JSON file."""
+    if json_input and json_file:
+        raise PyAirbyteInputError(
+            message="Only one JSON input source is allowed.",
+            context={"options": "--json, --json-file"},
+        )
+    if not json_input and not json_file:
+        return {}
+
+    if json_file:
+        if not json_file.exists():
+            raise PyAirbyteInputError(message="JSON input file does not exist.")
+        json_input = json_file.read_text(encoding="utf-8")
+
+    if not json_input:
+        return {}
+    parsed_json = json.loads(json_input)
+    if not isinstance(parsed_json, dict):
+        raise PyAirbyteInputError(message="JSON input must be an object.")
+    return parsed_json
+
+
+def _normalize_json_input_fields(
+    json_values: dict[str, object],
+    *,
+    field_aliases: Mapping[str, str],
+    comma_list_fields: set[str],
+    json_string_fields: set[str],
+) -> dict[str, object]:
+    """Normalize JSON input field names and values for command parameters."""
+    resolved = {}
+    for input_key, input_value in json_values.items():
+        field_name = field_aliases.get(input_key, input_key)
+        value = input_value
+        if field_name in comma_list_fields and isinstance(input_value, list):
+            value = ",".join(str(item) for item in input_value)
+        elif field_name in json_string_fields and not isinstance(input_value, str):
+            value = json.dumps(input_value, sort_keys=True)
+        if field_name in resolved and resolved[field_name] != value:
+            raise PyAirbyteInputError(
+                message="JSON input field values conflict.",
+                context={"field": field_name},
+            )
+        resolved[field_name] = value
+    return resolved
+
+
+def _json_string_values_match(named_value: object, json_value: object) -> bool:
+    """Return `True` when JSON string field values are semantically equal."""
+    if not isinstance(named_value, str) or not isinstance(json_value, str):
+        return False
+    try:
+        return json.loads(named_value) == json.loads(json_value)
+    except json.JSONDecodeError:
+        return False
+
+
+def resolve_json_input(
+    json_values: dict[str, object],
+    named_values: dict[str, object],
+    *,
+    required_fields: set[str],
+    json_string_fields: set[str] | None = None,
+) -> dict[str, object]:
+    """Merge JSON command input with named CLI values."""
+    json_string_fields = json_string_fields or set()
+    resolved = {}
+    for key, json_value in json_values.items():
+        if key not in named_values:
+            raise PyAirbyteInputError(
+                message="JSON input field is not supported.",
+                context={"field": key},
+            )
+
+        named_value = named_values[key]
+        if named_value is _MISSING:
+            resolved[key] = json_value
+            continue
+        if named_value == json_value:
+            continue
+        if key in json_string_fields and _json_string_values_match(named_value, json_value):
+            continue
+        raise PyAirbyteInputError(
+            message="JSON input value conflicts with named CLI argument.",
+            context={"field": key},
+        )
+
+    missing_fields = sorted(
+        field
+        for field in required_fields
+        if named_values.get(field) is _MISSING and field not in json_values
+    )
+    if missing_fields:
+        raise PyAirbyteInputError(
+            message="Required command input is missing.",
+            context={"fields": ", ".join(missing_fields)},
+        )
+    return resolved
+
+
+@overload
+def with_json_input(command: Callable[_P, _R]) -> Callable[_P, _R]: ...
+
+
+@overload
+def with_json_input(
+    *,
+    comma_list_fields: set[str] | None = None,
+    field_aliases: Mapping[str, str] | None = None,
+    json_string_fields: set[str] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
+
+
+def with_json_input(
+    command: Callable[_P, _R] | None = None,
+    *,
+    comma_list_fields: set[str] | None = None,
+    field_aliases: Mapping[str, str] | None = None,
+    json_string_fields: set[str] | None = None,
+) -> Callable[_P, _R] | Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """Allow a Cyclopts command to accept `--json` or `--json-file` input."""
+    comma_list_fields = comma_list_fields or set()
+    field_aliases = field_aliases or {}
+    json_string_fields = json_string_fields or set()
+
+    def decorate(command: Callable[_P, _R]) -> Callable[_P, _R]:
+        """Decorate a command with JSON input support."""
+        signature = inspect.signature(command)
+
+        @functools.wraps(command)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            json_values = parse_json_input_options(
+                json_input=kwargs.pop("json_input", None),  # pyrefly: ignore[bad-argument-type]
+                json_file=kwargs.pop("json_file", None),  # pyrefly: ignore[bad-argument-type]
+            )
+            json_values = _normalize_json_input_fields(
+                json_values,
+                comma_list_fields=comma_list_fields,
+                field_aliases=field_aliases,
+                json_string_fields=json_string_fields,
+            )
+            named_values = {}
+            required_fields = set()
+            for name, parameter in signature.parameters.items():
+                if parameter.kind is not inspect.Parameter.KEYWORD_ONLY:
+                    continue
+                if parameter.default is inspect.Parameter.empty:
+                    required_fields.add(name)
+                named_values[name] = kwargs.get(name, _MISSING)
+
+            resolved_values = resolve_json_input(
+                json_values,
+                named_values,
+                required_fields=required_fields,
+                json_string_fields=json_string_fields,
+            )
+            kwargs.update(resolved_values)
+            return command(*args, **kwargs)
+
+        parameters = []
+        for parameter in signature.parameters.values():
+            resolved_parameter = parameter
+            if (
+                parameter.kind is inspect.Parameter.KEYWORD_ONLY
+                and parameter.default is inspect.Parameter.empty
+            ):
+                resolved_parameter = parameter.replace(default=None)
+            parameters.append(resolved_parameter)
+
+        parameters.extend(
+            [
+                inspect.Parameter(
+                    "json_input",
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=JsonInputArg,
+                ),
+                inspect.Parameter(
+                    "json_file",
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=JsonFileInputArg,
+                ),
+            ]
+        )
+        wrapper.__signature__ = signature.replace(parameters=parameters)  # type: ignore[attr-defined]
+        return wrapper  # type: ignore[return-value]
+
+    if command is None:
+        return decorate
+    return decorate(command)
 
 
 def parse_config_options(

--- a/airbyte/cli/cloud/connections.py
+++ b/airbyte/cli/cloud/connections.py
@@ -24,6 +24,7 @@ from airbyte.cli._input import (
     WorkspaceIdArg,
     parse_csv,
     resolve_entity_id,
+    with_json_input,
 )
 from airbyte.cli._output import json_output
 from airbyte.cli.cloud._cli import cloud_app
@@ -80,6 +81,7 @@ def get(
 
 
 @connections_app.command
+@with_json_input(comma_list_fields={"selected_streams"})
 def create(  # noqa: PLR0913
     *,
     name: Annotated[str, Parameter(help="Display name for the connection.")],

--- a/airbyte/cli/cloud/connections.py
+++ b/airbyte/cli/cloud/connections.py
@@ -24,7 +24,7 @@ from airbyte.cli._input import (
     WorkspaceIdArg,
     parse_csv,
     resolve_entity_id,
-    with_json_input,
+    wrapped_cli,
 )
 from airbyte.cli._output import json_output
 from airbyte.cli.cloud._cli import cloud_app
@@ -81,7 +81,7 @@ def get(
 
 
 @connections_app.command
-@with_json_input(comma_list_fields={"selected_streams"})
+@wrapped_cli(comma_list_fields={"selected_streams"})
 def create(  # noqa: PLR0913
     *,
     name: Annotated[str, Parameter(help="Display name for the connection.")],

--- a/airbyte/cli/cloud/sources.py
+++ b/airbyte/cli/cloud/sources.py
@@ -25,6 +25,7 @@ from airbyte.cli._input import (
     WorkspaceIdArg,
     parse_config_options,
     resolve_entity_id,
+    with_json_input,
 )
 from airbyte.cli._output import json_output
 from airbyte.cli.cloud._cli import cloud_app
@@ -74,6 +75,7 @@ def get(
 
 
 @sources_app.command
+@with_json_input(field_aliases={"config": "config_json"}, json_string_fields={"config_json"})
 def create(
     *,
     name: Annotated[str, Parameter(help="Display name for the source.")],

--- a/airbyte/cli/cloud/sources.py
+++ b/airbyte/cli/cloud/sources.py
@@ -25,7 +25,7 @@ from airbyte.cli._input import (
     WorkspaceIdArg,
     parse_config_options,
     resolve_entity_id,
-    with_json_input,
+    wrapped_cli,
 )
 from airbyte.cli._output import json_output
 from airbyte.cli.cloud._cli import cloud_app
@@ -75,7 +75,7 @@ def get(
 
 
 @sources_app.command
-@with_json_input(field_aliases={"config": "config_json"}, json_string_fields={"config_json"})
+@wrapped_cli(field_aliases={"config": "config_json"}, json_string_fields={"config_json"})
 def create(
     *,
     name: Annotated[str, Parameter(help="Display name for the source.")],

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -333,10 +333,10 @@ class CloudOrganization:
 
     def __init__(
         self,
+        *,
         organization_id: str,
         organization_name: str | None = None,
         email: str | None = None,
-        *,
         api_root: str = api_util.CLOUD_API_ROOT,
         client_id: SecretString | None = None,
         client_secret: SecretString | None = None,
@@ -506,6 +506,7 @@ class CloudWorkspace:
 
     def __init__(
         self,
+        *,
         workspace_id: str | None = None,
         client_id: str | SecretString | None = None,
         client_secret: str | SecretString | None = None,

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -36,8 +36,14 @@ def test_parse_json_input_options(tmp_path) -> None:
     assert _input.parse_json_input_options(json_input='{"name": "inline"}') == {
         "name": "inline"
     }
+    assert _input.parse_json_input_options(json_input='  {"name": "inline"}') == {
+        "name": "inline"
+    }
     assert _input.parse_json_input_options(json_file=json_file) == {"name": "from-file"}
     assert _input.parse_json_input_options(json_input=f"@{json_file}") == {
+        "name": "from-file"
+    }
+    assert _input.parse_json_input_options(json_input=f"  @{json_file}") == {
         "name": "from-file"
     }
     assert _input.parse_json_input_options(json_input=json_file.as_posix()) == {
@@ -50,6 +56,9 @@ def test_parse_json_input_options(tmp_path) -> None:
 
     with pytest.raises(PyAirbyteInputError, match="JSON input must be an object"):
         _input.parse_json_input_options(json_input="[]")
+
+    with pytest.raises(PyAirbyteInputError, match="JSON input must be an object"):
+        _input.parse_json_input_options(json_input='  ["not-an-object"]')
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.chdir(tmp_path)

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -148,10 +148,10 @@ def test_resolve_json_input_errors(
         )
 
 
-def test_with_json_input_patches_cyclopts_signature() -> None:
-    """`with_json_input` exposes JSON options and makes required args optional."""
+def test_wrapped_cli_patches_cyclopts_signature() -> None:
+    """`wrapped_cli` exposes JSON options and makes required args optional."""
 
-    @_input.with_json_input
+    @_input.wrapped_cli
     def command(*, name: Annotated[str, Parameter(help="Name")]) -> str:
         return name
 

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -30,11 +30,19 @@ def test_parse_json_input_options(tmp_path) -> None:
     """`parse_json_input_options` parses inline JSON and JSON files."""
     json_file = tmp_path / "input.json"
     json_file.write_text('{"name": "from-file"}', encoding="utf-8")
+    relative_json_file = tmp_path / "relative.json"
+    relative_json_file.write_text('{"name": "from-relative-file"}', encoding="utf-8")
 
     assert _input.parse_json_input_options(json_input='{"name": "inline"}') == {
         "name": "inline"
     }
     assert _input.parse_json_input_options(json_file=json_file) == {"name": "from-file"}
+    assert _input.parse_json_input_options(json_input=f"@{json_file}") == {
+        "name": "from-file"
+    }
+    assert _input.parse_json_input_options(json_input=str(json_file)) == {
+        "name": "from-file"
+    }
     assert _input.parse_json_input_options() == {}
 
     with pytest.raises(PyAirbyteInputError, match="Only one JSON input source"):
@@ -42,6 +50,12 @@ def test_parse_json_input_options(tmp_path) -> None:
 
     with pytest.raises(PyAirbyteInputError, match="JSON input must be an object"):
         _input.parse_json_input_options(json_input="[]")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.chdir(tmp_path)
+        assert _input.parse_json_input_options(json_input="./relative.json") == {
+            "name": "from-relative-file"
+        }
 
 
 @pytest.mark.parametrize(
@@ -172,10 +186,22 @@ def test_connection_create_help_includes_json_options(
     assert "--json-file" in output
 
 
-def test_source_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`sources create` accepts command input from `--json`."""
+def test_source_create_accepts_json_path_input(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sources create` accepts command file input from `--json`."""
     calls = {}
     outputs = []
+    json_file = tmp_path / "source.json"
+    json_file.write_text(
+        json.dumps({
+            "name": "Test Source",
+            "source_type": "postgres",
+            "config": {"host": "localhost"},
+        }),
+        encoding="utf-8",
+    )
 
     class FakeSource:
         def get_info(self) -> dict[str, object]:
@@ -196,11 +222,7 @@ def test_source_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> No
         sources.create,
         [
             "--json",
-            json.dumps({
-                "name": "Test Source",
-                "source_type": "postgres",
-                "config": {"host": "localhost"},
-            }),
+            f"@{json_file}",
         ],
     )
 

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -129,7 +129,9 @@ def test_with_json_input_patches_cyclopts_signature() -> None:
     assert command(json_input='{"name": "json-name"}') == "json-name"  # type: ignore[call-arg]
 
 
-def test_source_create_help_includes_json_options(capsys: pytest.CaptureFixture[str]) -> None:
+def test_source_create_help_includes_json_options(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """`sources create --help` includes JSON input options."""
     app = App()
     app.command(sources.create)
@@ -143,7 +145,9 @@ def test_source_create_help_includes_json_options(capsys: pytest.CaptureFixture[
     assert "--json-file" in output
 
 
-def test_connection_create_help_includes_json_options(capsys: pytest.CaptureFixture[str]) -> None:
+def test_connection_create_help_includes_json_options(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """`connections create --help` includes JSON input options."""
     app = App()
     app.command(connections.create)

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Tests for CLI JSON input helpers."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Annotated
+
+import pytest
+from cyclopts import App, Parameter
+
+from airbyte.cli import _input
+from airbyte.cli.cloud import connections, sources
+from airbyte.exceptions import PyAirbyteInputError
+
+
+def test_parse_json_input_options(tmp_path) -> None:
+    """`parse_json_input_options` parses inline JSON and JSON files."""
+    json_file = tmp_path / "input.json"
+    json_file.write_text('{"name": "from-file"}', encoding="utf-8")
+
+    assert _input.parse_json_input_options(json_input='{"name": "inline"}') == {
+        "name": "inline"
+    }
+    assert _input.parse_json_input_options(json_file=json_file) == {"name": "from-file"}
+    assert _input.parse_json_input_options() == {}
+
+    with pytest.raises(PyAirbyteInputError, match="Only one JSON input source"):
+        _input.parse_json_input_options(json_input="{}", json_file=json_file)
+
+    with pytest.raises(PyAirbyteInputError, match="JSON input must be an object"):
+        _input.parse_json_input_options(json_input="[]")
+
+
+@pytest.mark.parametrize(
+    "json_values,named_values,required_fields,json_string_fields,expected",
+    [
+        pytest.param(
+            {"name": "json-name"},
+            {"name": _input._MISSING},  # noqa: SLF001
+            {"name"},
+            set(),
+            {"name": "json-name"},
+            id="json_supplies_required_value",
+        ),
+        pytest.param(
+            {"config_json": json.dumps({"host": "localhost"})},
+            {"config_json": '{"host":"localhost"}'},
+            set(),
+            {"config_json"},
+            {},
+            id="json_string_conflict_uses_semantic_equality",
+        ),
+    ],
+)
+def test_resolve_json_input(
+    json_values: dict[str, object],
+    named_values: dict[str, object],
+    required_fields: set[str],
+    json_string_fields: set[str],
+    expected: dict[str, object],
+) -> None:
+    """`resolve_json_input` merges JSON values into named CLI values."""
+    assert (
+        _input.resolve_json_input(
+            json_values,
+            named_values,
+            required_fields=required_fields,
+            json_string_fields=json_string_fields,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "json_values,named_values,required_fields,match",
+    [
+        pytest.param(
+            {"extra": "value"},
+            {"name": _input._MISSING},  # noqa: SLF001
+            {"name"},
+            "JSON input field is not supported",
+            id="unsupported_field",
+        ),
+        pytest.param(
+            {"name": "json-name"},
+            {"name": "named-name"},
+            {"name"},
+            "JSON input value conflicts with named CLI argument",
+            id="conflicting_named_value",
+        ),
+        pytest.param(
+            {},
+            {"name": _input._MISSING},  # noqa: SLF001
+            {"name"},
+            "Required command input is missing",
+            id="missing_required_value",
+        ),
+    ],
+)
+def test_resolve_json_input_errors(
+    json_values: dict[str, object],
+    named_values: dict[str, object],
+    required_fields: set[str],
+    match: str,
+) -> None:
+    """`resolve_json_input` rejects ambiguous or incomplete input."""
+    with pytest.raises(PyAirbyteInputError, match=match):
+        _input.resolve_json_input(
+            json_values,
+            named_values,
+            required_fields=required_fields,
+        )
+
+
+def test_with_json_input_patches_cyclopts_signature() -> None:
+    """`with_json_input` exposes JSON options and makes required args optional."""
+
+    @_input.with_json_input
+    def command(*, name: Annotated[str, Parameter(help="Name")]) -> str:
+        return name
+
+    signature = inspect.signature(command)
+
+    assert signature.parameters["name"].default is None
+    assert "json_input" in signature.parameters
+    assert "json_file" in signature.parameters
+    assert command(json_input='{"name": "json-name"}') == "json-name"  # type: ignore[call-arg]
+
+
+def test_source_create_help_includes_json_options(capsys: pytest.CaptureFixture[str]) -> None:
+    """`sources create --help` includes JSON input options."""
+    app = App()
+    app.command(sources.create)
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["create", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--json" in output
+    assert "--json-file" in output
+
+
+def test_connection_create_help_includes_json_options(capsys: pytest.CaptureFixture[str]) -> None:
+    """`connections create --help` includes JSON input options."""
+    app = App()
+    app.command(connections.create)
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["create", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--json" in output
+    assert "--json-file" in output
+
+
+def test_source_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`sources create` accepts command input from `--json`."""
+    calls = {}
+    outputs = []
+
+    class FakeSource:
+        def get_info(self) -> dict[str, object]:
+            return {"sourceId": "source-id"}
+
+    class FakeWorkspace:
+        def __init__(self, **kwargs: object) -> None:
+            calls["workspace"] = kwargs
+
+        def deploy_source(self, *, name: str, config: dict[str, object]) -> FakeSource:
+            calls["deploy_source"] = {"name": name, "config": config}
+            return FakeSource()
+
+    monkeypatch.setattr(sources, "CloudWorkspace", FakeWorkspace)
+    monkeypatch.setattr(sources, "json_output", outputs.append)
+
+    sources.create(
+        json_input=json.dumps(  # type: ignore[call-arg]
+            {
+                "name": "Test Source",
+                "source_type": "postgres",
+                "config": {"host": "localhost"},
+            }
+        )
+    )
+
+    assert calls["workspace"] == {
+        "workspace_id": None,
+        "client_id": None,
+        "client_secret": None,
+        "api_root": None,
+    }
+    assert calls["deploy_source"] == {
+        "name": "Test Source",
+        "config": {"host": "localhost", "sourceType": "postgres"},
+    }
+    assert outputs == [{"sourceId": "source-id"}]
+
+
+def test_connection_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`connections create` accepts command input from `--json`."""
+    calls = {}
+    outputs = []
+
+    class FakeConnection:
+        def get_info(self) -> dict[str, object]:
+            return {"connectionId": "connection-id"}
+
+    class FakeWorkspace:
+        def __init__(self, **kwargs: object) -> None:
+            calls["workspace"] = kwargs
+
+        def get_source(self, source_id: str) -> str:
+            calls["source_id"] = source_id
+            return f"source:{source_id}"
+
+        def get_destination(self, destination_id: str) -> str:
+            calls["destination_id"] = destination_id
+            return f"destination:{destination_id}"
+
+        def deploy_connection(
+            self,
+            *,
+            connection_name: str,
+            source: str,
+            destination: str,
+            table_prefix: str,
+            selected_streams: list[str],
+        ) -> FakeConnection:
+            calls["deploy_connection"] = {
+                "connection_name": connection_name,
+                "source": source,
+                "destination": destination,
+                "table_prefix": table_prefix,
+                "selected_streams": selected_streams,
+            }
+            return FakeConnection()
+
+    monkeypatch.setattr(connections, "CloudWorkspace", FakeWorkspace)
+    monkeypatch.setattr(connections, "json_output", outputs.append)
+
+    connections.create(
+        json_input=json.dumps(  # type: ignore[call-arg]
+            {
+                "name": "Test Connection",
+                "source_id": "source-id",
+                "destination_id": "destination-id",
+                "prefix": "raw_",
+                "selected_streams": ["users", "orders"],
+            }
+        )
+    )
+
+    assert calls["workspace"] == {
+        "workspace_id": None,
+        "client_id": None,
+        "client_secret": None,
+        "api_root": None,
+    }
+    assert calls["source_id"] == "source-id"
+    assert calls["destination_id"] == "destination-id"
+    assert calls["deploy_connection"] == {
+        "connection_name": "Test Connection",
+        "source": "source:source-id",
+        "destination": "destination:destination-id",
+        "table_prefix": "raw_",
+        "selected_streams": ["users", "orders"],
+    }
+    assert outputs == [{"connectionId": "connection-id"}]

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -15,6 +15,17 @@ from airbyte.cli.cloud import connections, sources
 from airbyte.exceptions import PyAirbyteInputError
 
 
+def _invoke_command(command, args: list[str]) -> None:
+    """Invoke a Cyclopts command and allow successful exits."""
+    app = App()
+    app.command(command)
+    try:
+        app(["create", *args])
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            raise
+
+
 def test_parse_json_input_options(tmp_path) -> None:
     """`parse_json_input_options` parses inline JSON and JSON files."""
     json_file = tmp_path / "input.json"
@@ -181,14 +192,16 @@ def test_source_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(sources, "CloudWorkspace", FakeWorkspace)
     monkeypatch.setattr(sources, "json_output", outputs.append)
 
-    sources.create(
-        json_input=json.dumps(  # type: ignore[call-arg]
-            {
+    _invoke_command(
+        sources.create,
+        [
+            "--json",
+            json.dumps({
                 "name": "Test Source",
                 "source_type": "postgres",
                 "config": {"host": "localhost"},
-            }
-        )
+            }),
+        ],
     )
 
     assert calls["workspace"] == {
@@ -204,8 +217,92 @@ def test_source_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> No
     assert outputs == [{"sourceId": "source-id"}]
 
 
-def test_connection_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`connections create` accepts command input from `--json`."""
+def test_source_create_accepts_named_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`sources create` accepts command input from named CLI args."""
+    calls = {}
+    outputs = []
+
+    class FakeSource:
+        def get_info(self) -> dict[str, object]:
+            return {"sourceId": "source-id"}
+
+    class FakeWorkspace:
+        def __init__(self, **kwargs: object) -> None:
+            calls["workspace"] = kwargs
+
+        def deploy_source(self, *, name: str, config: dict[str, object]) -> FakeSource:
+            calls["deploy_source"] = {"name": name, "config": config}
+            return FakeSource()
+
+    monkeypatch.setattr(sources, "CloudWorkspace", FakeWorkspace)
+    monkeypatch.setattr(sources, "json_output", outputs.append)
+
+    _invoke_command(
+        sources.create,
+        [
+            "--name",
+            "Named Source",
+            "--source-type",
+            "postgres",
+            "--config-json",
+            '{"host":"localhost"}',
+        ],
+    )
+
+    assert calls["workspace"] == {
+        "workspace_id": None,
+        "client_id": None,
+        "client_secret": None,
+        "api_root": None,
+    }
+    assert calls["deploy_source"] == {
+        "name": "Named Source",
+        "config": {"host": "localhost", "sourceType": "postgres"},
+    }
+    assert outputs == [{"sourceId": "source-id"}]
+
+
+@pytest.mark.parametrize(
+    "args,expected_name",
+    [
+        pytest.param(
+            [
+                "--json",
+                json.dumps({
+                    "name": "Test Connection",
+                    "source_id": "source-id",
+                    "destination_id": "destination-id",
+                    "prefix": "raw_",
+                    "selected_streams": ["users", "orders"],
+                }),
+            ],
+            "Test Connection",
+            id="json_input",
+        ),
+        pytest.param(
+            [
+                "--name",
+                "Named Connection",
+                "--source-id",
+                "source-id",
+                "--destination-id",
+                "destination-id",
+                "--prefix",
+                "raw_",
+                "--selected-streams",
+                "users,orders",
+            ],
+            "Named Connection",
+            id="named_args",
+        ),
+    ],
+)
+def test_connection_create_accepts_json_and_named_input(
+    args: list[str],
+    expected_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`connections create` accepts JSON input and named CLI args."""
     calls = {}
     outputs = []
 
@@ -246,17 +343,7 @@ def test_connection_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(connections, "CloudWorkspace", FakeWorkspace)
     monkeypatch.setattr(connections, "json_output", outputs.append)
 
-    connections.create(
-        json_input=json.dumps(  # type: ignore[call-arg]
-            {
-                "name": "Test Connection",
-                "source_id": "source-id",
-                "destination_id": "destination-id",
-                "prefix": "raw_",
-                "selected_streams": ["users", "orders"],
-            }
-        )
-    )
+    _invoke_command(connections.create, args)
 
     assert calls["workspace"] == {
         "workspace_id": None,
@@ -267,7 +354,7 @@ def test_connection_create_accepts_json_input(monkeypatch: pytest.MonkeyPatch) -
     assert calls["source_id"] == "source-id"
     assert calls["destination_id"] == "destination-id"
     assert calls["deploy_connection"] == {
-        "connection_name": "Test Connection",
+        "connection_name": expected_name,
         "source": "source:source-id",
         "destination": "destination:destination-id",
         "table_prefix": "raw_",

--- a/tests/unit_tests/test_cli_json_input.py
+++ b/tests/unit_tests/test_cli_json_input.py
@@ -40,7 +40,7 @@ def test_parse_json_input_options(tmp_path) -> None:
     assert _input.parse_json_input_options(json_input=f"@{json_file}") == {
         "name": "from-file"
     }
-    assert _input.parse_json_input_options(json_input=str(json_file)) == {
+    assert _input.parse_json_input_options(json_input=json_file.as_posix()) == {
         "name": "from-file"
     }
     assert _input.parse_json_input_options() == {}


### PR DESCRIPTION
This PR targets the following PR:
- https://github.com/airbytehq/PyAirbyte/pull/1010

---

## Summary
AJ requested this stacked PR on top of PR 1010 to add an optional JSON input path for Cyclopts-backed CLI commands.

This PR:
- Adds a reusable `wrapped_cli` decorator in `airbyte.cli._input` that injects `--json` and `--json-file` options into a command signature.
- Merges JSON-provided values with named CLI args while preserving named args as the primary path.
- Treats Cyclopts-populated defaults as absent input so `--json` can provide required fields and optional fields such as `prefix`.
- Supports `--json` as inline JSON, or as a JSON file path when the value starts with `@`, `.`, or `/`.
- Preserves inline JSON precedence by short-circuiting path detection when `json_input.lstrip()` starts with `{` or `[`.
- Raises clear `PyAirbyteInputError` failures for unsupported JSON fields, missing required values, multiple JSON input sources, missing JSON files, and conflicting JSON vs named CLI values.
- Supports small per-command adapters for nested JSON values, demonstrated by mapping source `config` to existing `--config-json` behavior and converting connection `selected_streams` lists to the existing comma-separated option format.
- Applies the wrapper only to representative `airbyte-cloud sources create` and `airbyte-cloud connections create` commands.
- Fixes the existing CloudWorkspace keyword-only constructor invariant that was failing on the PR 1010 base branch.

Design choices:
- `--json` accepts inline JSON object input.
- `--json` also accepts path shorthand: `@path/to/input.json`, `./input.json`, `../input.json`, or `/absolute/input.json`.
- Absolute paths are also detected with `Path(...).is_absolute()` after inline JSON is ruled out, covering Windows paths.
- `--json-file` remains an explicit file path option because it fit cleanly without broad command changes.
- Nested connector config composes through the existing `--config-json`/`--config-file` path by allowing `sources create --json '{"config": {...}}'`, where `config` is an alias for `config_json`.
- The wrapper lives in `airbyte/cli/_input.py` alongside existing CLI input parsing helpers.

## Review & Testing Checklist for Human
- [ ] Confirm `--json`, path shorthand, and `--json-file` are the desired public names for alternate command input.
- [ ] Confirm representative coverage on `sources create` and `connections create` is enough for this stacked PR, or identify additional commands to opt in later.
- [ ] Try an end-to-end Cloud create flow with real credentials before merging PR 1010.

### Notes
Local validation performed:
- `uv run python -m pytest tests/unit_tests/test_cli_json_input.py tests/unit_tests/test_cloud_api_roots.py::test_cloud_workspace_constructor_requires_keyword_arguments -q`
- `uv run ruff format --check .`
- `uv run ruff check airbyte/cli tests/unit_tests/test_cli_json_input.py`
- `uv run pyrefly check`
- Help smoke checks for `sources create` and `connections create`
- Real Cyclopts invocation smoke with fake workspaces for:
  - `sources create --json ...`
  - `sources create --json @/path/to/input.json`
  - `sources create --json /absolute/path/to/input.json`
  - `sources create --json ./relative/path.json`
  - `sources create --name ... --source-type ... --config-json ...`
  - `connections create --json ...`
  - `connections create --name ... --source-id ... --destination-id ... --prefix ... --selected-streams ...`

Open questions:
- Should future commands standardize on both `--json` and `--json-file`, or keep file input limited to commands that need it?
- For connection inputs, should JSON arrays become the preferred structured shape for stream selections while named CLI args remain comma-separated?

Link to Devin session: https://app.devin.ai/sessions/58c48af95945482ca97080e50487ae9e
Requested by: @aaronsteers