### PR TITLE
chore(lint): enable PERF203 rule (no try-except in loops)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -75,7 +75,7 @@ ignore = [
     "ISC001",  # Conflicts with ruff auto-format
     "NPY",     # NumPy-specific rules
     "PIE790",  # Allow unnecssary 'pass' (sometimes useful for readability)
-    "PERF203", # exception handling in loop
+    # "PERF203", # exception handling in loop (now enforced)
     "PLR6301", # Allow class methods that don't use 'self' (otherwise noisy)
     "RUF022",  # Allow unsorted __all__ (sometimes useful for grouping by type with pdoc)
     "S",       # flake8-bandit (noisy, security related)

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -75,7 +75,6 @@ ignore = [
     "ISC001",  # Conflicts with ruff auto-format
     "NPY",     # NumPy-specific rules
     "PIE790",  # Allow unnecssary 'pass' (sometimes useful for readability)
-    # "PERF203", # exception handling in loop (now enforced)
     "PLR6301", # Allow class methods that don't use 'self' (otherwise noisy)
     "RUF022",  # Allow unsorted __all__ (sometimes useful for grouping by type with pdoc)
     "S",       # flake8-bandit (noisy, security related)


### PR DESCRIPTION
## Summary

Un-ignore `PERF203` which flags `try`/`except` blocks inside `for`/`while` loops. Exception handling in loops has a measurable performance cost and often indicates code that should use guard statements instead.

70 existing violations. PR B (stacked on this branch) will add `noqa` directives for existing violations.

```diff
# .ruff.toml ignore list
-    "PERF203", # exception handling in loop
+    # "PERF203", # exception handling in loop (now enforced)
```

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers