### PR TITLE
fix(cloud): wrap public API response models

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -79,6 +79,8 @@ jobs:
     # Common steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        persist-credentials: false
     - name: Install uv
       uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
       with:

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -28,7 +28,7 @@ jobs:
       # We only need helper libraries
       run: uv sync --group dev
 
-    # Job-specifc step(s):
+    # Job-specific step(s):
     - name: Lint code
       run: uv run ruff check .
 
@@ -48,7 +48,7 @@ jobs:
       # We only need helper libraries
       run: uv sync --group dev
 
-    # Job-specifc step(s):
+    # Job-specific step(s):
     - name: Check code format
       run: uv run ruff format --diff .
 
@@ -68,7 +68,7 @@ jobs:
       # We only need helper libraries
       run: uv sync --group dev
 
-    # Job-specifc step(s):
+    # Job-specific step(s):
     - name: Run Pyrefly Check
       run: uv run pyrefly check
 
@@ -90,6 +90,6 @@ jobs:
       # We only need helper libraries
       run: uv sync --group dev
 
-    # Job-specifc step(s):
+    # Job-specific step(s):
     - name: Check public API imports
       run: uv run pytest tests/unit_tests/test_public_api_imports.py -m linting

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -71,3 +71,23 @@ jobs:
     # Job-specifc step(s):
     - name: Run Pyrefly Check
       run: uv run pyrefly check
+
+  public-api-import-guard:
+    name: Public API Import Guard
+    runs-on: ubuntu-latest
+    steps:
+    # Common steps:
+    - name: Checkout code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+    - name: Install uv
+      uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
+      with:
+        version: "latest"
+        python-version: '3.10'
+    - name: Install dev dependencies
+      # We only need helper libraries
+      run: uv sync --group dev
+
+    # Job-specifc step(s):
+    - name: Check public API imports
+      run: uv run pytest tests/unit_tests/test_public_api_imports.py -m linting

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -854,7 +854,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
     client_secret: SecretString | None,
     bearer_token: SecretString | None,
     order_by: str | None = None,
-    job_type: models.JobTypeEnum | None = None,
+    job_type: str | models.JobTypeEnum | None = None,
 ) -> list[models.JobResponse]:
     """Get a list of jobs for a connection.
 
@@ -871,7 +871,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         client_secret: The client secret for authentication.
         bearer_token: Bearer token for authentication (alternative to client credentials).
         order_by: Field and direction to order by (e.g., "createdAt|DESC"). Defaults to None.
-        job_type: Filter by job type (e.g., JobTypeEnum.SYNC, JobTypeEnum.REFRESH).
+        job_type: Filter by job type (e.g., `sync`, `refresh`).
             If not specified, defaults to sync and reset jobs only (API default behavior).
 
     Returns:
@@ -892,6 +892,8 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         "connection_id": connection_id,
         "api_root": api_root,
     }
+    job_type_value = models.JobTypeEnum(job_type) if isinstance(job_type, str) else job_type
+
     while remaining is None or remaining > 0:
         page_limit = _get_page_limit(remaining)
         try:
@@ -902,7 +904,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
                     limit=page_limit,
                     offset=current_offset,
                     order_by=order_by,
-                    job_type=job_type,
+                    job_type=job_type_value,
                 ),
             )
         except SDKError as e:

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -896,7 +896,7 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         try:
             job_type_value = models.JobTypeEnum(job_type)
         except ValueError:
-            valid_job_types = ", ".join(job_type.value for job_type in models.JobTypeEnum)
+            valid_job_types = ", ".join(job_type_enum.value for job_type_enum in models.JobTypeEnum)
             raise PyAirbyteInputError(
                 message=f"`job_type` must be one of: {valid_job_types}.",
                 input_value=job_type,
@@ -1688,7 +1688,7 @@ def patch_connection(  # noqa: PLR0913  # Too many arguments
     configurations: models.StreamConfigurationsInput | None = None,
     schedule: models.AirbyteAPIConnectionSchedule | None = None,
     prefix: str | None = None,
-    status: models.ConnectionStatusEnum | None = None,
+    status: str | models.ConnectionStatusEnum | None = None,
 ) -> models.ConnectionResponse:
     """Update/patch a connection configuration.
 
@@ -1716,6 +1716,20 @@ def patch_connection(  # noqa: PLR0913  # Too many arguments
         bearer_token=bearer_token,
         api_root=api_root,
     )
+    if isinstance(status, str):
+        try:
+            status_value = models.ConnectionStatusEnum(status)
+        except ValueError:
+            valid_statuses = ", ".join(
+                connection_status.value for connection_status in models.ConnectionStatusEnum
+            )
+            raise PyAirbyteInputError(
+                message=f"`status` must be one of: {valid_statuses}.",
+                input_value=status,
+            ) from None
+    else:
+        status_value = status
+
     response = airbyte_instance.connections.patch_connection(
         api.PatchConnectionRequest(
             connection_id=connection_id,
@@ -1724,7 +1738,7 @@ def patch_connection(  # noqa: PLR0913  # Too many arguments
                 configurations=configurations,
                 schedule=schedule,
                 prefix=prefix,
-                status=status,
+                status=status_value,
             ),
         ),
     )

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -892,7 +892,17 @@ def get_job_logs(  # noqa: PLR0913  # Too many arguments - needed for auth flexi
         "connection_id": connection_id,
         "api_root": api_root,
     }
-    job_type_value = models.JobTypeEnum(job_type) if isinstance(job_type, str) else job_type
+    if isinstance(job_type, str):
+        try:
+            job_type_value = models.JobTypeEnum(job_type)
+        except ValueError:
+            valid_job_types = ", ".join(job_type.value for job_type in models.JobTypeEnum)
+            raise PyAirbyteInputError(
+                message=f"`job_type` must be one of: {valid_job_types}.",
+                input_value=job_type,
+            ) from None
+    else:
+        job_type_value = job_type
 
     while remaining is None or remaining > 0:
         page_limit = _get_page_limit(remaining)

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -1492,6 +1492,17 @@ def build_stream_configurations(
     return models.StreamConfigurations(streams=stream_configurations)
 
 
+def build_connection_schedule(
+    schedule_type: str,
+    cron_expression: str | None = None,
+) -> models.AirbyteAPIConnectionSchedule:
+    """Build a connection schedule object."""
+    return models.AirbyteAPIConnectionSchedule(
+        schedule_type=models.ScheduleTypeEnum(schedule_type),
+        cron_expression=cron_expression,
+    )
+
+
 def create_connection(  # noqa: PLR0913  # Too many arguments
     name: str,
     *,

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -88,6 +88,7 @@ from airbyte.cloud.client import CloudClient
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
 from airbyte.cloud.constants import JobStatusEnum
+from airbyte.cloud.models import CloudWorkspaceInfo
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.cloud.workspaces import CloudWorkspace
@@ -122,6 +123,7 @@ __all__ = [
     "CloudWorkspace",
     "CloudConnection",
     "CloudClientConfig",
+    "CloudWorkspaceInfo",
     "SyncResult",
     # Enums
     "JobStatusEnum",

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -87,7 +87,7 @@ from typing import TYPE_CHECKING
 from airbyte.cloud.client import CloudClient
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
-from airbyte.cloud.models import CloudWorkspaceInfo, JobStatusEnum
+from airbyte.cloud.models import CloudWorkspaceInfo, JobStatusEnum, JobTypeEnum
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.cloud.workspaces import CloudWorkspace
@@ -126,4 +126,5 @@ __all__ = [
     "SyncResult",
     # Enums
     "JobStatusEnum",
+    "JobTypeEnum",
 ]

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -87,8 +87,7 @@ from typing import TYPE_CHECKING
 from airbyte.cloud.client import CloudClient
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
-from airbyte.cloud.constants import JobStatusEnum
-from airbyte.cloud.models import CloudWorkspaceInfo
+from airbyte.cloud.models import CloudWorkspaceInfo, JobStatusEnum
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.cloud.workspaces import CloudWorkspace

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, overload
 from airbyte import exceptions as exc
 from airbyte._util import api_util
 from airbyte.cloud._credentials import _AirbyteCredentials
+from airbyte.cloud.models import CloudWorkspaceInfo
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteMissingResourceError
@@ -17,7 +18,6 @@ from airbyte.exceptions import AirbyteMissingResourceError
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from airbyte._util import api_imports
     from airbyte.secrets.base import SecretString
 
 
@@ -146,10 +146,10 @@ class CloudClient:
         name: str,
         organization_id: str | None = None,
         region_id: str | None = None,
-    ) -> api_imports.WorkspaceResponse:
+    ) -> CloudWorkspaceInfo:
         """Create an Airbyte workspace."""
         resolved_organization_id = organization_id or self.organization_id
-        return api_util.create_workspace(
+        workspace = api_util.create_workspace(
             name=name,
             organization_id=resolved_organization_id,
             region_id=region_id,
@@ -158,15 +158,16 @@ class CloudClient:
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
         )
+        return CloudWorkspaceInfo.from_api_response(workspace)
 
     def rename_workspace(
         self,
         workspace_id: str,
         *,
         name: str,
-    ) -> api_imports.WorkspaceResponse:
+    ) -> CloudWorkspaceInfo:
         """Rename an Airbyte workspace."""
-        return api_util.rename_workspace(
+        workspace = api_util.rename_workspace(
             workspace_id=workspace_id,
             name=name,
             api_root=self.public_api_root,
@@ -174,6 +175,7 @@ class CloudClient:
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
         )
+        return CloudWorkspaceInfo.from_api_response(workspace)
 
     def permanently_delete_workspace(
         self,
@@ -207,7 +209,7 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
-    ) -> list[api_imports.WorkspaceResponse]:
+    ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
     @overload
@@ -219,7 +221,7 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
-    ) -> list[dict[str, object]]:
+    ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
     def list_workspaces(
@@ -230,7 +232,7 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
-    ) -> list[api_imports.WorkspaceResponse] | list[dict[str, object]]:
+    ) -> list[CloudWorkspaceInfo]:
         """List workspaces available to this client."""
         if organization_id is not None or self.organization_id is not None:
             resolved_organization_id = organization_id or self.organization_id
@@ -249,15 +251,16 @@ class CloudClient:
                 name_contains=name_contains or name,
                 limit=None if name_filter is not None else limit,
             )
+            workspace_infos = [
+                CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces
+            ]
             if name_filter is not None:
-                workspaces = [
-                    workspace
-                    for workspace in workspaces
-                    if name_filter(str(workspace.get("name", "")))
+                workspace_infos = [
+                    workspace for workspace in workspace_infos if name_filter(workspace.name)
                 ]
                 if limit is not None:
-                    workspaces = workspaces[:limit]
-            return workspaces
+                    workspace_infos = workspace_infos[:limit]
+            return workspace_infos
         if name_contains is not None:
             if name_filter is not None:
                 raise exc.PyAirbyteInputError(
@@ -268,16 +271,19 @@ class CloudClient:
             def name_filter(workspace_name: str) -> bool:
                 return name_substring in workspace_name
 
-        return api_util.list_workspaces(
-            workspace_id="",
-            api_root=self.public_api_root,
-            name=name,
-            name_filter=name_filter,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            bearer_token=self.bearer_token,
-            limit=limit,
-        )
+        return [
+            CloudWorkspaceInfo.from_api_response(workspace)
+            for workspace in api_util.list_workspaces(
+                workspace_id="",
+                api_root=self.public_api_root,
+                name=name,
+                name_filter=name_filter,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+                limit=limit,
+            )
+        ]
 
     def get_organization(
         self,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -23,7 +23,12 @@ from airbyte.cloud._connection_state import (
     _normalize_state_to_protocol,
 )
 from airbyte.cloud.connectors import CloudDestination, CloudSource
-from airbyte.cloud.models import CloudConnectionInfo, CloudJobInfo, _ConnectionResponseLike
+from airbyte.cloud.models import (
+    CloudConnectionInfo,
+    CloudJobInfo,
+    JobTypeEnum,
+    _ConnectionResponseLike,
+)
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.exceptions import AirbyteWorkspaceMismatchError, PyAirbyteInputError
 
@@ -33,8 +38,6 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from airbyte.cloud.workspaces import CloudWorkspace
-
-JobType = Literal["sync", "reset", "refresh", "clear"]
 
 
 class CloudConnection:  # noqa: PLR0904  # Too many public methods
@@ -312,7 +315,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         limit: int = 20,
         offset: int | None = None,
         from_tail: bool = True,
-        job_type: JobType | None = None,
+        job_type: JobTypeEnum | None = None,
     ) -> list[SyncResult]:
         """Get previous sync jobs for a connection with pagination support.
 

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -315,7 +315,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         limit: int = 20,
         offset: int | None = None,
         from_tail: bool = True,
-        job_type: JobTypeEnum | None = None,
+        job_type: str | JobTypeEnum | None = None,
     ) -> list[SyncResult]:
         """Get previous sync jobs for a connection with pagination support.
 

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -23,6 +23,7 @@ from airbyte.cloud._connection_state import (
     _normalize_state_to_protocol,
 )
 from airbyte.cloud.connectors import CloudDestination, CloudSource
+from airbyte.cloud.models import CloudConnectionInfo, CloudJobInfo, _ConnectionResponseLike
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.exceptions import AirbyteWorkspaceMismatchError, PyAirbyteInputError
 
@@ -31,8 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from airbyte_api.models import ConnectionResponse, JobResponse
-
     from airbyte.cloud.workspaces import CloudWorkspace
 
 JobType = Literal["sync", "reset", "refresh", "clear"]
@@ -67,7 +66,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         self._destination_id = destination
         """The ID of the destination."""
 
-        self._connection_info: ConnectionResponse | None = None
+        self._connection_info: CloudConnectionInfo | None = None
         """The connection info object. (Cached.)"""
 
         self._cloud_source_object: CloudSource | None = None
@@ -81,7 +80,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         *,
         force_refresh: bool = False,
         verify: bool = True,
-    ) -> ConnectionResponse:
+    ) -> CloudConnectionInfo:
         """Fetch and cache connection info from the API.
 
         By default, this method will only fetch from the API if connection info is not
@@ -96,7 +95,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
                 validation fails.
 
         Returns:
-            The ConnectionResponse from the API.
+            Information about the connection from the API.
 
         Raises:
             AirbyteWorkspaceMismatchError: If verify is True and the connection's
@@ -118,17 +117,17 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
         )
+        result = CloudConnectionInfo.from_api_response(connection_info)
 
-        # Cache the result first (before verification may raise)
-        self._connection_info = connection_info
+        self._connection_info = result
 
         # Verify if requested
         if verify:
-            self._verify_workspace_match(connection_info)
+            self._verify_workspace_match(result)
 
-        return connection_info
+        return result
 
-    def _verify_workspace_match(self, connection_info: ConnectionResponse) -> None:
+    def _verify_workspace_match(self, connection_info: CloudConnectionInfo) -> None:
         """Verify that the connection belongs to the expected workspace.
 
         Raises:
@@ -168,16 +167,17 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
     def _from_connection_response(
         cls,
         workspace: CloudWorkspace,
-        connection_response: ConnectionResponse,
+        connection_response: _ConnectionResponseLike,
     ) -> CloudConnection:
-        """Create a CloudConnection from a ConnectionResponse."""
+        """Create a CloudConnection from an API connection response."""
+        connection_info = CloudConnectionInfo.from_api_response(connection_response)
         result = cls(
             workspace=workspace,
-            connection_id=connection_response.connection_id,
-            source=connection_response.source_id,
-            destination=connection_response.destination_id,
+            connection_id=connection_info.connection_id,
+            source=connection_info.source_id,
+            destination=connection_info.destination_id,
         )
-        result._connection_info = connection_response  # noqa: SLF001 # Accessing Non-Public API
+        result._connection_info = connection_info  # noqa: SLF001 # Accessing Non-Public API
         return result
 
     # Properties
@@ -337,7 +337,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             if from_tail
             else api_util.JOB_ORDER_BY_CREATED_AT_ASC
         )
-        sync_logs: list[JobResponse] = api_util.get_job_logs(
+        sync_logs = api_util.get_job_logs(
             connection_id=self.connection_id,
             api_root=self.workspace.api_root,
             workspace_id=self.workspace.workspace_id,
@@ -354,7 +354,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
                 workspace=self.workspace,
                 connection=self,
                 job_id=sync_log.job_id,
-                _latest_job_info=sync_log,
+                _latest_job_info=CloudJobInfo.from_api_response(sync_log),
             )
             for sync_log in sync_logs
         ]
@@ -750,7 +750,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             bearer_token=self.workspace.bearer_token,
             name=name,
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
         return self
 
     def set_table_prefix(self, prefix: str) -> CloudConnection:
@@ -770,7 +770,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             bearer_token=self.workspace.bearer_token,
             prefix=prefix,
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
         return self
 
     def set_selected_streams(self, stream_names: list[str]) -> CloudConnection:
@@ -795,7 +795,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             bearer_token=self.workspace.bearer_token,
             configurations=configurations,
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
         return self
 
     # Enable/Disable
@@ -811,7 +811,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             True if the connection status is 'active', False otherwise.
         """
         connection_info = self._fetch_connection_info(force_refresh=True)
-        return connection_info.status == api_util.models.ConnectionStatusEnum.ACTIVE
+        return connection_info.status == "active"
 
     @enabled.setter
     def enabled(self, value: bool) -> None:
@@ -845,11 +845,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         # Always fetch fresh data to check current status
         connection_info = self._fetch_connection_info(force_refresh=True)
         current_status = connection_info.status
-        desired_status = (
-            api_util.models.ConnectionStatusEnum.ACTIVE
-            if enabled
-            else api_util.models.ConnectionStatusEnum.INACTIVE
-        )
+        desired_status = "active" if enabled else "inactive"
 
         if current_status == desired_status:
             if ignore_noop:
@@ -867,7 +863,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             bearer_token=self.workspace.bearer_token,
             status=desired_status,
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
 
     # Scheduling
 
@@ -885,37 +881,33 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
                 - "0 */6 * * *" - Every 6 hours
                 - "0 0 * * 0" - Weekly on Sunday at midnight UTC
         """
-        schedule = api_util.models.AirbyteAPIConnectionSchedule(
-            schedule_type=api_util.models.ScheduleTypeEnum.CRON,
-            cron_expression=cron_expression,
-        )
         updated_response = api_util.patch_connection(
             connection_id=self.connection_id,
             api_root=self.workspace.api_root,
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
-            schedule=schedule,
+            schedule=api_util.build_connection_schedule(
+                schedule_type="cron",
+                cron_expression=cron_expression,
+            ),
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
 
     def set_manual_schedule(self) -> None:
         """Set the connection to manual scheduling.
 
         Disables automatic syncs. Syncs will only run when manually triggered.
         """
-        schedule = api_util.models.AirbyteAPIConnectionSchedule(
-            schedule_type=api_util.models.ScheduleTypeEnum.MANUAL,
-        )
         updated_response = api_util.patch_connection(
             connection_id=self.connection_id,
             api_root=self.workspace.api_root,
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,
             bearer_token=self.workspace.bearer_token,
-            schedule=schedule,
+            schedule=api_util.build_connection_schedule(schedule_type="manual"),
         )
-        self._connection_info = updated_response
+        self._connection_info = CloudConnectionInfo.from_api_response(updated_response)
 
     # Deletions
 

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -31,9 +31,11 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from airbyte_api.models import ConnectionResponse, JobResponse, JobTypeEnum
+    from airbyte_api.models import ConnectionResponse, JobResponse
 
     from airbyte.cloud.workspaces import CloudWorkspace
+
+JobType = Literal["sync", "reset", "refresh", "clear"]
 
 
 class CloudConnection:  # noqa: PLR0904  # Too many public methods
@@ -310,7 +312,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         limit: int = 20,
         offset: int | None = None,
         from_tail: bool = True,
-        job_type: JobTypeEnum | None = None,
+        job_type: JobType | None = None,
     ) -> list[SyncResult]:
         """Get previous sync jobs for a connection with pagination support.
 
@@ -324,7 +326,7 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             from_tail: If True, returns jobs ordered newest-first (createdAt DESC).
                 If False, returns jobs ordered oldest-first (createdAt ASC).
                 Defaults to True.
-            job_type: Filter by job type (e.g., JobTypeEnum.SYNC, JobTypeEnum.REFRESH).
+            job_type: Filter by job type (e.g., `sync`, `refresh`).
                 If not specified, defaults to sync and reset jobs only (API default behavior).
 
         Returns:

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -45,10 +45,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import yaml
-from airbyte_api import models as api_models  # noqa: TC002
 
 from airbyte import exceptions as exc
 from airbyte._util import api_util, text_util
+from airbyte.cloud.models import (
+    CloudCustomSourceDefinitionInfo,
+    CloudDestinationInfo,
+    CloudSourceInfo,
+    _DeclarativeSourceDefinitionResponseLike,
+    _DestinationResponseLike,
+    _SourceResponseLike,
+)
 
 
 if TYPE_CHECKING:
@@ -104,9 +111,7 @@ class CloudConnector(abc.ABC):
         self.connector_id = connector_id
         """The ID of the connector."""
 
-        self._connector_info: api_models.SourceResponse | api_models.DestinationResponse | None = (
-            None
-        )
+        self._connector_info: CloudSourceInfo | CloudDestinationInfo | None = None
         """The connection info object. (Cached.)"""
 
     @property
@@ -121,7 +126,7 @@ class CloudConnector(abc.ABC):
         return self._connector_info.name
 
     @abc.abstractmethod
-    def _fetch_connector_info(self) -> api_models.SourceResponse | api_models.DestinationResponse:
+    def _fetch_connector_info(self) -> CloudSourceInfo | CloudDestinationInfo:
         """Populate the connector with data from the API."""
         ...
 
@@ -192,14 +197,16 @@ class CloudSource(CloudConnector):
         """
         return self.connector_id
 
-    def _fetch_connector_info(self) -> api_models.SourceResponse:
+    def _fetch_connector_info(self) -> CloudSourceInfo:
         """Populate the source with data from the API."""
-        return api_util.get_source(
-            source_id=self.connector_id,
-            api_root=self.workspace.api_root,
-            client_id=self.workspace.client_id,
-            client_secret=self.workspace.client_secret,
-            bearer_token=self.workspace.bearer_token,
+        return CloudSourceInfo.from_api_response(
+            api_util.get_source(
+                source_id=self.connector_id,
+                api_root=self.workspace.api_root,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
         )
 
     def rename(self, name: str) -> CloudSource:
@@ -219,7 +226,7 @@ class CloudSource(CloudConnector):
             bearer_token=self.workspace.bearer_token,
             name=name,
         )
-        self._connector_info = updated_response
+        self._connector_info = CloudSourceInfo.from_api_response(updated_response)
         return self
 
     def update_config(self, config: dict[str, Any]) -> CloudSource:
@@ -242,24 +249,25 @@ class CloudSource(CloudConnector):
             bearer_token=self.workspace.bearer_token,
             config=config,
         )
-        self._connector_info = updated_response
+        self._connector_info = CloudSourceInfo.from_api_response(updated_response)
         return self
 
     @classmethod
     def _from_source_response(
         cls,
         workspace: CloudWorkspace,
-        source_response: api_models.SourceResponse,
+        source_response: _SourceResponseLike,
     ) -> CloudSource:
         """Internal factory method.
 
-        Creates a CloudSource object from a REST API SourceResponse object.
+        Creates a CloudSource object from a REST API source response object.
         """
