### PR TITLE
docs: rename PyAirbyte MCP references

### DIFF
--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -44,7 +44,8 @@ def set_mcp_mode() -> None:
     proper detection and prevent interactive prompts.
     """
     print(
-        f"Running in MCP mode: PyAirbyte MCP v{get_version()} (Python v{python_version()})",
+        "Running in MCP mode: "
+        f"Airbyte Replication MCP v{get_version()} (Python v{python_version()})",
         file=sys.stderr,
     )
     global _MCP_MODE_ENABLED

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -1,19 +1,19 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-r"""***PyAirbyte MCP Server - Model Context Protocol Integration***
+r"""***Airbyte Replication MCP Server - Model Context Protocol Integration***
 
 > **NOTE:**
 > This MCP server implementation is experimental and may change without notice between minor
 > versions of PyAirbyte. The API may be modified or entirely refactored in future versions.
 
-The PyAirbyte MCP (Model Context Protocol) server provides a standardized interface for
-managing Airbyte connectors through MCP-compatible clients. This experimental feature
-allows you to list connectors, validate configurations, and run sync operations using
-the MCP protocol.
+The Airbyte Replication MCP (Model Context Protocol) server provides a standardized interface
+for managing Airbyte connectors through MCP-compatible clients. This PyAirbyte-powered
+experimental feature allows you to list connectors, validate configurations, and run sync
+operations using the MCP protocol.
 
-## Getting Started with PyAirbyte MCP
+## Getting Started with Airbyte Replication MCP
 
-To get started with the PyAirbyte MCP server, follow these steps:
+To get started with the Airbyte Replication MCP server, follow these steps:
 
 1. Create a Dotenv secrets file.
 2. Register the MCP server with your MCP client.
@@ -21,7 +21,7 @@ To get started with the PyAirbyte MCP server, follow these steps:
 
 ### Step 1: Generate a Dotenv Secrets File
 
-To get started with the PyAirbyte MCP server, you will need to create a dotenv
+To get started with the Airbyte Replication MCP server, you will need to create a dotenv
 file containing your Airbyte Cloud credentials, as well as credentials for any
 third-party services you wish to connect to via Airbyte.
 
@@ -113,8 +113,8 @@ Helpful prompts to try:
 
 ## Airbyte Cloud MCP Server Safety
 
-The PyAirbyte MCP server supports environment variables to control safety and access levels for
-Airbyte Cloud operations.
+The Airbyte Replication MCP server supports environment variables to control safety and access
+levels for Airbyte Cloud operations.
 
 **Important:** The below settings only affect Cloud operations; local operations are not affected.
 

--- a/airbyte/mcp/prompts.py
+++ b/airbyte/mcp/prompts.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
-"""MCP prompt definitions for the PyAirbyte MCP server.
+"""MCP prompt definitions for the Airbyte Replication MCP server.
 
 This module defines prompts that can be invoked by MCP clients to perform
 common workflows.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -75,7 +75,7 @@ To pin your GitHub actions, you can use the [pinact](https://github.com/suzuki-s
 pinact run [optional_file]
 ```
 
-## Contributing to the PyAirbyte MCP Server
+## Contributing to the Airbyte Replication MCP Server
 
 The Airbyte MCP server is part of the PyAirbyte project. Contributions are welcome!
 
@@ -118,7 +118,7 @@ In your MCP config, you can test your development updates using `uv` as the entr
 
 ### Testing MCP Tools
 
-The easiest way to test PyAirbyte MCP tools during development is using the built-in Poe tasks.
+The easiest way to test Airbyte Replication MCP tools during development is using the built-in Poe tasks.
 
 ```bash
 poe mcp-tool-test <tool_name> '<json_args>'

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
-"""Generate Markdown documentation for the PyAirbyte MCP server.
+"""Generate Markdown documentation for the Airbyte Replication MCP server.
 
 Runs `fastmcp inspect` against the default `airbyte/mcp/server.py:app` spec
 (override with `--server-spec`) to obtain the full FastMCP protocol surface


### PR DESCRIPTION
## Summary
Renames public-facing `PyAirbyte MCP` references to `Airbyte Replication MCP` in the PyAirbyte source docs and MCP startup text.

Requested by @aaronsteers as a follow-on to https://github.com/airbytehq/airbyte/pull/78241.

## Review & Testing Checklist for Human
- [ ] Confirm `Airbyte Replication MCP` is the desired public name before marking ready.
- [ ] Confirm retaining PyAirbyte package, command, and env var names is expected.
- [ ] Optionally run the MCP server locally and verify the startup text uses the new name.

### Notes
Validation performed:
- `git diff --check`
- `uv run ruff check airbyte/_util/meta.py airbyte/mcp/__init__.py airbyte/mcp/prompts.py scripts/generate_mcp_markdown.py`
- Deep search confirmed no remaining `PyAirbyte MCP` references in this repo.


Link to Devin session: https://app.devin.ai/sessions/ceda5eaaaa204e44a0cb879a03b0ba84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product name from "PyAirbyte MCP" to "Airbyte Replication MCP" across documentation, contribution guidelines, and startup messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/PyAirbyte/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->