### PR TITLE
chore(lint): enable T20 rule (no print() in library code)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -51,7 +51,7 @@ select = [
     "SLF",   # flake8-self
     "SLOT",  # flake8-slots
     "T10",   # debugger calls
-    # "T20", # flake8-print # TODO: Re-enable once we have logging
+    "T20",   # flake8-print (no print() in library code)
     "TCH",    # flake8-type-checking
     "TD",     # flake8-todos
     "TID",    # flake8-tidy-imports


### PR DESCRIPTION
## Summary

Uncomment `T20` (flake8-print) in the select list. `print()` calls in library code bypass log levels and pollute stdout — critical for a library consumed by downstream tools.

`T201` remains in the `unfixable` list to prevent `ruff check --fix` from silently deleting print statements.

Existing violations will be addressed by a stacked compliance PR with `noqa` directives.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to prevent `print()` statements in library code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->