+        source_info = CloudSourceInfo.from_api_response(source_response)
         result = cls(
             workspace=workspace,
-            connector_id=source_response.source_id,
+            connector_id=source_info.source_id,
         )
-        result._connector_info = source_response  # noqa: SLF001  # Accessing Non-Public API
+        result._connector_info = source_info  # noqa: SLF001  # Accessing Non-Public API
         return result
 
 
@@ -277,14 +285,16 @@ class CloudDestination(CloudConnector):
         """
         return self.connector_id
 
-    def _fetch_connector_info(self) -> api_models.DestinationResponse:
+    def _fetch_connector_info(self) -> CloudDestinationInfo:
         """Populate the destination with data from the API."""
-        return api_util.get_destination(
-            destination_id=self.connector_id,
-            api_root=self.workspace.api_root,
-            client_id=self.workspace.client_id,
-            client_secret=self.workspace.client_secret,
-            bearer_token=self.workspace.bearer_token,
+        return CloudDestinationInfo.from_api_response(
+            api_util.get_destination(
+                destination_id=self.connector_id,
+                api_root=self.workspace.api_root,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
         )
 
     def rename(self, name: str) -> CloudDestination:
@@ -304,7 +314,7 @@ class CloudDestination(CloudConnector):
             bearer_token=self.workspace.bearer_token,
             name=name,
         )
-        self._connector_info = updated_response
+        self._connector_info = CloudDestinationInfo.from_api_response(updated_response)
         return self
 
     def update_config(self, config: dict[str, Any]) -> CloudDestination:
@@ -327,24 +337,25 @@ class CloudDestination(CloudConnector):
             bearer_token=self.workspace.bearer_token,
             config=config,
         )
-        self._connector_info = updated_response
+        self._connector_info = CloudDestinationInfo.from_api_response(updated_response)
         return self
 
     @classmethod
     def _from_destination_response(
         cls,
         workspace: CloudWorkspace,
-        destination_response: api_models.DestinationResponse,
+        destination_response: _DestinationResponseLike,
     ) -> CloudDestination:
         """Internal factory method.
 
-        Creates a CloudDestination object from a REST API DestinationResponse object.
+        Creates a CloudDestination object from a REST API destination response object.
         """
+        destination_info = CloudDestinationInfo.from_api_response(destination_response)
         result = cls(
             workspace=workspace,
-            connector_id=destination_response.destination_id,
+            connector_id=destination_info.destination_id,
         )
-        result._connector_info = destination_response  # noqa: SLF001  # Accessing Non-Public API
+        result._connector_info = destination_info  # noqa: SLF001  # Accessing Non-Public API
         return result
 
 
@@ -371,7 +382,7 @@ class CustomCloudSourceDefinition:
         self.workspace = workspace
         self.definition_id = definition_id
         self.definition_type: Literal["yaml", "docker"] = definition_type
-        self._definition_info: api_models.DeclarativeSourceDefinitionResponse | None = None
+        self._definition_info: CloudCustomSourceDefinitionInfo | None = None
         self._connector_builder_project_id: str | None = None
         self._connector_builder_project_id_fetched: bool = False
         self._builder_project_workspace_id: str | None = None
@@ -379,16 +390,18 @@ class CustomCloudSourceDefinition:
 
     def _fetch_definition_info(
         self,
-    ) -> api_models.DeclarativeSourceDefinitionResponse:
+    ) -> CloudCustomSourceDefinitionInfo:
         """Fetch definition info from the API."""
         if self.definition_type == "yaml":
-            return api_util.get_custom_yaml_source_definition(
-                workspace_id=self.workspace.workspace_id,
-                definition_id=self.definition_id,
-                api_root=self.workspace.api_root,
-                client_id=self.workspace.client_id,
-                client_secret=self.workspace.client_secret,
-                bearer_token=self.workspace.bearer_token,
+            return CloudCustomSourceDefinitionInfo.from_api_response(
+                api_util.get_custom_yaml_source_definition(
+                    workspace_id=self.workspace.workspace_id,
+                    definition_id=self.definition_id,
+                    api_root=self.workspace.api_root,
+                    client_id=self.workspace.client_id,
+                    client_secret=self.workspace.client_secret,
+                    bearer_token=self.workspace.bearer_token,
+                )
             )
         raise NotImplementedError(
             "Docker custom source definitions are not yet supported. "
@@ -749,15 +762,16 @@ class CustomCloudSourceDefinition:
     def _from_yaml_response(
         cls,
         workspace: CloudWorkspace,
-        response: api_models.DeclarativeSourceDefinitionResponse,
+        response: _DeclarativeSourceDefinitionResponseLike,
     ) -> CustomCloudSourceDefinition:
         """Internal factory method for YAML connectors."""
+        definition_info = CloudCustomSourceDefinitionInfo.from_api_response(response)
         result = cls(
             workspace=workspace,
-            definition_id=response.id,
+            definition_id=definition_info.definition_id,
             definition_type="yaml",
         )
-        result._definition_info = response  # noqa: SLF001
+        result._definition_info = definition_info  # noqa: SLF001
         return result
 
     def deploy_source(

--- a/airbyte/cloud/constants.py
+++ b/airbyte/cloud/constants.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from airbyte._util.api_imports import JobStatusEnum
+from airbyte.cloud.models import JobStatusEnum
 
 
 FINAL_STATUSES: set[JobStatusEnum] = {

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
-from typing import Protocol
+from enum import Enum
+from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,6 +16,53 @@ class _WorkspaceResponseLike(Protocol):
     name: str
     data_residency: str
     notifications: object
+
+
+class _ConnectionResponseLike(Protocol):
+    connection_id: str
+    workspace_id: str
+    source_id: str
+    destination_id: str
+    name: str
+    configurations: Any
+    prefix: str | None
+    status: object
+
+
+class _JobResponseLike(Protocol):
+    job_id: int
+    status: object
+    bytes_synced: int | None
+    rows_synced: int | None
+    start_time: str
+
+
+class _SourceResponseLike(Protocol):
+    source_id: str
+    name: str
+
+
+class _DestinationResponseLike(Protocol):
+    destination_id: str
+    name: str
+
+
+class _DeclarativeSourceDefinitionResponseLike(Protocol):
+    id: str
+    name: str
+    manifest: dict[str, Any] | None
+    version: object
+
+
+class JobStatusEnum(str, Enum):
+    """Status values for an Airbyte Cloud job."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    INCOMPLETE = "incomplete"
+    FAILED = "failed"
+    SUCCEEDED = "succeeded"
+    CANCELLED = "cancelled"
 
 
 class CloudWorkspaceInfo(BaseModel):
@@ -58,6 +106,140 @@ class CloudWorkspaceInfo(BaseModel):
         return self.model_dump(mode="json")
 
 
