### PR TITLE
ci: add explicit workflow permissions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -8,6 +8,9 @@ on:
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
+permissions:
+  contents: write
+
 jobs:
   python-autofix:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix-pr-command.yml
+++ b/.github/workflows/fix-pr-command.yml
@@ -15,6 +15,11 @@ on:
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   # This is copied from the `python_pytest.yml` file.
   # Only the first two steps of the job are different, and they check out the PR's branch.

--- a/.github/workflows/pydoc_preview.yml
+++ b/.github/workflows/pydoc_preview.yml
@@ -9,6 +9,9 @@ on:
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
+permissions:
+  contents: read
+
 jobs:
   preview_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -8,9 +8,7 @@ env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
 permissions:
-  contents: read
   issues: write
-  pull-requests: read
 
 jobs:
   slashCommandDispatch:

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -7,6 +7,11 @@ on:
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   slashCommandDispatch:
     # Only allow slash commands on pull request (not on issues)


### PR DESCRIPTION
## Summary
- Add explicit `GITHUB_TOKEN` permissions to the four workflows flagged by CodeQL for missing workflow permissions.
- Scope read-only docs preview to `contents: read`.
- Scope autofix to `contents: write` for committing/pushing formatting changes.
- Scope slash-command dispatch and fix-pr command workflows to the PR/comment permissions they use.

## Review & Testing Checklist for Human
- [ ] Confirm the four CodeQL alerts for missing workflow permissions are resolved after security scanning updates.
- [ ] Confirm the slash-command dispatch and fix-pr command workflows still have enough token access for PR lookups and comments.
- [ ] Confirm the autofix workflow can still push formatting commits when manually dispatched.

### Notes
Local validation run:
- `git diff --check`
- `actionlint -ignore 'unknown permission scope "code-quality"'`

GitHub code scanning API access returned `403 Resource not accessible by integration`, so I used the screenshot and affected workflow files to target the four open alerts.

Link to Devin session: https://app.devin.ai/sessions/e40fb30d0d02439eb6877f3b683c7e86
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to explicitly define access levels for repository operations, issue management, and pull request handling, implementing a principle of least privilege approach for automation pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airbytehq/PyAirbyte/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->