### PR TITLE
chore: widen cryptography constraint and bump CDK to 7.21.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "airbyte-api>=0.53.0,<1.0",
     "airbyte-cdk>=7.21.0.post4.dev27052511259,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
-    "cryptography>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1",
+    "cryptography>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1",  # 45.0.0/45.0.1 broke load_pem_private_key()
     "cyclopts>=4.0,<5.0",
     # TODO: Restore broader version constraints after verifying compatibility
     # "duckdb>=1.4.0,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "airbyte-api>=0.53.0,<1.0",
     "airbyte-cdk>=7.3.9,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
-    "cryptography>=44.0.0,<45.0.0",
+    "cryptography>=44.0.0",
     "cyclopts>=4.0,<5.0",
     # TODO: Restore broader version constraints after verifying compatibility
     # "duckdb>=1.4.0,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 dependencies = [
     "airbyte-api>=0.53.0,<1.0",
-    "airbyte-cdk>=7.3.9,<8.0.0",
+    "airbyte-cdk>=7.21.0.post4.dev27051402174,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
-    "cryptography>=44.0.0,!=45.0.0,!=45.0.1",
+    "cryptography>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1",
     "cyclopts>=4.0,<5.0",
     # TODO: Restore broader version constraints after verifying compatibility
     # "duckdb>=1.4.0,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 dependencies = [
     "airbyte-api>=0.53.0,<1.0",
-    "airbyte-cdk>=7.21.0.post4.dev27051402174,<8.0.0",
+    "airbyte-cdk>=7.21.0.post4.dev27052511259,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
     "cryptography>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1",
     "cyclopts>=4.0,<5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 dependencies = [
     "airbyte-api>=0.53.0,<1.0",
-    "airbyte-cdk>=7.21.0.post4.dev27052511259,<8.0.0",
+    "airbyte-cdk>=7.21.1,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
     "cryptography>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1",  # 45.0.0/45.0.1 broke load_pem_private_key()
     "cyclopts>=4.0,<5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "airbyte-api>=0.53.0,<1.0",
     "airbyte-cdk>=7.3.9,<8.0.0",
     "airbyte-protocol-models-pdv2>=0.13.0,<1.0",
-    "cryptography>=44.0.0",
+    "cryptography>=44.0.0,!=45.0.0,!=45.0.1",
     "cyclopts>=4.0,<5.0",
     # TODO: Restore broader version constraints after verifying compatibility
     # "duckdb>=1.4.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "airbyte-api", specifier = ">=0.53.0,<1.0" },
-    { name = "airbyte-cdk", specifier = ">=7.21.0.post4.dev27051402174,<8.0.0" },
+    { name = "airbyte-cdk", specifier = ">=7.21.0.post4.dev27052511259,<8.0.0" },
     { name = "airbyte-protocol-models-pdv2", specifier = ">=0.13.0,<1.0" },
     { name = "cryptography", specifier = ">=44.0.0,!=45.0.0,!=45.0.1,<47.0.0" },
     { name = "cyclopts", specifier = ">=4.0,<5.0" },
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "airbyte-cdk"
-version = "7.21.0.post4.dev27051402174"
+version = "7.21.0.post4.dev27052511259"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "airbyte-protocol-models-dataclasses" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "whenever" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/4d/291b246f336e98f863e9e13629fb8efa3ec3dc44b4ce0f46bf16bce72a5d/airbyte_cdk-7.21.0.post4.dev27051402174.tar.gz", hash = "sha256:17667839b9678aa5890686a601144b58273e9c2848412e7b650f3946a44db6b4", size = 569682, upload-time = "2026-06-06T03:32:18.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/77/5e384ae7d4a9038ee3f6f7b8554a08f6088ed0ae4c21b143b4defcf45272/airbyte_cdk-7.21.0.post4.dev27052511259.tar.gz", hash = "sha256:5ca86faa05852f2f9460b29a3f5b44e13b1769b584ccc985fb2cfce667fdeb6f", size = 569767, upload-time = "2026-06-06T04:26:19.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/f4/6208792a64bdc6f3389af3f2dd7f53c59bebb263274445537a2c92f350e3/airbyte_cdk-7.21.0.post4.dev27051402174-py3-none-any.whl", hash = "sha256:2521033a43f1b3640236e6211ecfbfe3e5ce910cd93906776e38960f34c69ad0", size = 799695, upload-time = "2026-06-06T03:32:16.261Z" },
+    { url = "https://files.pythonhosted.org/packages/95/58/5b01fd2f0512ee8b64cd8aec31652f1f04955bc3071a8afb0ffede31fd52/airbyte_cdk-7.21.0.post4.dev27052511259-py3-none-any.whl", hash = "sha256:be495ce37bc41a0e301e5936773960b9d033f19238ef9d240b2ee124c8da3992", size = 799693, upload-time = "2026-06-06T04:26:16.458Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -193,9 +193,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "airbyte-api", specifier = ">=0.53.0,<1.0" },
-    { name = "airbyte-cdk", specifier = ">=7.3.9,<8.0.0" },
+    { name = "airbyte-cdk", specifier = ">=7.21.0.post4.dev27051402174,<8.0.0" },
     { name = "airbyte-protocol-models-pdv2", specifier = ">=0.13.0,<1.0" },
-    { name = "cryptography", specifier = ">=44.0.0,!=45.0.0,!=45.0.1" },
+    { name = "cryptography", specifier = ">=44.0.0,!=45.0.0,!=45.0.1,<47.0.0" },
     { name = "cyclopts", specifier = ">=4.0,<5.0" },
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "airbyte-cdk"
-version = "7.6.5"
+version = "7.21.0.post4.dev27051402174"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "airbyte-protocol-models-dataclasses" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "whenever" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/07/c1e4190443a6ecaee6456b3809a59d6968da13e974cac8ecdecf75ea67ba/airbyte_cdk-7.6.5.tar.gz", hash = "sha256:b1c02a287eb0ac87ccf51cce92cbf8c55e7095146b509df984c526997938486c", size = 543495, upload-time = "2026-01-16T03:06:07.079Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/4d/291b246f336e98f863e9e13629fb8efa3ec3dc44b4ce0f46bf16bce72a5d/airbyte_cdk-7.21.0.post4.dev27051402174.tar.gz", hash = "sha256:17667839b9678aa5890686a601144b58273e9c2848412e7b650f3946a44db6b4", size = 569682, upload-time = "2026-06-06T03:32:18.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/f9/1a858ea603c32bd818fd4d9cb4c1ca882a16a5faaa2769ed695733b1fbfd/airbyte_cdk-7.6.5-py3-none-any.whl", hash = "sha256:2918b7e0c692d80253627c7c830d6272688f99fab7c6e008b8d8e1c90daca835", size = 773046, upload-time = "2026-01-16T03:06:04.987Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/6208792a64bdc6f3389af3f2dd7f53c59bebb263274445537a2c92f350e3/airbyte_cdk-7.21.0.post4.dev27051402174-py3-none-any.whl", hash = "sha256:2521033a43f1b3640236e6211ecfbfe3e5ce910cd93906776e38960f34c69ad0", size = 799695, upload-time = "2026-06-06T03:32:16.261Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "airbyte-api", specifier = ">=0.53.0,<1.0" },
-    { name = "airbyte-cdk", specifier = ">=7.21.0.post4.dev27052511259,<8.0.0" },
+    { name = "airbyte-cdk", specifier = ">=7.21.1,<8.0.0" },
     { name = "airbyte-protocol-models-pdv2", specifier = ">=0.13.0,<1.0" },
     { name = "cryptography", specifier = ">=44.0.0,!=45.0.0,!=45.0.1,<47.0.0" },
     { name = "cyclopts", specifier = ">=4.0,<5.0" },
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "airbyte-cdk"
-version = "7.21.0.post4.dev27052511259"
+version = "7.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "airbyte-protocol-models-dataclasses" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "whenever" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/77/5e384ae7d4a9038ee3f6f7b8554a08f6088ed0ae4c21b143b4defcf45272/airbyte_cdk-7.21.0.post4.dev27052511259.tar.gz", hash = "sha256:5ca86faa05852f2f9460b29a3f5b44e13b1769b584ccc985fb2cfce667fdeb6f", size = 569767, upload-time = "2026-06-06T04:26:19.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/12/5de6fa396b7770899da8138a7e815eb44de6fd649ac66e5c2b53f282aeb9/airbyte_cdk-7.21.1.tar.gz", hash = "sha256:42ca6da4d7bff43d23d9128301953e6d7145a493cbf476b289be3b262c65c16b", size = 568436, upload-time = "2026-06-07T04:33:59.074Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/58/5b01fd2f0512ee8b64cd8aec31652f1f04955bc3071a8afb0ffede31fd52/airbyte_cdk-7.21.0.post4.dev27052511259-py3-none-any.whl", hash = "sha256:be495ce37bc41a0e301e5936773960b9d033f19238ef9d240b2ee124c8da3992", size = 799693, upload-time = "2026-06-06T04:26:16.458Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0a/1cbfb85628705e2400498f93317f60d3acf394456fb22555ff5aa186de0e/airbyte_cdk-7.21.1-py3-none-any.whl", hash = "sha256:aedac9c41744b8610a310734d183f27d7ecc1907cbf22d3e09e76665ef093737", size = 799407, upload-time = "2026-06-07T04:33:56.334Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ requires-dist = [
     { name = "airbyte-api", specifier = ">=0.53.0,<1.0" },
     { name = "airbyte-cdk", specifier = ">=7.3.9,<8.0.0" },
     { name = "airbyte-protocol-models-pdv2", specifier = ">=0.13.0,<1.0" },
-    { name = "cryptography", specifier = ">=44.0.0" },
+    { name = "cryptography", specifier = ">=44.0.0,!=45.0.0,!=45.0.1" },
     { name = "cyclopts", specifier = ">=4.0,<5.0" },
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ requires-dist = [
     { name = "airbyte-api", specifier = ">=0.53.0,<1.0" },
     { name = "airbyte-cdk", specifier = ">=7.3.9,<8.0.0" },
     { name = "airbyte-protocol-models-pdv2", specifier = ">=0.13.0,<1.0" },
-    { name = "cryptography", specifier = ">=44.0.0,<45.0.0" },
+    { name = "cryptography", specifier = ">=44.0.0" },
     { name = "cyclopts", specifier = ">=4.0,<5.0" },
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },


### PR DESCRIPTION
## Summary

Widens `cryptography` from `>=44.0.0,<45.0.0` to `>=44.0.0,<47.0.0,!=45.0.0,!=45.0.1` — the negation constraints exclude 45.0.0/45.0.1 which had `load_pem_private_key()` regressions (fixed in 45.0.2+). PyAirbyte imports `cryptography` directly in `airbyte/_processors/sql/snowflake.py` for key-pair auth, so we keep the explicit dependency.

Bumps `airbyte-cdk` lower bound from `>=7.3.9` to `>=7.21.1` — CDK 7.21.1 includes the same widened cryptography constraint, so the two packages no longer conflict on resolution.

Restores `workflow_dispatch` trigger to `pypi_publish.yml` (removed by #944), which broke the `/prerelease` slash command. Adds security hardening (`persist-credentials: false`, conditional cache disable) and uses SHA-pinned action references.

Unblocks `boring-semantic-layer>=0.3.0` in downstream projects (specifically `airbytehq/airbyte-transforms-poc`) which transitively requires `cryptography>=45.0.3`.

Link to Devin session: https://app.devin.ai/sessions/9f900ef4021147adb369727617d08827
Requested by: @aaronsteers