+class CloudConnectionInfo(BaseModel):
+    """Information about an Airbyte Cloud connection."""
+
+    connection_id: str
+    """The connection ID."""
+
+    workspace_id: str
+    """The workspace ID."""
+
+    source_id: str
+    """The source ID."""
+
+    destination_id: str
+    """The destination ID."""
+
+    name: str
+    """The connection name."""
+
+    configurations: Any
+    """Stream configuration details for the connection."""
+
+    prefix: str | None = None
+    """The destination table prefix."""
+
+    status: str
+    """The connection status."""
+
+    @classmethod
+    def from_api_response(cls, connection: _ConnectionResponseLike) -> CloudConnectionInfo:
+        """Create a public model from an internal API connection response."""
+        return cls(
+            connection_id=connection.connection_id,
+            workspace_id=connection.workspace_id,
+            source_id=connection.source_id,
+            destination_id=connection.destination_id,
+            name=connection.name,
+            configurations=connection.configurations,
+            prefix=connection.prefix,
+            status=_enum_value(connection.status),
+        )
+
+
+class CloudJobInfo(BaseModel):
+    """Information about an Airbyte Cloud job."""
+
+    job_id: int
+    """The job ID."""
+
+    status: JobStatusEnum
+    """The job status."""
+
+    bytes_synced: int | None = None
+    """The number of bytes synced by the job, if available."""
+
+    rows_synced: int | None = None
+    """The number of rows synced by the job, if available."""
+
+    start_time: str
+    """The job start time."""
+
+    @classmethod
+    def from_api_response(cls, job: _JobResponseLike) -> CloudJobInfo:
+        """Create a public model from an internal API job response."""
+        return cls(
+            job_id=job.job_id,
+            status=JobStatusEnum(_enum_value(job.status)),
+            bytes_synced=job.bytes_synced,
+            rows_synced=job.rows_synced,
+            start_time=job.start_time,
+        )
+
+
+class CloudSourceInfo(BaseModel):
+    """Information about an Airbyte Cloud source."""
+
+    source_id: str
+    """The source ID."""
+
+    name: str
+    """The source name."""
+
+    @classmethod
+    def from_api_response(cls, source: _SourceResponseLike) -> CloudSourceInfo:
+        """Create a public model from an internal API source response."""
+        return cls(source_id=source.source_id, name=source.name)
+
+
+class CloudDestinationInfo(BaseModel):
+    """Information about an Airbyte Cloud destination."""
+
+    destination_id: str
+    """The destination ID."""
+
+    name: str
+    """The destination name."""
+
+    @classmethod
+    def from_api_response(
+        cls,
+        destination: _DestinationResponseLike,
+    ) -> CloudDestinationInfo:
+        """Create a public model from an internal API destination response."""
+        return cls(destination_id=destination.destination_id, name=destination.name)
+
+
+class CloudCustomSourceDefinitionInfo(BaseModel):
+    """Information about a custom Airbyte Cloud source definition."""
+
+    definition_id: str
+    """The source definition ID."""
+
+    name: str
+    """The source definition name."""
+
+    manifest: dict[str, Any] | None = None
+    """The source definition manifest."""
+
+    version: str
+    """The source definition version."""
+
+    @classmethod
+    def from_api_response(
+        cls,
+        definition: _DeclarativeSourceDefinitionResponseLike,
+    ) -> CloudCustomSourceDefinitionInfo:
+        """Create a public model from an internal API source definition response."""
+        return cls(
+            definition_id=definition.id,
+            name=definition.name,
+            manifest=definition.manifest,
+            version=str(definition.version),
+        )
+
+
 def _notifications_to_dict(notifications: object) -> dict[str, object | None]:
     """Convert workspace notification settings into a dictionary."""
     if notifications is None:
@@ -67,3 +249,10 @@ def _notifications_to_dict(notifications: object) -> dict[str, object | None]:
     if isinstance(notifications, Mapping):
         return {str(key): value for key, value in notifications.items()}
     return {}
+
+
+def _enum_value(value: object) -> str:
+    """Return the string value for an enum-like object."""
+    if isinstance(value, Enum):
+        return str(value.value)
+    return str(value)

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -65,6 +65,15 @@ class JobStatusEnum(str, Enum):
     CANCELLED = "cancelled"
 
 
+class JobTypeEnum(str, Enum):
+    """Job type values for Airbyte Cloud jobs."""
+
+    SYNC = "sync"
+    RESET = "reset"
+    REFRESH = "refresh"
+    CLEAR = "clear"
+
+
 class CloudWorkspaceInfo(BaseModel):
     """Information about an Airbyte workspace."""
 

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Public response models for Airbyte Cloud APIs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _WorkspaceResponseLike(Protocol):
+    workspace_id: str
+    name: str
+    data_residency: str
+    notifications: object
+
+
+class CloudWorkspaceInfo(BaseModel):
+    """Information about an Airbyte workspace."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    workspace_id: str = Field(alias="workspaceId")
+    """The workspace ID."""
+
+    name: str
+    """The workspace name."""
+
+    data_residency: str | None = Field(default=None, alias="dataResidency")
+    """The data residency setting for the workspace, if available."""
+
+    organization_id: str | None = Field(default=None, alias="organizationId")
+    """The organization ID for the workspace, if available."""
+
+    notifications: dict[str, object | None] = Field(default_factory=dict)
+    """Workspace notification settings."""
+
+    @classmethod
+    def from_api_response(cls, workspace: _WorkspaceResponseLike) -> CloudWorkspaceInfo:
+        """Create a public model from an internal API workspace response."""
+        return cls(
+            workspace_id=workspace.workspace_id,
+            name=workspace.name,
+            data_residency=workspace.data_residency,
+            notifications=_notifications_to_dict(workspace.notifications),
+        )
+
+    @classmethod
+    def from_mapping(cls, workspace: Mapping[str, object]) -> CloudWorkspaceInfo:
+        """Create a public model from a workspace mapping."""
+        return cls.model_validate(workspace)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable dictionary."""
+        return self.model_dump(mode="json")
+
+
+def _notifications_to_dict(notifications: object) -> dict[str, object | None]:
+    """Convert workspace notification settings into a dictionary."""
+    if notifications is None:
+        return {}
+    if is_dataclass(notifications) and not isinstance(notifications, type):
+        return {str(key): value for key, value in asdict(notifications).items()}
+    if isinstance(notifications, Mapping):
+        return {str(key): value for key, value in notifications.items()}
+    return {}

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -44,6 +44,7 @@ class CloudWorkspaceInfo(BaseModel):
             workspace_id=workspace.workspace_id,
             name=workspace.name,
             data_residency=workspace.data_residency,
+            organization_id=getattr(workspace, "organization_id", None),
             notifications=_notifications_to_dict(workspace.notifications),
         )
 

--- a/airbyte/cloud/sync_results.py
+++ b/airbyte/cloud/sync_results.py
@@ -112,6 +112,7 @@ from airbyte_cdk.utils.datetime_helpers import ab_datetime_parse
 from airbyte._util import api_util
 from airbyte.caches._utils._dest_to_cache import destination_to_cache
 from airbyte.cloud.constants import FAILED_STATUSES, FINAL_STATUSES
+from airbyte.cloud.models import CloudConnectionInfo, CloudJobInfo, JobStatusEnum
 from airbyte.datasets import CachedDataset
 from airbyte.exceptions import AirbyteConnectionSyncError, AirbyteConnectionSyncTimeoutError
 
@@ -124,7 +125,6 @@ if TYPE_CHECKING:
 
     import sqlalchemy
 
-    from airbyte._util.api_imports import ConnectionResponse, JobResponse, JobStatusEnum
     from airbyte.caches.base import CacheBase
     from airbyte.cloud.connections import CloudConnection
     from airbyte.cloud.workspaces import CloudWorkspace
@@ -227,8 +227,8 @@ class SyncResult:
     job_id: int
     table_name_prefix: str = ""
     table_name_suffix: str = ""
-    _latest_job_info: JobResponse | None = None
-    _connection_response: ConnectionResponse | None = None
+    _latest_job_info: CloudJobInfo | None = None
+    _connection_response: CloudConnectionInfo | None = None
     _cache: CacheBase | None = None
     _job_with_attempts_info: dict[str, Any] | None = None
 
