### PR TITLE
chore(lint): enable PLW0108 rule (no unnecessary lambdas)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -91,7 +91,7 @@ ignore = [
     "ERA001",  # Remove commented-out code
     "FIX002",  # Allow "TODO:" until release (then switch to requiring links via TDO003)
     "PLW0603", # Using the global statement to update _cache is discouraged
-    "PLW0108", # Lambda may be unnecessary; consider inlining inner function
+    # "PLW0108", # Lambda may be unnecessary; consider inlining inner function (now enforced)
     "TRY003",  # Allow exceptions to receive strings in constructors.
     # "TD003", # Require links for TODOs (now enabled)
     "UP038",   # Allow tuples instead of "|" syntax in `isinstance()` checks ("|" is sometimes slower)


### PR DESCRIPTION
## Summary

Un-ignore `PLW0108` which flags lambdas that simply wrap an inner function and can be replaced by the function reference directly (e.g. `lambda x: fn(x)` → `fn`). The codebase already has 0 violations — this just prevents future regressions.

No PR B (code compliance) needed since the codebase already complies.

Part of a set of 10 atomic proposals to increase ruff lint coverage in PyAirbyte.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers