### PR TITLE
style(lint): add ERA001 noqa directives for existing violations

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -466,7 +466,7 @@ class ConnectorBase(abc.ABC):
                         "stream": "",
                         "data": {},
                         "emitted_at": 1234567890,
-                        # "namespace": "",  # We're knowingly omitting this to keep perf impact low.
+                        # "namespace": "",  # We're knowingly omitting this to keep perf impact low.  # noqa: ERA001
                     },
                 }
             )

--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -466,7 +466,8 @@ class ConnectorBase(abc.ABC):
                         "stream": "",
                         "data": {},
                         "emitted_at": 1234567890,
-                        # "namespace": "",  # We're knowingly omitting this to keep perf impact low.  # noqa: ERA001
+                        # Omitting "namespace" key to keep perf impact low.
+                        # "namespace": "",  # noqa: ERA001
                     },
                 }
             )

--- a/airbyte/_util/document_rendering.py
+++ b/airbyte/_util/document_rendering.py
@@ -44,8 +44,8 @@ class DocumentRenderer(BaseModel):
 
     # TODO: Add primary key and cursor key support:
     # https://github.com/airbytehq/pyairbyte/issues/319
-    # primary_key_properties: list[str]
-    # cursor_property: str | None
+    # primary_key_properties: list[str]  # noqa: ERA001
+    # cursor_property: str | None  # noqa: ERA001
 
     def render_document(self, record: dict[str, Any]) -> Document:
         """Render a record as a document.
@@ -85,7 +85,7 @@ class DocumentRenderer(BaseModel):
             )
 
         return Document(
-            # id=doc_id,  # TODD: Add support for primary key and doc ID generation.
+            # id=doc_id,  # TODD: Add support for primary key and doc ID generation.  # noqa: ERA001
             content=content,
             metadata={key: record[key] for key in self.metadata_properties},
         )

--- a/airbyte/_util/temp_files.py
+++ b/airbyte/_util/temp_files.py
@@ -41,7 +41,7 @@ def as_temp_files(files_contents: list[dict | str]) -> Generator[list[str], Any,
             Path(temp_file.name).chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
             # Don't close the file yet (breaks Windows)
-            # temp_file.close()
+            # temp_file.close()  # noqa: ERA001
             temp_files.append(temp_file)
         yield [file.name for file in temp_files]
     finally:

--- a/airbyte/caches/motherduck.py
+++ b/airbyte/caches/motherduck.py
@@ -59,7 +59,7 @@ class MotherDuckConfig(DuckDBConfig):
         return SecretString(
             f"duckdb:///md:{self.database}?motherduck_token={self.api_key}"
             # Not sure why this doesn't work. We have to override later in the flow.
-            # f"&schema={self.schema_name}"
+            # f"&schema={self.schema_name}"  # noqa: ERA001
         )
 
     @overrides

--- a/airbyte/cli/pyab.py
+++ b/airbyte/cli/pyab.py
@@ -349,7 +349,7 @@ def _resolve_destination_job(
             use_python=use_python_parsed,
         )
 
-    # else: # Treat the destination as a name.
+    # else: # Treat the destination as a name.  # noqa: ERA001
 
     return get_destination(
         name=destination,

--- a/airbyte/cloud/_connection_state.py
+++ b/airbyte/cloud/_connection_state.py
@@ -139,7 +139,7 @@ def _normalize_state_to_protocol(
             }
         ]
 
-    # state_type == "stream"
+    # state_type == "stream"  # noqa: ERA001
     if not parsed.stream_state:
         return []
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -435,7 +435,7 @@ class CloudWorkspace:
         if isinstance(destination, Destination):
             destination_conf_dict = destination._hydrated_config.copy()  # noqa: SLF001 (non-public API)
             destination_conf_dict["destinationType"] = destination.name.replace("destination-", "")
-            # raise ValueError(destination_conf_dict)
+            # raise ValueError(destination_conf_dict)  # noqa: ERA001
         else:
             destination_conf_dict = destination.copy()
             if "destinationType" not in destination_conf_dict:

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -2506,7 +2506,7 @@ def get_connection_artifact(
             return {"ERROR": "No state is set for this connection (stateType: not_set)"}
         return state
 
-    # artifact_type == "catalog"
+    # artifact_type == "catalog"  # noqa: ERA001
     catalog = connection.dump_raw_catalog()
     if catalog is None:
         return {"ERROR": "No catalog found for this connection"}

--- a/airbyte/registry.py
+++ b/airbyte/registry.py
@@ -134,7 +134,7 @@ class ConnectorMetadata(BaseModel):
         if InstallType.PYTHON in self.install_types:
             return InstallType.PYTHON
 
-        # Else: Java or Docker
+        # Else: Java or Docker  # noqa: ERA001
         return InstallType.DOCKER
 
 

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -175,7 +175,7 @@ def get_benchmark_source(
     return get_source(
         name="source-e2e-test",
         docker_image=True,
-        # docker_image="airbyte/source-e2e-test:latest",
+        # docker_image="airbyte/source-e2e-test:latest",  # noqa: ERA001
         config={
             "type": "BENCHMARK",
             "schema": "FIVE_STRING_COLUMNS",

--- a/airbyte/types.py
+++ b/airbyte/types.py
@@ -135,7 +135,7 @@ class SQLTypeConverter:
         except SQLTypeConversionError:
             print(f"Could not determine airbyte type from JSON schema: {json_schema_property_def}")
         except KeyError:
-            # pyrefly: ignore[unbound-name]
+            # pyrefly: ignore[unbound-name]  # noqa: ERA001
             print(f"Could not find SQL type for airbyte type: {airbyte_type}")
         else:
             # No exceptions were raised, so we can return the SQL type.

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -82,7 +82,7 @@ def run() -> None:
     # individual tools / prompts / resources show up in the left nav. This
     # monkey-patches the module-level `markdown_extensions` dict because pdoc
     # 16's `configure()` does not expose markdown extension options.
-    # pyrefly: ignore[unsupported-operation]
+    # pyrefly: ignore[unsupported-operation]  # noqa: ERA001
     pdoc.render_helpers.markdown_extensions["toc"] = {"depth": 3}
 
     pdoc.render.configure(

--- a/examples/run_bigquery_destination.py
+++ b/examples/run_bigquery_destination.py
@@ -51,7 +51,7 @@ def main() -> None:
         )
         write_result = destination.write(
             source,
-            # cache=False,  # Toggle comment to test with/without caching
+            # cache=False,  # Toggle comment to test with/without caching  # noqa: ERA001
         )
 
 

--- a/examples/run_file_source.py
+++ b/examples/run_file_source.py
@@ -19,5 +19,5 @@ source = ab.get_source(
 )
 source.check()
 
-# print(list(source.get_records("pokemon")))
+# print(list(source.get_records("pokemon")))  # noqa: ERA001
 source.read(cache=ab.new_local_cache("poke"))

--- a/examples/run_get_documents_from_github.py
+++ b/examples/run_get_documents_from_github.py
@@ -23,8 +23,8 @@ def main() -> None:
         title_property="title",
         content_properties=["body"],
         metadata_properties=["state", "url", "number"],
-        # primary_key_properties=["id"],
-        # cursor_property="updated_at",
+        # primary_key_properties=["id"],  # noqa: ERA001
+        # cursor_property="updated_at",  # noqa: ERA001
         render_metadata=True,
     ):
         rich.print(rich.markdown.Markdown(str(doc) + "\n\n" + str("-" * 40)))

--- a/examples/run_pokeapi.py
+++ b/examples/run_pokeapi.py
@@ -21,5 +21,5 @@ source = get_source(
 )
 source.check()
 
-# print(list(source.get_records("pokemon")))
+# print(list(source.get_records("pokemon")))  # noqa: ERA001
 source.read(cache=ab.new_local_cache("poke"))

--- a/examples/run_sync_to_destination_from_read_result.py
+++ b/examples/run_sync_to_destination_from_read_result.py
@@ -38,7 +38,7 @@ def get_my_destination() -> ab.Destination:
         },
         docker_image="airbyte/destination-duckdb:latest",
         # OR:
-        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",
+        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",  # noqa: ERA001
     )
 
 

--- a/examples/run_sync_to_destination_w_cache.py
+++ b/examples/run_sync_to_destination_w_cache.py
@@ -38,7 +38,7 @@ def get_my_destination() -> ab.Destination:
         },
         docker_image=True,
         # OR:
-        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",
+        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",  # noqa: ERA001
     )
 
 

--- a/examples/run_sync_to_destination_wo_cache.py
+++ b/examples/run_sync_to_destination_wo_cache.py
@@ -51,7 +51,7 @@ def get_my_destination() -> ab.Destination:
         },
         docker_image="airbyte/destination-duckdb:latest",
         # OR:
-        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",
+        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",  # noqa: ERA001
     )
 
 

--- a/tests/integration_tests/cloud/conftest.py
+++ b/tests/integration_tests/cloud/conftest.py
@@ -114,7 +114,7 @@ def deployable_dummy_source(*, use_docker: bool) -> Source:
         config={
             "count": 100,
         },
-        # install_if_missing=False,
+        # install_if_missing=False,  # noqa: ERA001
         docker_image=use_docker,
     )
 
@@ -150,8 +150,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """
     deployable_destination_fixtures: dict[str, str] = {
         # Ordered by priority (fastest first)
-        # "MotherDuck": "new_motherduck_destination",
-        # "Postgres": "new_remote_postgres_cache",
+        # "MotherDuck": "new_motherduck_destination",  # noqa: ERA001
+        # "Postgres": "new_remote_postgres_cache",  # noqa: ERA001
         "BigQuery": "new_bigquery_destination",
         "Snowflake": "new_snowflake_destination",
     }

