### PR TITLE
ci: Upload coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@95395aac8c053577d0bc67eb7b74936c660c6f66 # v1.67.0
         with:
+          # TODO: Remove once actionlint supports GitHub's public-preview code-quality permission scope.
           actionlint_flags: -ignore 'unknown permission scope "code-quality"'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@95395aac8c053577d0bc67eb7b74936c660c6f66 # v1.67.0
         with:
+          actionlint_flags: -ignore 'unknown permission scope "code-quality"'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           level: error

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -36,6 +36,8 @@ jobs:
     # Common steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Install uv
       uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
       with:
@@ -108,6 +110,8 @@ jobs:
     # Common steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Install uv
       uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
       with:
@@ -194,6 +198,8 @@ jobs:
     # Common steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Install uv
       uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
       with:

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -28,7 +28,6 @@ jobs:
     name: Pytest (Fast)
     runs-on: ubuntu-latest
     permissions:
-      checks: write
       contents: read
       code-quality: write
       pull-requests: read

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -28,6 +28,7 @@ jobs:
     name: Pytest (Fast)
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read
@@ -100,6 +101,7 @@ jobs:
     name: Pytest (No Creds)
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read
@@ -181,6 +183,7 @@ jobs:
 
     runs-on: "${{ matrix.os }}-latest"
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Upload coverage to GitHub Code Quality
       if: always()
-      uses: actions/upload-code-coverage@v1
+      uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
       with:
         file: htmlcov/coverage.xml
         language: Python
@@ -147,7 +147,7 @@ jobs:
 
     - name: Upload coverage to GitHub Code Quality
       if: always()
-      uses: actions/upload-code-coverage@v1
+      uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
       with:
         file: htmlcov/coverage.xml
         language: Python
@@ -244,7 +244,7 @@ jobs:
 
     - name: Upload coverage to GitHub Code Quality
       if: always() && matrix.python-version == '3.10' && matrix.os == 'Ubuntu'
-      uses: actions/upload-code-coverage@v1
+      uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1
       with:
         file: htmlcov/coverage.xml
         language: Python

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -21,7 +21,6 @@ env:
 
 permissions:
   contents: read
-  code-quality: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -61,7 +61,7 @@ jobs:
       if: always()
       run: |
         uv run coverage html -d htmlcov
-        uv run coverage xml -o htmlcov/coverage.xml
+        uv run coverage xml --include="airbyte/*" -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
       if: always()
@@ -135,7 +135,7 @@ jobs:
       if: always()
       run: |
         uv run coverage html -d htmlcov
-        uv run coverage xml -o htmlcov/coverage.xml
+        uv run coverage xml --include="airbyte/*" -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
       if: always()
@@ -231,7 +231,7 @@ jobs:
       if: always()
       run: |
         uv run coverage html -d htmlcov
-        uv run coverage xml -o htmlcov/coverage.xml
+        uv run coverage xml --include="airbyte/*" -o htmlcov/coverage.xml
 
     - name: Upload coverage to GitHub Artifacts
       if: always()

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -27,6 +27,10 @@ jobs:
   pytest-fast:
     name: Pytest (Fast)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     steps:
     # Common steps:
     - name: Checkout code
@@ -95,6 +99,10 @@ jobs:
   pytest-no-creds:
     name: Pytest (No Creds)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     steps:
     # Common steps:
     - name: Checkout code
@@ -172,6 +180,10 @@ jobs:
       fail-fast: false
 
     runs-on: "${{ matrix.os }}-latest"
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     env:
       # Enforce UTF-8 encoding so Windows runners don't fail inside the connector code.
       # TODO: See if we can fully enforce this within PyAirbyte itself.

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -28,6 +28,7 @@ jobs:
     name: Pytest (Fast)
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       contents: read
       code-quality: write
       pull-requests: read
@@ -100,7 +101,6 @@ jobs:
     name: Pytest (No Creds)
     runs-on: ubuntu-latest
     permissions:
-      checks: write
       contents: read
       code-quality: write
       pull-requests: read

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -19,6 +19,11 @@ on:
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
+permissions:
+  contents: read
+  code-quality: write
+  pull-requests: read
+
 jobs:
   pytest-fast:
     name: Pytest (Fast)
@@ -61,6 +66,15 @@ jobs:
       with:
         name: fasttest-coverage
         path: htmlcov/
+
+    - name: Upload coverage to GitHub Code Quality
+      if: always()
+      uses: actions/upload-code-coverage@v1
+      with:
+        file: htmlcov/coverage.xml
+        language: Python
+        label: code-coverage/pytest-fast
+        fail-on-error: false
 
     - name: Upload logs to GitHub Artifacts
       if: failure()
@@ -122,6 +136,15 @@ jobs:
       with:
         name: nocreds-test-coverage
         path: htmlcov/
+
+    - name: Upload coverage to GitHub Code Quality
+      if: always()
+      uses: actions/upload-code-coverage@v1
+      with:
+        file: htmlcov/coverage.xml
+        language: Python
+        label: code-coverage/pytest-no-creds
+        fail-on-error: false
 
     - name: Upload logs to GitHub Artifacts
       if: failure()
@@ -205,6 +228,15 @@ jobs:
       with:
         name: py${{ matrix.python-version }}-${{ matrix.os }}-test-coverage
         path: htmlcov/
+
+    - name: Upload coverage to GitHub Code Quality
+      if: always() && matrix.python-version == '3.10' && matrix.os == 'Ubuntu'
+      uses: actions/upload-code-coverage@v1
+      with:
+        file: htmlcov/coverage.xml
+        language: Python
+        label: code-coverage/pytest
+        fail-on-error: false
 
     - name: Upload logs to GitHub Artifacts
       if: failure()


### PR DESCRIPTION
## Summary
- Add `actions/upload-code-coverage@v1` uploads for PyAirbyte's existing Cobertura XML reports from Pytest Fast, Pytest No Creds, and the representative full pytest matrix job.
- Scope `code-quality: write` to only the pytest jobs that upload coverage while keeping workflow-level read permissions for `contents` and `pull-requests`.
- Limit uploaded coverage XML to `airbyte/*` package files so GitHub Code Quality does not report stdlib or test-helper paths.
- Keep existing GitHub artifact uploads intact and make Code Quality uploads best-effort with `fail-on-error: false`.
- Add an actionlint ignore for GitHub's new public-preview `code-quality` permission scope until actionlint recognizes it upstream.

## Review & Testing Checklist for Human
- [ ] Confirm GitHub Code Quality is enabled for this repository so uploaded coverage appears on PRs.
- [ ] Confirm the three coverage labels are useful and not too noisy in the PR coverage UI.
- [ ] Let the `Run Tests` and actionlint workflows run once on this PR and confirm the Code Quality upload steps complete or produce actionable preview-period errors.

### Notes
- Requested by AJ Steers in Slack.
- Local validation: `yq e '.' .github/workflows/python_pytest.yml`, `yq e '.' .github/workflows/actionlint.yml`, and `git diff --check`.

---
[Devin session](https://app.devin.ai/sessions/8d50d98662104dc58f3bf41ea229b503)
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced code coverage workflow: limited coverage collection to project code and adjusted when reports are uploaded (always for fast/no-creds runs; full report from one specified environment).
  * Tightened CI permissions with explicit top-level and job-level permission settings.
  * Updated CI linting to suppress a specific workflow lint warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/PyAirbyte/pull/1036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->