### PR TITLE
fix(mcp): derive MCP endpoint path dynamically from MCP_SERVER_URL

### DIFF
--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -16,8 +16,15 @@ Environment variables:
 from __future__ import annotations
 
 import logging
+import os
+from urllib.parse import urlparse
 
-from airbyte.mcp.server import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, app
+from airbyte.mcp.server import (
+    DEFAULT_HTTP_HOST,
+    DEFAULT_HTTP_PORT,
+    MCP_SERVER_URL_ENV,
+    app,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -26,16 +33,28 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     """Start the Airbyte MCP server with HTTP transport."""
     logging.basicConfig(level=logging.INFO)
+
+    # When deployed behind a path-stripping LB (MCP_SERVER_URL has a path
+    # component like /cloud-mcp), serve the MCP endpoint at root so the
+    # public URL is just the base path. Otherwise keep the FastMCP default.
+    server_url = os.getenv(
+        MCP_SERVER_URL_ENV,
+        f"http://localhost:{DEFAULT_HTTP_PORT}",
+    )
+    mcp_path = "/" if urlparse(server_url).path.strip("/") else "/mcp"
+
     logger.info(
-        "Starting Airbyte MCP HTTP server on %s:%d",
+        "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",
         DEFAULT_HTTP_HOST,
         DEFAULT_HTTP_PORT,
+        mcp_path,
     )
 
     app.run(
         transport="streamable-http",
         host=DEFAULT_HTTP_HOST,
         port=DEFAULT_HTTP_PORT,
+        path=mcp_path,
         stateless_http=True,
     )
 

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -7,7 +7,9 @@ handled by `OIDCProxy` (configured in `server.py`).
 
 Environment variables:
 
-- `MCP_SERVER_URL`: Public base URL (for OIDC redirect callbacks)
+- `MCP_SERVER_URL`: Public base URL. Used for OIDC redirect callbacks and to
+  derive the MCP endpoint mount path (serves at `/` when the URL has a path
+  prefix, otherwise defaults to `/mcp`).
 - `OIDC_CONFIG_URL`: Keycloak OIDC discovery URL (enables auth with all three OIDC vars)
 - `OIDC_CLIENT_ID`: OIDC client identifier
 - `OIDC_CLIENT_SECRET`: OIDC client secret


### PR DESCRIPTION
## Summary

Mirrors [airbytehq/airbyte-ops-mcp#1002](https://github.com/airbytehq/airbyte-ops-mcp/pull/1002) for the cloud-mcp deployment.

The hosted cloud-mcp server is behind a path-stripping LB (`/cloud-mcp/*` → `/*`), but FastMCP defaults to mounting the streamable-http endpoint at `/mcp`. This forces users to configure `https://mcp.internal.airbyte.ai/cloud-mcp/mcp` — the trailing `/mcp` is redundant.

The fix derives the endpoint path from `MCP_SERVER_URL`:

```python
mcp_path = "/" if urlparse(server_url).path.strip("/") else "/mcp"
```

- `MCP_SERVER_URL=https://…/cloud-mcp` → serves at `/` → public URL is `/cloud-mcp`
- `MCP_SERVER_URL=http://localhost:8080` (default) → keeps `/mcp`

OIDC routes are unaffected — they're derived from `base_url`, not the MCP endpoint path.

Link to Devin session: https://app.devin.ai/sessions/5bfc7d5ac9544cf1be05a9b1631cc890
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The MCP HTTP service now automatically serves its endpoint based on the configured public base URL, including support for deployments behind a path-aware proxy.
  * If the public URL includes a path, the MCP endpoint is exposed at `/`; otherwise it uses the default `/mcp` route.
* **Bug Fixes**
  * Improved startup behavior and logging to reflect the active MCP route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._