--- a/tests/integration_tests/cloud/test_cloud_api_util.py
+++ b/tests/integration_tests/cloud/test_cloud_api_util.py
@@ -282,7 +282,7 @@ def test_get_bearer_token(
     "connector_id, connector_type, expect_success",
     [
         ("f45dd701-d1f0-4e8e-97c4-2b89c40ac928", "source", True),
-        # ("......-....-....-............", "destination", True),
+        # ("......-....-....-............", "destination", True),  # noqa: ERA001
     ],
 )
 def test_check_connector(

--- a/tests/integration_tests/cloud/test_cloud_sql_reads.py
+++ b/tests/integration_tests/cloud/test_cloud_sql_reads.py
@@ -79,7 +79,7 @@ def test_read_from_deployed_connection(
     assert len(data_as_list) == 100
 
     # TODO: Fails on BigQuery: https://github.com/airbytehq/PyAirbyte/issues/165
-    # pandas_df = dataset.to_pandas()
+    # pandas_df = dataset.to_pandas()  # noqa: ERA001
 
     pandas_df = pd.DataFrame(data_as_list)
 
@@ -196,7 +196,7 @@ def test_read_from_previous_job(
     assert len(data_as_list) == 100
 
     # TODO: Fails on BigQuery: https://github.com/airbytehq/PyAirbyte/issues/165
-    # pandas_df = dataset.to_pandas()
+    # pandas_df = dataset.to_pandas()  # noqa: ERA001
 
     pandas_df = pd.DataFrame(data_as_list)
 

--- a/tests/integration_tests/destinations/test_source_to_destination.py
+++ b/tests/integration_tests/destinations/test_source_to_destination.py
@@ -39,7 +39,7 @@ def new_duckdb_destination_executor() -> Executor:
     return get_connector_executor(
         name="destination-duckdb",
         docker_image="airbyte/destination-duckdb:latest",
-        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",
+        # pip_url="git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-integrations/connectors/destination-duckdb",  # noqa: ERA001
     )
 
 

--- a/tests/integration_tests/test_all_cache_types.py
+++ b/tests/integration_tests/test_all_cache_types.py
@@ -169,7 +169,7 @@ def test_faker_read(
         assert sum(1 for _ in arrow_dataset.to_batches()) == FAKER_SCALE_A / 10
 
     # TODO: Uncomment this line after resolving https://github.com/airbytehq/PyAirbyte/issues/165
-    # assert len(result["users"].to_pandas()) == FAKER_SCALE_A
+    # assert len(result["users"].to_pandas()) == FAKER_SCALE_A  # noqa: ERA001
 
 
 @pytest.mark.requires_creds

--- a/tests/integration_tests/test_bigquery_cache.py
+++ b/tests/integration_tests/test_bigquery_cache.py
@@ -13,7 +13,7 @@ def test_bigquery_props(
     new_bigquery_cache: ab.BigQueryCache,
 ) -> None:
     """Test that the BigQueryCache properties are set correctly."""
-    # assert new_bigquery_cache.credentials_path.endswith(".json")
+    # assert new_bigquery_cache.credentials_path.endswith(".json")  # noqa: ERA001
     assert new_bigquery_cache.dataset_name == new_bigquery_cache.schema_name, (
         "Dataset name should be the same as schema name."
     )

--- a/tests/integration_tests/test_source_test_fixture.py
+++ b/tests/integration_tests/test_source_test_fixture.py
@@ -386,7 +386,7 @@ def test_dataset_list_and_len(
 
     # Test the lazy dataset implementation
     lazy_dataset = source.get_records("stream1")
-    # assert len(stream_1) == 2  # This is not supported by the lazy dataset
+    # assert len(stream_1) == 2  # This is not supported by the lazy dataset  # noqa: ERA001
     lazy_dataset_list = list(lazy_dataset)
     # Make sure counts are correct
     assert len(list(lazy_dataset_list)) == 2

--- a/tests/integration_tests/test_state_handling.py
+++ b/tests/integration_tests/test_state_handling.py
@@ -175,15 +175,15 @@ def test_destination_state(
     e2e_test_destination: ab.Destination,
 ) -> None:
     """Test destination state handling."""
-    # config_a = source_faker_seed_a.get_config()
-    # config_a["always_updated"] = False  # disable ensuring new `updated_at` timestamps
-    # source_faker_seed_a.set_config(config_a)
+    # config_a = source_faker_seed_a.get_config()  # noqa: ERA001
+    # config_a["always_updated"] = False  # disable ensuring new `updated_at` timestamps  # noqa: ERA001
+    # source_faker_seed_a.set_config(config_a)  # noqa: ERA001
 
     cache = ab.new_local_cache("aj_test05")
 
     source_faker_seed_a.select_streams(["products", "users"])
     read_result = source_faker_seed_a.read(cache)
-    # assert read_result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2
+    # assert read_result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2  # noqa: ERA001
 
     cache_state_provider = cache.get_state_provider("source-faker")
     assert cache_state_provider.known_stream_names == {
@@ -198,7 +198,7 @@ def test_destination_state(
         read_result,
         state_cache=cache,
     )
-    # assert write_result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2
+    # assert write_result.processed_records == NUM_PRODUCTS + FAKER_SCALE_A * 2  # noqa: ERA001
     write_result_state_provider = write_result.get_state_provider()
     assert write_result_state_provider.known_stream_names == {
         "users",


### PR DESCRIPTION
## Summary

This PR targets PR #1061.

Adds `# noqa: ERA001` to 37 existing commented-out code blocks across 27 files. Each instance needs case-by-case review to determine whether the commented code should be removed or kept (with the noqa directive).

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers