### PR TITLE
style(lint): add PERF203 noqa directives for existing violations

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -486,7 +486,7 @@ class ConnectorBase(abc.ABC):
                     self._peek_airbyte_message(message)
                     yield message
 
-                except Exception:
+                except Exception:  # noqa: PERF203
                     # This is likely a log message, so log it as INFO.
                     self._print_info_message(line)
 

--- a/airbyte/_message_iterators.py
+++ b/airbyte/_message_iterators.py
@@ -154,7 +154,7 @@ class AirbyteMessageIterator:
                 try:
                     # Let Pydantic handle the JSON decoding from the raw string
                     yield AirbyteMessage.model_validate_json(line)
-                except pydantic.ValidationError:
+                except pydantic.ValidationError:  # noqa: PERF203
                     # Handle JSON decoding errors (optional)
                     raise ValueError(f"Invalid JSON format in input string: {line}")  # noqa: B904
 

--- a/examples/run_downloadable_yaml_source.py
+++ b/examples/run_downloadable_yaml_source.py
@@ -23,7 +23,7 @@ failed_installs: dict[str, list[str]] = {}
 for yaml_connector in yaml_connectors:
     try:
         _ = get_source(yaml_connector, source_manifest=True)
-    except Exception as ex:
+    except Exception as ex:  # noqa: PERF203
         exception_type = type(ex).__name__
         if exception_type in failed_installs:
             failed_installs[exception_type].append(yaml_connector)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def test_pg_connection(host) -> bool:
             conn = psycopg.connect(pg_url)
             conn.close()
             return True
-        except psycopg.OperationalError:
+        except psycopg.OperationalError:  # noqa: PERF203
             logger.info(
                 f"Waiting for postgres to start (attempt {attempt + 1}/{max_attempts})"
             )
@@ -199,7 +199,7 @@ def new_postgres_db():
         try:
             postgres.reload()
             postgres_is_running = postgres.status == "running"
-        except docker.errors.NotFound:
+        except docker.errors.NotFound:  # noqa: PERF203
             attempts -= 1
             time.sleep(3)
     if not postgres_is_running:


### PR DESCRIPTION
## Summary

This PR targets PR #1059.

Adds `# noqa: PERF203` to 5 existing try-except-in-loop patterns that need case-by-case review before refactoring. Files affected:

- `airbyte/_connector_base.py` — exception handling in message processing loop
- `airbyte/_message_iterators.py` — generator exception handling
- `examples/run_downloadable_yaml_source.py` — example script
- `tests/conftest.py` (2 sites) — test fixtures

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers