### PR TITLE
chore(lint): enable ERA001 rule (flag commented-out code)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -88,7 +88,6 @@ ignore = [
     # TODO: Consider re-enabling these before release:
     "A003",    # Class attribute 'type' is shadowing a Python builtin
     "BLE001",  # Do not catch blind exception: Exception
-    "ERA001",  # Remove commented-out code
     "FIX002",  # Allow "TODO:" until release (then switch to requiring links via TDO003)
     "PLW0603", # Using the global statement to update _cache is discouraged
     "PLW0108", # Lambda may be unnecessary; consider inlining inner function


### PR DESCRIPTION
## Summary

Remove `ERA001` from the ignore list. `ERA` is already in the select list, so this enables enforcement of the rule which flags commented-out code blocks.

`ERA001` remains in the `unfixable` list to prevent `ruff check --fix` from silently deleting commented-out code — each instance requires manual review.

Existing violations will be addressed by a stacked compliance PR with `noqa` directives.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers