### PR TITLE
chore(lint): enable A003 rule (no builtin shadowing in classes)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -86,7 +86,7 @@ ignore = [
     "INP001",  # Dir 'examples' is part of an implicit namespace package. Add an __init__.py.
 
     # TODO: Consider re-enabling these before release:
-    "A003",    # Class attribute 'type' is shadowing a Python builtin
+    # "A003",  # Class attribute 'type' is shadowing a Python builtin (now enforced)
     "BLE001",  # Do not catch blind exception: Exception
     "ERA001",  # Remove commented-out code
     "FIX002",  # Allow "TODO:" until release (then switch to requiring links via TDO003)


### PR DESCRIPTION
## Summary

Un-ignore `A003` which prevents class attributes from shadowing Python builtins (e.g. `type`, `id`, `list`). The codebase already has 0 violations — this just prevents future regressions.

No PR B (code compliance) needed since the codebase already complies.

Part of a set of 10 atomic proposals to increase ruff lint coverage in PyAirbyte.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to flag a previously excluded rule again, making linting stricter for future changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->