### PR TITLE
ci: allow manual coverage test workflow runs

### DIFF
--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -15,6 +15,7 @@ on:
       branches:
       - main
     pull_request: {}
+    workflow_dispatch: {}
 
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}

--- a/.github/workflows/python_pytest.yml
+++ b/.github/workflows/python_pytest.yml
@@ -171,6 +171,7 @@ jobs:
     # Don't run on forks. Run on pushes to main, and on PRs that are not from forks.
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to the PyAirbyte `Run Tests` workflow.
- Ensures the coverage-producing full pytest job also runs on manual dispatch, not only on pushes to `main` or non-fork PRs.
- This lets maintainainers manually rerun coverage-producing tests from GitHub Actions when `main` coverage data is missing/stale or when a PR needs a coverage refresh after unrelated `main` changes.

## Review & Testing Checklist for Human
- [ ] Confirm the `Run Tests` workflow shows a manual "Run workflow" option after merge.
- [ ] If needed, manually dispatch the workflow on `main` and confirm GitHub Code Quality receives the coverage upload.

### Notes
- Requested by AJ Steers while validating GitHub Code Quality coverage uploads.
- Local validation: `yq e` parsed the workflow, `yq e '.on.workflow_dispatch'` returns `{}`, and `git diff --check` passed.
- `actionlint` is not installed in this VM, so I could not run it locally.

---
[Devin session](https://app.devin.ai/sessions/8d50d98662104dc58f3bf41ea229b503)

Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow to allow manual triggering of test runs.
  * Ensured the test job now runs when workflows are manually triggered in addition to existing triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/PyAirbyte/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->