### PR TITLE
feat(cli): rename detail commands to describe

### DIFF
--- a/airbyte/cli/cloud/connections.py
+++ b/airbyte/cli/cloud/connections.py
@@ -56,7 +56,7 @@ def list_(
 
 
 @connections_app.command
-def get(
+def describe(
     *connection_id_args: PositionalIdArg,
     connection_id: ConnectionIdArg = None,
     workspace_id: WorkspaceIdArg = None,
@@ -64,7 +64,7 @@ def get(
     client_secret: ClientSecretArg = None,
     public_api_root: ApiUrlArg = None,
 ) -> None:
-    """Get details of a specific connection."""
+    """Describe a specific connection."""
     resolved_connection_id = resolve_entity_id(
         connection_id_args,
         connection_id,

--- a/airbyte/cli/cloud/destinations.py
+++ b/airbyte/cli/cloud/destinations.py
@@ -54,7 +54,7 @@ def list_(
 
 
 @destinations_app.command
-def get(
+def describe(
     *destination_id_args: PositionalIdArg,
     destination_id: DestinationIdArg = None,
     workspace_id: WorkspaceIdArg = None,
@@ -62,7 +62,7 @@ def get(
     client_secret: ClientSecretArg = None,
     public_api_root: ApiUrlArg = None,
 ) -> None:
-    """Get details of a specific destination."""
+    """Describe a specific destination."""
     resolved_destination_id = resolve_entity_id(
         destination_id_args,
         destination_id,

--- a/airbyte/cli/cloud/jobs.py
+++ b/airbyte/cli/cloud/jobs.py
@@ -66,7 +66,7 @@ def list_(
 
 
 @jobs_app.command
-def get(
+def describe(
     *job_id_args: PositionalIdArg,
     job_id: JobIdArg = None,
     workspace_id: WorkspaceIdArg = None,
@@ -74,7 +74,7 @@ def get(
     client_secret: ClientSecretArg = None,
     public_api_root: ApiUrlArg = None,
 ) -> None:
-    """Get details of a specific job."""
+    """Describe a specific job."""
     resolved_job_id = _resolve_job_id(job_id_args, job_id)
     workspace = CloudWorkspace(
         workspace_id=workspace_id,

--- a/airbyte/cli/cloud/sources.py
+++ b/airbyte/cli/cloud/sources.py
@@ -54,7 +54,7 @@ def list_(
 
 
 @sources_app.command
-def get(
+def describe(
     *source_id_args: PositionalIdArg,
     source_id: SourceIdArg = None,
     workspace_id: WorkspaceIdArg = None,
@@ -62,7 +62,7 @@ def get(
     client_secret: ClientSecretArg = None,
     public_api_root: ApiUrlArg = None,
 ) -> None:
-    """Get details of a specific source."""
+    """Describe a specific source."""
     resolved_source_id = resolve_entity_id(source_id_args, source_id, option_name="--source-id")
     workspace = CloudWorkspace(
         workspace_id=workspace_id,

--- a/airbyte/cli/cloud/workspaces.py
+++ b/airbyte/cli/cloud/workspaces.py
@@ -45,14 +45,14 @@ def list_(
 
 
 @workspaces_app.command
-def get(
+def describe(
     workspace_id: WorkspaceIdArg = None,
     *,
     client_id: ClientIdArg = None,
     client_secret: ClientSecretArg = None,
     public_api_root: ApiUrlArg = None,
 ) -> None:
-    """Get workspace details."""
+    """Describe workspace details."""
     workspace = CloudWorkspace(
         workspace_id=workspace_id,
         client_id=client_id,

--- a/tests/docs_tests/test_cli_docs.py
+++ b/tests/docs_tests/test_cli_docs.py
@@ -34,6 +34,31 @@ def test_generate_cli_reference_writes_markdown(tmp_path: Path) -> None:
 
 
 @pytest.mark.filterwarnings("ignore")
+@pytest.mark.parametrize(
+    "command_group",
+    [
+        pytest.param("workspaces", id="workspaces"),
+        pytest.param("sources", id="sources"),
+        pytest.param("destinations", id="destinations"),
+        pytest.param("connections", id="connections"),
+        pytest.param("jobs", id="jobs"),
+    ],
+)
+def test_generate_cli_reference_uses_describe_for_detail_commands(
+    tmp_path: Path,
+    command_group: str,
+) -> None:
+    """Cloud resource detail commands use `describe` rather than `get`."""
+    output_path = tmp_path / "cloud-reference.md"
+
+    generate_cli_reference(output_path)
+
+    content = output_path.read_text()
+    assert f"airbyte cloud {command_group} describe" in content
+    assert f"airbyte cloud {command_group} get" not in content
+
+
+@pytest.mark.filterwarnings("ignore")
 def test_generate_local_cli_reference_writes_markdown(tmp_path: Path) -> None:
     """`generate_local_cli_reference` writes a non-empty Markdown file."""
     output_path = tmp_path / "local-reference.md"


### PR DESCRIPTION
This PR targets the following PR:
- #1010

---

## Summary
AJ approved replacing resource-detail `get` commands with `describe` for the PyAirbyte Cloud CLI where the command describes top-level primitives.

This PR:
- Renames Cloud detail commands for workspaces, sources, destinations, connections, and jobs from `get` to `describe`.
- Updates command docstrings so generated CLI docs use `describe` wording.
- Adds docs-generator test coverage that asserts these Cloud resource groups expose `describe` and do not expose `get`.

This intentionally leaves deferred items untouched: universal `--json`, credential compatibility, output envelope/`--fields`, public/config API root naming, and the existing non-blocking `connections sync` default.

## Review & Testing Checklist for Human
- [ ] Confirm these are the intended top-level primitive detail commands to rename, and that no state/catalog/log-style property commands were changed.
- [ ] Verify the generated Cloud CLI reference names now show `describe` for workspaces, sources, destinations, connections, and jobs.
- [ ] Confirm deferred convention decisions remain out of scope for this PR.

### Notes
Validated locally with:
- `uv run ruff check airbyte/cli/cloud tests/docs_tests/test_cli_docs.py`
- `uv run ruff format --check airbyte/cli/cloud tests/docs_tests/test_cli_docs.py`
- `uv run pytest tests/docs_tests/test_cli_docs.py -q`

---
[Devin session](https://app.devin.ai/sessions/edd174c432a14effba2f90d588ff5c18)

Requested by: @aaronsteers