### PR TITLE
chore(lint): enable SIM910 rule (no explicit None in dict.get)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -79,7 +79,7 @@ ignore = [
     "PLR6301", # Allow class methods that don't use 'self' (otherwise noisy)
     "RUF022",  # Allow unsorted __all__ (sometimes useful for grouping by type with pdoc)
     "S",       # flake8-bandit (noisy, security related)
-    "SIM910",  # Allow "None" as second argument to Dict.get(). "Explicit is better than implicit."
+    # "SIM910",  # Allow "None" as second argument to Dict.get() (now enforced)
     "TC006",   # Require quoted type names in cast() calls
     "TD002",   # Require author for TODOs
     "ASYNC1",  # flake8-trio (opinionated, noisy)


### PR DESCRIPTION
## Summary

Un-ignore `SIM910` which flags `dict.get(key, None)` → `dict.get(key)` since `None` is already the default return value. 72 existing violations, all auto-fixable via `ruff check --fix`.

PR B (code compliance) will be stacked on this branch with the auto-fixed changes.

Part of a set of 10 atomic proposals to increase ruff lint coverage in PyAirbyte.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers