### PR TITLE
ci(release-drafter): adopt not-ready 3-step workflow, upgrade to v2.1.0

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -30,27 +30,26 @@ jobs:
           # Shallow clone is sufficient since we bypass dynamic versioning
           fetch-depth: 1
 
-      - name: Get release version (dry-run)
+      - name: Create draft release (not ready)
         uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
-        id: dry-run
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          dry-run: true
-
-      - name: Build package
-        env:
-          VERSION: ${{ steps.dry-run.outputs.tag-name }}
-        # Standardize by removing preceding 'v' char:
-        run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
-
-      - name: Create draft release with assets (not ready)
-        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        id: draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           not-ready: true
-          version: ${{ steps.dry-run.outputs.tag-name }}
+
+      - name: Build package
+        env:
+          VERSION: ${{ steps.draft.outputs.tag-name }}
+        # Standardize by removing preceding 'v' char:
+        run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
+
+      - name: Attach assets and finalize draft
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: ${{ steps.draft.outputs.tag-name }}
           attach-files: |
             dist/*.whl
             dist/*.tar.gz
@@ -82,10 +81,3 @@ jobs:
                 - 'docs'
               collapse-after: 3
               display-order: 999
-
-      - name: Finalize draft release (remove banner)
-        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: ${{ steps.dry-run.outputs.tag-name }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 1
 
       - name: Get release version (dry-run)
-        uses: aaronsteers/semantic-pr-release-drafter@v1.0.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
         id: dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,11 +44,12 @@ jobs:
         # Standardize by removing preceding 'v' char:
         run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
 
-      - name: Create or update draft release
-        uses: aaronsteers/semantic-pr-release-drafter@v1.0.0
+      - name: Create draft release with assets (not ready)
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          not-ready: true
           version: ${{ steps.dry-run.outputs.tag-name }}
           attach-files: |
             dist/*.whl
@@ -81,3 +82,10 @@ jobs:
                 - 'docs'
               collapse-after: 3
               display-order: 999
+
+      - name: Finalize draft release (remove banner)
+        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: ${{ steps.dry-run.outputs.tag-name }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create draft release (not ready)
         uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
-        id: draft
+        id: not-ready-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build package
         env:
-          VERSION: ${{ steps.draft.outputs.tag-name }}
+          VERSION: ${{ steps.not-ready-draft.outputs.tag-name }}
         # Standardize by removing preceding 'v' char:
         run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
 
@@ -49,7 +49,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ steps.draft.outputs.tag-name }}
+          version: ${{ steps.not-ready-draft.outputs.tag-name }}
           attach-files: |
             dist/*.whl
             dist/*.tar.gz


### PR DESCRIPTION
## Summary

Upgrades `semantic-pr-release-drafter` from `v1.0.0` to `v2.1.0` and adopts the new `not-ready` input to prevent admins from publishing a draft release while file assets are still being uploaded.

New flow (Pattern B — 2 calls to release-drafter):
```
not-ready: true (create draft with banner) → build → attach-files (finalize, banner removed)
```

Previously the dry-run + create were separate calls; now the first call also creates the draft with a WIP banner, and the second call attaches files and removes the banner in one step.

Depends on aaronsteers/semantic-pr-release-drafter#54 being released as v2.1.0.

Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/601932cfa6b54ec8a6145cd9300d43aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to generate draft releases more reliably.
  * Package builds now use the version from the draft release step, helping keep release versions aligned.
  * Improved the final release publishing flow by streamlining how draft releases are finalized and attached with assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**