### PR TITLE
ci: restore workflow_dispatch trigger to pypi_publish.yml for prereleases

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,6 +2,7 @@
 #
 # Triggers:
 # - release: published - When user clicks "Publish" on a draft release (downloads pre-built assets)
+# - workflow_dispatch - On-demand prerelease builds from a PR branch
 #
 # Authentication: This workflow expects GitHub OIDC for passwordless PyPI publishing.
 # For more info: https://docs.pypi.org/trusted-publishers/
@@ -11,6 +12,21 @@ name: Publish Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from (e.g., refs/pull/123/head)'
+        type: string
+        required: true
+      version_override:
+        description: 'Version string to publish (overrides dynamic versioning)'
+        type: string
+        required: true
+      publish:
+        description: 'Whether to publish to PyPI'
+        type: string
+        required: false
+        default: 'true'
 
 env:
   AIRBYTE_ANALYTICS_ID: ${{ vars.AIRBYTE_ANALYTICS_ID }}
@@ -26,13 +42,40 @@ jobs:
       name: PyPi
       url: https://pypi.org/p/airbyte
     steps:
+      # For release events: download pre-built assets
       - name: Download release assets
+        if: github.event_name == 'release'
         uses: robinraju/release-downloader@v1.12
         with:
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
           out-file-path: dist
 
+      # For workflow_dispatch (prereleases): checkout, override version, and build
+      - name: Checkout code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        if: github.event_name == 'workflow_dispatch'
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+
+      - name: Build package with version override
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          # Override dynamic versioning with the prerelease version
+          export UV_DYNAMIC_VERSIONING_BYPASS="$VERSION_OVERRIDE"
+          uv build
+        env:
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
+
       # Uses GitHub OIDC for passwordless authentication (see header comment)
       - name: Publish to PyPI
+        if: github.event_name == 'release' || inputs.publish == 'true'
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -54,15 +54,15 @@ jobs:
       # For workflow_dispatch (prereleases): checkout, override version, and build
       - name: Checkout code
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ github.event.inputs.git_ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
         if: github.event_name == 'workflow_dispatch'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
         with:
           enable-cache: false
 
@@ -73,9 +73,9 @@ jobs:
           export UV_DYNAMIC_VERSIONING_BYPASS="$VERSION_OVERRIDE"
           uv build
         env:
-          VERSION_OVERRIDE: ${{ inputs.version_override }}
+          VERSION_OVERRIDE: ${{ github.event.inputs.version_override }}
 
       # Uses GitHub OIDC for passwordless authentication (see header comment)
       - name: Publish to PyPI
-        if: github.event_name == 'release' || inputs.publish == 'true'
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
         uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
## Summary

PR #944 accidentally removed the `workflow_dispatch` trigger from `pypi_publish.yml`, breaking the `/prerelease` slash command. `prerelease-command.yml` dispatches `pypi_publish.yml` via `workflow_dispatch` with `git_ref`, `version_override`, and `publish` inputs — but the simplified workflow only had `release: published`.

This restores the trigger with conditional steps to handle both paths:
- **release**: downloads pre-built assets (existing behavior, unchanged)
- **workflow_dispatch**: checks out `inputs.git_ref`, builds with `UV_DYNAMIC_VERSIONING_BYPASS`, publishes

Security hardening for the dispatch path: `persist-credentials: false` on checkout, `enable-cache: false` on `setup-uv` (prevents cache poisoning from untrusted PR refs).

Requested by: @aaronsteers

Link to Devin session: https://app.devin.ai/sessions/9f900ef4021147adb369727617d08827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual prerelease publishing trigger with inputs for selecting a ref, overriding the package version, and toggling publish behavior, enabling flexible prerelease builds.
  * Updated publish behavior so release-triggered publishes remain unchanged while manual prerelease dispatches can opt into publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->