@@ -244,24 +244,26 @@ class SyncResult:
         """
         return f"{self.connection.job_history_url}"
 
-    def _get_connection_info(self, *, force_refresh: bool = False) -> ConnectionResponse:
+    def _get_connection_info(self, *, force_refresh: bool = False) -> CloudConnectionInfo:
         """Return connection info for the sync job."""
         if self._connection_response and not force_refresh:
             return self._connection_response
 
-        self._connection_response = api_util.get_connection(
-            workspace_id=self.workspace.workspace_id,
-            api_root=self.workspace.api_root,
-            connection_id=self.connection.connection_id,
-            client_id=self.workspace.client_id,
-            client_secret=self.workspace.client_secret,
-            bearer_token=self.workspace.bearer_token,
+        self._connection_response = CloudConnectionInfo.from_api_response(
+            api_util.get_connection(
+                workspace_id=self.workspace.workspace_id,
+                api_root=self.workspace.api_root,
+                connection_id=self.connection.connection_id,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
         )
         return self._connection_response
 
     def _get_destination_configuration(self, *, force_refresh: bool = False) -> dict[str, Any]:
         """Return the destination configuration for the sync job."""
-        connection_info: ConnectionResponse = self._get_connection_info(force_refresh=force_refresh)
+        connection_info = self._get_connection_info(force_refresh=force_refresh)
         destination_response = api_util.get_destination(
             destination_id=connection_info.destination_id,
             api_root=self.workspace.api_root,
@@ -279,17 +281,19 @@ class SyncResult:
         """Check if the sync job is still running."""
         return self._fetch_latest_job_info().status
 
-    def _fetch_latest_job_info(self) -> JobResponse:
+    def _fetch_latest_job_info(self) -> CloudJobInfo:
         """Return the job info for the sync job."""
         if self._latest_job_info and self._latest_job_info.status in FINAL_STATUSES:
             return self._latest_job_info
 
-        self._latest_job_info = api_util.get_job_info(
-            job_id=self.job_id,
-            api_root=self.workspace.api_root,
-            client_id=self.workspace.client_id,
-            client_secret=self.workspace.client_secret,
-            bearer_token=self.workspace.bearer_token,
+        self._latest_job_info = CloudJobInfo.from_api_response(
+            api_util.get_job_info(
+                job_id=self.job_id,
+                api_root=self.workspace.api_root,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
         )
         return self._latest_job_info
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -53,6 +53,7 @@ from airbyte.cloud.connectors import (
     CloudSource,
     CustomCloudSourceDefinition,
 )
+from airbyte.cloud.models import CloudWorkspaceInfo
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.destinations.base import Destination
 from airbyte.exceptions import AirbyteError
@@ -61,7 +62,6 @@ from airbyte.exceptions import AirbyteError
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from airbyte._util.api_imports import WorkspaceResponse
     from airbyte.secrets.base import SecretString
     from airbyte.sources.base import Source
 
@@ -647,18 +647,21 @@ class CloudWorkspace:
         *,
         name_filter: Callable | None = None,
         limit: int | None = None,
-    ) -> list[WorkspaceResponse]:
+    ) -> list[CloudWorkspaceInfo]:
         """List workspaces available to the current credentials, with an optional limit."""
-        return api_util.list_workspaces(
-            workspace_id="",
-            api_root=self.api_root,
-            name=name,
-            name_filter=name_filter,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            bearer_token=self.bearer_token,
-            limit=limit,
-        )
+        return [
+            CloudWorkspaceInfo.from_api_response(workspace)
+            for workspace in api_util.list_workspaces(
+                workspace_id="",
+                api_root=self.api_root,
+                name=name,
+                name_filter=name_filter,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+                limit=limit,
+            )
+        ]
 
     def rename(
         self,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -22,6 +22,7 @@ from airbyte._util import api_util
 from airbyte.cloud.client import CloudClient
 from airbyte.cloud.connectors import CustomCloudSourceDefinition
 from airbyte.cloud.constants import FAILED_STATUSES
+from airbyte.cloud.models import JobTypeEnum
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.constants import (
     MCP_CONFIG_API_URL,
@@ -47,7 +48,6 @@ CLOUD_AUTH_TIP_TEXT = (
     "will be used to authenticate with the Airbyte Cloud API."
 )
 WORKSPACE_ID_TIP_TEXT = "Workspace ID. Defaults to `AIRBYTE_CLOUD_WORKSPACE_ID` env var."
-JobType = Literal["sync", "reset", "refresh", "clear"]
 
 
 class CloudSourceResult(BaseModel):
@@ -747,7 +747,7 @@ def list_cloud_sync_jobs(
         ),
     ],
     job_type: Annotated[
-        JobType | None,
+        JobTypeEnum | None,
         Field(
             description=(
                 "Filter by job type. Options: 'sync', 'reset', 'refresh', 'clear'. "

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -13,7 +13,6 @@ __all__: list[str] = []
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
-from airbyte_api.models import JobTypeEnum
 from fastmcp import Context, FastMCP
 from fastmcp_extensions import get_mcp_config, mcp_tool, register_mcp_tools
 from pydantic import BaseModel, Field
@@ -48,6 +47,7 @@ CLOUD_AUTH_TIP_TEXT = (
     "will be used to authenticate with the Airbyte Cloud API."
 )
 WORKSPACE_ID_TIP_TEXT = "Workspace ID. Defaults to `AIRBYTE_CLOUD_WORKSPACE_ID` env var."
+JobType = Literal["sync", "reset", "refresh", "clear"]
 
 
 class CloudSourceResult(BaseModel):
@@ -747,7 +747,7 @@ def list_cloud_sync_jobs(
         ),
     ],
     job_type: Annotated[
-        JobTypeEnum | None,
+        JobType | None,
         Field(
             description=(
                 "Filter by job type. Options: 'sync', 'reset', 'refresh', 'clear'. "
@@ -1364,9 +1364,9 @@ def list_cloud_workspaces(
 
     return [
         CloudWorkspaceResult(
-            workspace_id=ws.get("workspaceId", ""),
-            workspace_name=ws.get("name", ""),
-            organization_id=ws.get("organizationId", ""),
+            workspace_id=ws.workspace_id,
+            workspace_name=ws.name,
+            organization_id=ws.organization_id or "",
         )
         for ws in workspaces
     ]

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1253,7 +1253,7 @@ def list_deployed_cloud_connections(
                     continue
 
                 last_completed_job_status = job_status
-                last_job_status = str(job_status.value) if job_status else None
+                last_job_status = str(job_status) if job_status else None
                 last_job_id = sync_result.job_id
                 last_job_time = sync_result.start_time.isoformat()
                 break

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1253,7 +1253,7 @@ def list_deployed_cloud_connections(
                     continue
 
                 last_completed_job_status = job_status
-                last_job_status = job_status.value if job_status else None
+                last_job_status = job_status.value
                 last_job_id = sync_result.job_id
                 last_job_time = sync_result.start_time.isoformat()
                 break

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -782,7 +782,7 @@ def list_cloud_sync_jobs(
     jobs = [
         SyncJobResult(
             job_id=sync_result.job_id,
-            status=str(sync_result.get_job_status()),
+            status=sync_result.get_job_status().value,
             bytes_synced=sync_result.bytes_synced,
             records_synced=sync_result.records_synced,
             start_time=sync_result.start_time.isoformat(),
@@ -1253,7 +1253,7 @@ def list_deployed_cloud_connections(
                     continue
 
                 last_completed_job_status = job_status
-                last_job_status = str(job_status) if job_status else None
+                last_job_status = job_status.value if job_status else None
                 last_job_id = sync_result.job_id
                 last_job_time = sync_result.start_time.isoformat()
                 break

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -196,6 +196,73 @@ def test_rename_workspace_forwards_request(
     assert captured_request.workspace_update_request.name == "Renamed workspace"
 
 
+def test_patch_connection_normalizes_status_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify string connection statuses are normalized for the generated SDK."""
+    captured_request = None
+
+    def patch_connection(
+        request: api.PatchConnectionRequest,
+    ) -> api.PatchConnectionResponse:
+        nonlocal captured_request
+        captured_request = request
+        raw_response = requests.Response()
+        raw_response.url = "https://api.airbyte.com/v1/connections/connection-1"
+        return api.PatchConnectionResponse(
+            content_type="application/json",
+            status_code=200,
+            raw_response=raw_response,
+            connection_response=_connection_response("Connection", 1),
+        )
+
+    airbyte_instance = SimpleNamespace(
+        connections=SimpleNamespace(patch_connection=patch_connection)
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    api_util.patch_connection(
+        connection_id="connection-1",
+        api_root="https://api.airbyte.com/v1",
+        client_id=None,
+        client_secret=None,
+        bearer_token=SecretString("token"),
+        status="inactive",
+    )
+
+    assert captured_request is not None
+    assert (
+        captured_request.connection_patch_request.status
+        == models.ConnectionStatusEnum.INACTIVE
+    )
+
+
+def test_patch_connection_rejects_invalid_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify invalid string connection statuses produce PyAirbyte errors."""
+    airbyte_instance = SimpleNamespace(connections=SimpleNamespace())
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    with pytest.raises(PyAirbyteInputError, match="`status` must be one of"):
+        api_util.patch_connection(
+            connection_id="connection-1",
+            api_root="https://api.airbyte.com/v1",
+            client_id=None,
+            client_secret=None,
+            bearer_token=SecretString("token"),
+            status="paused",
+        )
+
+
 @pytest.mark.parametrize(
     "workspace_name,should_delete",
     [

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -212,6 +212,7 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
     )
 
     assert captured_limit is None
+    assert all(isinstance(workspace, CloudWorkspaceInfo) for workspace in result)
     assert [workspace.name for workspace in result] == ["target-one"]
 
 

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -8,6 +8,7 @@ from airbyte import constants
 from airbyte._util import api_util
 from airbyte.cloud import _credentials as cloud_credentials
 from airbyte.cloud.client import CloudClient
+from airbyte.cloud.models import CloudWorkspaceInfo
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteMissingResourceError, PyAirbyteInputError
@@ -191,9 +192,9 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
         nonlocal captured_limit
         captured_limit = limit
         return [
-            {"name": "miss"},
-            {"name": "target-one"},
-            {"name": "target-two"},
+            {"name": "miss", "workspaceId": "workspace-miss"},
+            {"name": "target-one", "workspaceId": "workspace-target-one"},
+            {"name": "target-two", "workspaceId": "workspace-target-two"},
         ]
 
     monkeypatch.setattr(
@@ -211,7 +212,7 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
     )
 
     assert captured_limit is None
-    assert result == [{"name": "target-one"}]
+    assert [workspace.name for workspace in result] == ["target-one"]
 
 
 def test_cloud_client_create_workspace_uses_default_organization_id(
@@ -240,6 +241,7 @@ def test_cloud_client_create_workspace_uses_default_organization_id(
         organization_id="organization-id",
     ).create_workspace(name="New workspace")
 
+    assert isinstance(workspace, CloudWorkspaceInfo)
     assert workspace.workspace_id == "workspace-id"
     assert captured_organization_id == "organization-id"
 
@@ -265,6 +267,7 @@ def test_cloud_client_rename_workspace_forwards_inputs(
         name="Renamed workspace",
     )
 
+    assert isinstance(workspace, CloudWorkspaceInfo)
     assert workspace.name == "Renamed workspace"
     assert captured_kwargs["workspace_id"] == "workspace-id"
     assert captured_kwargs["name"] == "Renamed workspace"

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -214,6 +214,7 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
     assert captured_limit is None
     assert all(isinstance(workspace, CloudWorkspaceInfo) for workspace in result)
     assert [workspace.name for workspace in result] == ["target-one"]
+    assert [workspace.workspace_id for workspace in result] == ["workspace-target-one"]
 
 
 def test_cloud_client_create_workspace_uses_default_organization_id(

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Callable, cast
 
 import pytest
-from airbyte._util.api_imports import JobStatusEnum
+from airbyte.cloud.models import JobStatusEnum
 from airbyte.mcp import cloud as cloud_mcp
 from airbyte.mcp.cloud import (
     CloudConnectionResult,

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[2]
+RESTRICTED_IMPORTS_BY_PATH = {
+    Path("airbyte/cli"): ("airbyte_api", "airbyte._util.api_imports"),
+    Path("airbyte/mcp"): ("airbyte_api", "airbyte._util.api_imports"),
+    Path("airbyte/cloud/client.py"): ("airbyte_api", "airbyte._util.api_imports"),
+    Path("airbyte/cloud/workspaces.py"): ("airbyte_api", "airbyte._util.api_imports"),
+}
+
+
+def _python_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    return sorted(path.rglob("*.py"))
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+            imported_modules.extend(
+                f"{node.module}.{alias.name}" for alias in node.names
+            )
+    return imported_modules
+
+
+def _is_restricted_import(imported_module: str, restricted_import: str) -> bool:
+    return imported_module == restricted_import or imported_module.startswith(
+        f"{restricted_import}."
+    )
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "restricted_imports"),
+    [
+        pytest.param(relative_path, restricted_imports, id=relative_path.as_posix())
+        for relative_path, restricted_imports in RESTRICTED_IMPORTS_BY_PATH.items()
+    ],
+)
+def test_public_modules_do_not_import_generated_api_models(
+    relative_path: Path,
+    restricted_imports: tuple[str, ...],
+) -> None:
+    violations: list[str] = []
+    for file_path in _python_files(REPO_ROOT / relative_path):
+        for imported_module in _imported_modules(file_path):
+            for restricted_import in restricted_imports:
+                if _is_restricted_import(imported_module, restricted_import):
+                    violations.append(
+                        f"{file_path.relative_to(REPO_ROOT)} imports {imported_module}"
+                    )
+
+    assert not violations, (
+        "Public CLI, MCP, and workspace modules must not import generated Airbyte API "
+        "models directly. Wrap generated API models in PyAirbyte-owned response models "
+        "before exposing them through public or presentation-layer modules.\n"
+        + "\n".join(violations)
+    )

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -119,10 +119,12 @@ def test_public_modules_do_not_reference_generated_api_model_namespaces(
     violations: list[str] = []
     for file_path in _python_files(REPO_ROOT / relative_path):
         for reference in _attribute_references(file_path):
-            if reference in restricted_references:
-                violations.append(
-                    f"{file_path.relative_to(REPO_ROOT)} references {reference}"
-                )
+            for restricted_reference in restricted_references:
+                if _is_restricted_import(reference, restricted_reference):
+                    violations.append(
+                        f"{file_path.relative_to(REPO_ROOT)} references {reference}"
+                    )
+                    break
     assert not violations, (
         "Public CLI, MCP, and cloud modules must not reference generated Airbyte API "
         "model namespaces through internal utilities. Keep generated API models behind "

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Validate public modules do not import generated Airbyte API models directly."""
+
 from __future__ import annotations
 
 import ast
@@ -23,7 +25,10 @@ def _python_files(path: Path) -> list[Path]:
 
 
 def _imported_modules(path: Path) -> list[str]:
-    tree = ast.parse(path.read_text(), filename=str(path))
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        pytest.fail(f"Syntax error parsing {path}: {exc}")
     imported_modules: list[str] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -16,8 +16,8 @@ PUBLIC_MODULE_RESTRICTED_IMPORTS = {
     Path("airbyte/cloud"): ("airbyte_api", "airbyte._util.api_imports"),
 }
 PUBLIC_MODULE_RESTRICTED_REFERENCES = {
-    Path("airbyte/cli"): ("api_util.models", ".value"),
-    Path("airbyte/mcp"): ("api_util.models", ".value"),
+    Path("airbyte/cli"): ("api_util.models",),
+    Path("airbyte/mcp"): ("api_util.models",),
     Path("airbyte/cloud"): ("api_util.models",),
 }
 
@@ -123,11 +123,6 @@ def test_public_modules_do_not_reference_generated_api_model_namespaces(
                 violations.append(
                     f"{file_path.relative_to(REPO_ROOT)} references {reference}"
                 )
-            if ".value" in restricted_references and reference.endswith(".value"):
-                violations.append(
-                    f"{file_path.relative_to(REPO_ROOT)} references {reference}"
-                )
-
     assert not violations, (
         "Public CLI, MCP, and cloud modules must not reference generated Airbyte API "
         "model namespaces through internal utilities. Keep generated API models behind "

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -57,6 +57,24 @@ def _attribute_references(path: Path) -> list[str]:
     return references
 
 
+def _api_util_model_reference_aliases(path: Path) -> tuple[str, ...]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        pytest.fail(f"Syntax error parsing {path}: {exc}")
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "airbyte._util.api_util":
+                    aliases.add(f"{alias.asname or alias.name}.models")
+        elif isinstance(node, ast.ImportFrom) and node.module == "airbyte._util":
+            for alias in node.names:
+                if alias.name == "api_util":
+                    aliases.add(f"{alias.asname or alias.name}.models")
+    return tuple(sorted(aliases))
+
+
 def _attribute_reference(node: ast.Attribute) -> str:
     parts: list[str] = []
     current: ast.AST = node
@@ -72,6 +90,34 @@ def _is_restricted_import(imported_module: str, restricted_import: str) -> bool:
     return imported_module == restricted_import or imported_module.startswith(
         f"{restricted_import}."
     )
+
+
+@pytest.mark.linting
+@pytest.mark.parametrize(
+    ("source", "expected_reference"),
+    [
+        pytest.param(
+            "from airbyte._util import api_util as au\nvalue = au.models.JobTypeEnum.SYNC\n",
+            "au.models",
+            id="from_import_alias",
+        ),
+        pytest.param(
+            "import airbyte._util.api_util as au\nvalue = au.models.JobTypeEnum.SYNC\n",
+            "au.models",
+            id="import_alias",
+        ),
+    ],
+)
+def test_api_util_model_reference_aliases(
+    tmp_path: Path,
+    source: str,
+    expected_reference: str,
+) -> None:
+    """Verify aliases for `api_util.models` references are restricted."""
+    file_path = tmp_path / "module.py"
+    file_path.write_text(source, encoding="utf-8")
+
+    assert expected_reference in _api_util_model_reference_aliases(file_path)
 
 
 @pytest.mark.linting
@@ -118,8 +164,12 @@ def test_public_modules_do_not_reference_generated_api_model_namespaces(
     """Check that public modules don't reach through internal model namespaces."""
     violations: list[str] = []
     for file_path in _python_files(REPO_ROOT / relative_path):
+        file_restricted_references = (
+            *restricted_references,
+            *_api_util_model_reference_aliases(file_path),
+        )
         for reference in _attribute_references(file_path):
-            for restricted_reference in restricted_references:
+            for restricted_reference in file_restricted_references:
                 if _is_restricted_import(reference, restricted_reference):
                     violations.append(
                         f"{file_path.relative_to(REPO_ROOT)} references {reference}"

--- a/tests/unit_tests/test_public_api_imports.py
+++ b/tests/unit_tests/test_public_api_imports.py
@@ -10,11 +10,15 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).parents[2]
-RESTRICTED_IMPORTS_BY_PATH = {
+PUBLIC_MODULE_RESTRICTED_IMPORTS = {
     Path("airbyte/cli"): ("airbyte_api", "airbyte._util.api_imports"),
     Path("airbyte/mcp"): ("airbyte_api", "airbyte._util.api_imports"),
-    Path("airbyte/cloud/client.py"): ("airbyte_api", "airbyte._util.api_imports"),
-    Path("airbyte/cloud/workspaces.py"): ("airbyte_api", "airbyte._util.api_imports"),
+    Path("airbyte/cloud"): ("airbyte_api", "airbyte._util.api_imports"),
+}
+PUBLIC_MODULE_RESTRICTED_REFERENCES = {
+    Path("airbyte/cli"): ("api_util.models", ".value"),
+    Path("airbyte/mcp"): ("api_util.models", ".value"),
+    Path("airbyte/cloud"): ("api_util.models",),
 }
 
 
@@ -41,20 +45,44 @@ def _imported_modules(path: Path) -> list[str]:
     return imported_modules
 
 
+def _attribute_references(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        pytest.fail(f"Syntax error parsing {path}: {exc}")
+    references: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            references.append(_attribute_reference(node))
+    return references
+
+
+def _attribute_reference(node: ast.Attribute) -> str:
+    parts: list[str] = []
+    current: ast.AST = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
 def _is_restricted_import(imported_module: str, restricted_import: str) -> bool:
     return imported_module == restricted_import or imported_module.startswith(
         f"{restricted_import}."
     )
 
 
+@pytest.mark.linting
 @pytest.mark.parametrize(
     ("relative_path", "restricted_imports"),
     [
         pytest.param(relative_path, restricted_imports, id=relative_path.as_posix())
-        for relative_path, restricted_imports in RESTRICTED_IMPORTS_BY_PATH.items()
+        for relative_path, restricted_imports in PUBLIC_MODULE_RESTRICTED_IMPORTS.items()
     ],
 )
-def test_public_modules_do_not_import_generated_api_models(
+def test_public_modules_do_not_import_generated_api_model_modules(
     relative_path: Path,
     restricted_imports: tuple[str, ...],
 ) -> None:
@@ -68,8 +96,40 @@ def test_public_modules_do_not_import_generated_api_models(
                     )
 
     assert not violations, (
-        "Public CLI, MCP, and workspace modules must not import generated Airbyte API "
+        "Public CLI, MCP, and cloud modules must not import generated Airbyte API "
         "models directly. Wrap generated API models in PyAirbyte-owned response models "
         "before exposing them through public or presentation-layer modules.\n"
         + "\n".join(violations)
+    )
+
+
+@pytest.mark.linting
+@pytest.mark.parametrize(
+    ("relative_path", "restricted_references"),
+    [
+        pytest.param(relative_path, restricted_references, id=relative_path.as_posix())
+        for relative_path, restricted_references in PUBLIC_MODULE_RESTRICTED_REFERENCES.items()
+    ],
+)
+def test_public_modules_do_not_reference_generated_api_model_namespaces(
+    relative_path: Path,
+    restricted_references: tuple[str, ...],
+) -> None:
+    """Check that public modules don't reach through internal model namespaces."""
+    violations: list[str] = []
+    for file_path in _python_files(REPO_ROOT / relative_path):
+        for reference in _attribute_references(file_path):
+            if reference in restricted_references:
+                violations.append(
+                    f"{file_path.relative_to(REPO_ROOT)} references {reference}"
+                )
+            if ".value" in restricted_references and reference.endswith(".value"):
+                violations.append(
+                    f"{file_path.relative_to(REPO_ROOT)} references {reference}"
+                )
+
+    assert not violations, (
+        "Public CLI, MCP, and cloud modules must not reference generated Airbyte API "
+        "model namespaces through internal utilities. Keep generated API models behind "
+        "internal helpers or PyAirbyte-owned response models.\n" + "\n".join(violations)
     )


### PR DESCRIPTION
## Summary
- Adds PyAirbyte-owned public Cloud API models for workspace, connection, job, source, destination, and custom source definition responses so public Cloud/MCP surfaces no longer expose generated `airbyte_api` response models.
- Adds PyAirbyte-owned `JobStatusEnum` and `JobTypeEnum` values for public job status/type signatures; generated Speakeasy enums stay behind `airbyte._util.api_util` conversion boundaries.
- Adds an explicit release-path public API import guard in CI (`public-api-import-guard`) that blocks `airbyte_api` and `airbyte._util.api_imports` imports plus generated model namespace references from public CLI/MCP/Cloud modules.
- Addresses follow-up review feedback by normalizing string connection statuses in `patch_connection()`, widening `CloudConnection.get_previous_sync_logs()` to accept string job types, strengthening restricted-reference matching, hardening checkout credentials, and cleaning workflow comments.

Local validation passed:
- `uv run ruff format --check airbyte/_util/api_util.py airbyte/cloud/connections.py tests/unit_tests/test_cloud_api_util.py tests/unit_tests/test_public_api_imports.py`
- `uv run ruff check airbyte/_util/api_util.py airbyte/cloud/connections.py tests/unit_tests/test_cloud_api_util.py tests/unit_tests/test_public_api_imports.py`
- `uv run pytest -q -m linting`
- `uv run pytest -q tests/unit_tests/test_cloud_api_util.py tests/unit_tests/test_public_api_imports.py tests/unit_tests/test_cloud_credentials.py`
- `uv run pyrefly check`

Link to Devin session: https://app.devin.ai/sessions/a1ddc40130ad4cf09fcf4b8cd7b82354
Requested by: @aaronsteers