### PR TITLE
style(lint): add T20 noqa directives for existing violations

### DIFF
--- a/airbyte/_util/meta.py
+++ b/airbyte/_util/meta.py
@@ -43,7 +43,7 @@ def set_mcp_mode() -> None:
     This should be called early in MCP server initialization to ensure
     proper detection and prevent interactive prompts.
     """
-    print(
+    print(  # noqa: T201
         "Running in MCP mode: "
         f"Airbyte Replication MCP v{get_version()} (Python v{python_version()})",
         file=sys.stderr,

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -102,7 +102,7 @@ def _setup_analytics() -> str | bool:
 
     if not _ANALYTICS_FILE.exists():
         # This is a one-time message to inform the user that we are tracking anonymous usage stats.
-        print(
+        print(  # noqa: T201
             "Thank you for using Airbyte!\n"
             "Anonymous usage reporting is currently enabled. For more information, please"
             " see https://docs.airbyte.com/telemetry",
@@ -127,7 +127,7 @@ def _setup_analytics() -> str | bool:
                 return analytics["anonymous_user_id"]
 
             issues.append("Provided analytics ID did not match the file. Rewriting the file.")
-            print(
+            print(  # noqa: T201
                 f"Received a user-provided analytics ID override in the '{_ENV_ANALYTICS_ID}' "
                 "environment variable.",
                 file=sys.stderr,
@@ -150,7 +150,7 @@ def _setup_analytics() -> str | bool:
 
     if DEBUG and issues:
         nl = "\n"
-        print(
+        print(  # noqa: T201
             f"One or more issues occurred when configuring usage tracking:\n{nl.join(issues)}",
             file=sys.stderr,
         )

--- a/airbyte/caches/util.py
+++ b/airbyte/caches/util.py
@@ -157,7 +157,7 @@ def get_colab_cache(
     cache_dir.mkdir(parents=True, exist_ok=True)
     db_file_path = cache_dir / f"{cache_name}.duckdb"
 
-    print(f"Using persistent PyAirbyte cache in Google Drive: `{db_file_path}`.")
+    print(f"Using persistent PyAirbyte cache in Google Drive: `{db_file_path}`.")  # noqa: T201
     return DuckDBCache(
         db_path=db_file_path,
         cache_dir=cache_dir,

--- a/airbyte/cli/pyab.py
+++ b/airbyte/cli/pyab.py
@@ -420,11 +420,11 @@ def validate(
             use_python=use_python,
         )
 
-    print("Getting `spec` output from connector...", file=sys.stderr)
+    print("Getting `spec` output from connector...", file=sys.stderr)  # noqa: T201
     connector_obj.print_config_spec(stderr=True)
 
     if config:
-        print("Running connector check...")
+        print("Running connector check...")  # noqa: T201
         config_dict: dict[str, Any] = _resolve_config(config)
         connector_obj.set_config(config_dict)
         connector_obj.check()
@@ -526,7 +526,7 @@ def benchmark(
         else get_noop_destination()
     )
 
-    print("Running benchmarks...", file=sys.stderr)
+    print("Running benchmarks...", file=sys.stderr)  # noqa: T201
     destination_obj.write(
         source_data=source_obj,
         cache=False,
@@ -621,7 +621,7 @@ def sync(
         use_python=use_python,
     )
 
-    print("Running sync...")
+    print("Running sync...")  # noqa: T201
     destination_obj.write(
         source_data=source_obj,
         cache=False,
@@ -749,7 +749,7 @@ def destination_smoke_test(  # noqa: PLR0913
     --config=./secrets/snowflake.json
     --reuse-namespace=zz_deleteme_20260318_2256`
     """
-    print("Resolving destination...", file=sys.stderr)
+    print("Resolving destination...", file=sys.stderr)  # noqa: T201
     destination_obj = _resolve_destination_job(
         destination=destination,
         config=config,
@@ -757,7 +757,7 @@ def destination_smoke_test(  # noqa: PLR0913
         use_python=use_python,
     )
 
-    print("Running destination smoke test...", file=sys.stderr)
+    print("Running destination smoke test...", file=sys.stderr)  # noqa: T201
     result = run_destination_smoke_test(
         destination=destination_obj,
         scenarios=scenarios,
@@ -767,11 +767,11 @@ def destination_smoke_test(  # noqa: PLR0913
         skip_preflight=skip_preflight,
     )
 
-    print(json.dumps(result.model_dump(), indent=2))
+    print(json.dumps(result.model_dump(), indent=2))  # noqa: T201
 
     if not result.success:
         if result.error:
-            print(f"Smoke test FAILED: {result.error}", file=sys.stderr)
+            print(f"Smoke test FAILED: {result.error}", file=sys.stderr)  # noqa: T201
         sys.exit(1)
 
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -317,7 +317,7 @@ class CloudWorkspace:
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
         )
-        print(f"Successfully connected to workspace: {self.workspace_url}")
+        print(f"Successfully connected to workspace: {self.workspace_url}")  # noqa: T201
 
     # Get sources, destinations, and connections
 

--- a/airbyte/logs.py
+++ b/airbyte/logs.py
@@ -157,7 +157,7 @@ def get_global_file_logger() -> logging.Logger | None:
         return None
 
     logfile_path = folder / f"airbyte-log-{str(ulid.ULID())[2:11]}.log"
-    print(f"Writing PyAirbyte logs to file: {logfile_path!s}", file=sys.stderr)
+    print(f"Writing PyAirbyte logs to file: {logfile_path!s}", file=sys.stderr)  # noqa: T201
 
     file_handler = logging.FileHandler(
         filename=logfile_path,
@@ -246,7 +246,7 @@ def get_global_stats_logger() -> structlog.BoundLogger:
         # No temp directory available, so return no-op logger without handlers
         return structlog.get_logger("airbyte.stats")
 
-    print(f"Writing PyAirbyte performance stats to file: {logfile_path!s}", file=sys.stderr)
+    print(f"Writing PyAirbyte performance stats to file: {logfile_path!s}", file=sys.stderr)  # noqa: T201
 
     # Remove any existing handlers
     for handler in logger.handlers:
@@ -303,7 +303,7 @@ def new_passthrough_file_logger(connector_name: str) -> logging.Logger:
     global_logger = get_global_file_logger()
     logfile_path = folder / f"{connector_name}-log-{str(ulid.ULID())[2:11]}.log"
     logfile_msg = f"Writing `{connector_name}` logs to file: {logfile_path!s}"
-    print(logfile_msg, file=sys.stderr)
+    print(logfile_msg, file=sys.stderr)  # noqa: T201
     if global_logger:
         global_logger.info(logfile_msg)
 

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -462,7 +462,7 @@ def read_source_stream_records(
         # Next we load a limited number of records from the generator into our list.
         records: list[dict[str, Any]] = list(islice(record_generator, max_records))
 
-        print(f"Retrieved {len(records)} records from stream '{stream_name}'", sys.stderr)
+        print(f"Retrieved {len(records)} records from stream '{stream_name}'", sys.stderr)  # noqa: T201
 
     except Exception as ex:
         tb_str = traceback.format_exc()

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -177,16 +177,16 @@ def main() -> None:
     It should not be called directly; instead, consult the MCP client documentation
     for instructions on how to connect to the server.
     """
-    print("Starting Airbyte MCP server.", file=sys.stderr)
+    print("Starting Airbyte MCP server.", file=sys.stderr)  # noqa: T201
     try:
         asyncio.run(app.run_stdio_async())
     except KeyboardInterrupt:
-        print("Airbyte MCP server interrupted by user.", file=sys.stderr)
+        print("Airbyte MCP server interrupted by user.", file=sys.stderr)  # noqa: T201
     except Exception as ex:
-        print(f"Error running Airbyte MCP server: {ex}", file=sys.stderr)
+        print(f"Error running Airbyte MCP server: {ex}", file=sys.stderr)  # noqa: T201
         sys.exit(1)
 
-    print("Airbyte MCP server stopped.", file=sys.stderr)
+    print("Airbyte MCP server stopped.", file=sys.stderr)  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/airbyte/progress.py
+++ b/airbyte/progress.py
@@ -432,7 +432,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         )
 
     def _log_sync_cancel(self) -> None:
-        print(
+        print(  # noqa: T201
             f"Canceled `{self.job_description}` sync at `{ab_datetime_now().strftime('%H:%M:%S')}`."
         )
         self._send_telemetry(
@@ -441,7 +441,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         )
 
     def _log_stream_read_start(self, stream_name: str) -> None:
-        print(
+        print(  # noqa: T201
             f"Read started on stream `{stream_name}` at "
             f"`{ab_datetime_now().strftime('%H:%M:%S')}`..."
         )
@@ -618,7 +618,7 @@ class ProgressTracker:  # noqa: PLR0904  # Too many public methods
         else:
             streams_str = f" ({len(streams)} streams)"
 
-        print(
+        print(  # noqa: T201
             f"Completed `{self.job_description}` sync at "
             f"`{ab_datetime_now().strftime('%H:%M:%S')}`{streams_str}."
         )

--- a/airbyte/secrets/base.py
+++ b/airbyte/secrets/base.py
@@ -257,7 +257,7 @@ class SecretHandle:
         This method is a convenience method that writes the secret to a file as text.
         """
         if not silent:
-            print(
+            print(  # noqa: T201
                 f"Writing secret '{self.secret_name.split('/')[-1]}' to '{file_path.absolute()!s}'"
             )
 

--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -1200,8 +1200,8 @@ class SqlProcessorBase(abc.ABC):
         )
 
         if DEBUG_MODE:
-            print(str(update_stmt))
-            print(str(insert_new_records_stmt))
+            print(str(update_stmt))  # noqa: T201
+            print(str(insert_new_records_stmt))  # noqa: T201
 
         with self.get_sql_connection() as conn:
             conn.execute(update_stmt)

--- a/airbyte/shared/state_writers.py
+++ b/airbyte/shared/state_writers.py
@@ -76,7 +76,7 @@ class StdOutStateWriter(StateWriterBase):
         state_message: AirbyteStateMessage,
     ) -> None:
         """Save or 'write' a state artifact."""
-        print(state_message.model_dump_json())
+        print(state_message.model_dump_json())  # noqa: T201
 
 
 class NoOpStateWriter(StateWriterBase):

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -42,7 +42,7 @@ def _regenerate_mcp_markdown() -> None:
     """
     script = pathlib.Path(__file__).parent.parent / "scripts" / "generate_mcp_markdown.py"
     if not script.exists():
-        print(f"[docs-generate] MCP markdown generator not found at {script}; skipping.")
+        print(f"[docs-generate] MCP markdown generator not found at {script}; skipping.")  # noqa: T201
         return
     try:
         spec = importlib.util.spec_from_file_location("_mcp_markdown_gen", script)
@@ -51,13 +51,13 @@ def _regenerate_mcp_markdown() -> None:
             raise RuntimeError(msg)  # noqa: TRY301
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        print("[docs-generate] Regenerating docs/mcp-generated/ ...")
+        print("[docs-generate] Regenerating docs/mcp-generated/ ...")  # noqa: T201
         module.generate(
             server_spec=module.DEFAULT_SERVER_SPEC,
             output=module.DEFAULT_OUTPUT,
         )
     except Exception as ex:
-        print(
+        print(  # noqa: T201
             f"[docs-generate] WARNING: failed to regenerate MCP Markdown docs: {ex}. "
             "pdoc will continue, but module pages may show missing include warnings.",
             file=sys.stderr,

--- a/examples/run_bigquery_faker.py
+++ b/examples/run_bigquery_faker.py
@@ -60,7 +60,7 @@ def main() -> None:
         result = source.read(cache)
 
         for name, records in result.streams.items():
-            print(f"Stream {name}: {len(records)} records")
+            print(f"Stream {name}: {len(records)} records")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/examples/run_declarative_manifest_source.py
+++ b/examples/run_declarative_manifest_source.py
@@ -166,7 +166,7 @@ schemas:
 
 source_manifest_dict = cast(dict, yaml.safe_load(SOURCE_MANIFEST_TEXT))
 
-print("Installing declarative source...")
+print("Installing declarative source...")  # noqa: T201
 source = get_source(
     "source-rick-and-morty",
     config={},
@@ -178,4 +178,4 @@ source.select_all_streams()
 result = source.read()
 
 for name, records in result.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+    print(f"Stream {name}: {len(records)} records")  # noqa: T201

--- a/examples/run_downloadable_yaml_source.py
+++ b/examples/run_downloadable_yaml_source.py
@@ -13,7 +13,7 @@ from airbyte import get_source
 
 yaml_connectors: list[str] = ab.get_available_connectors(install_type="yaml")
 
-print(
+print(  # noqa: T201
     f"Downloadable yaml sources ({len(yaml_connectors)}): \n- "
     + "\n- ".join(yaml_connectors)
 )
@@ -32,13 +32,13 @@ for yaml_connector in yaml_connectors:
 
 # Print any connector failures, grouped by the error message
 for error, connectors_failed in failed_installs.items():
-    print(
+    print(  # noqa: T201
         f"\nInstallation Errors ({len(failed_installs)}): {error}\n- "
         + "\n- ".join(connectors_failed)
         + "\n"
     )
 
-print("Running declarative source...")
+print("Running declarative source...")  # noqa: T201
 source = get_source(
     "source-pokeapi",
     config={
@@ -52,4 +52,4 @@ source.select_all_streams()
 result = source.read()
 
 for name, records in result.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+    print(f"Stream {name}: {len(records)} records")  # noqa: T201

--- a/examples/run_faker.py
+++ b/examples/run_faker.py
@@ -30,6 +30,6 @@ result = source.read(
     force_full_refresh=FORCE_FULL_REFRESH,
 )
 
-print("Read complete. Validating results...")
+print("Read complete. Validating results...")  # noqa: T201
 for name, records in result.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+    print(f"Stream {name}: {len(records)} records")  # noqa: T201

--- a/examples/run_faker_to_motherduck.py
+++ b/examples/run_faker_to_motherduck.py
@@ -38,4 +38,4 @@ cache = MotherDuckCache(
 result = source.read(cache=cache, force_full_refresh=True)
 
 for name, records in result.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+    print(f"Stream {name}: {len(records)} records")  # noqa: T201

--- a/examples/run_github.py
+++ b/examples/run_github.py
@@ -32,7 +32,7 @@ source.select_streams([
 ])
 
 result = source.read(cache=ab.new_local_cache("github"))
-print(result.processed_records)
+print(result.processed_records)  # noqa: T201
 
 for name, records in result.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+    print(f"Stream {name}: {len(records)} records")  # noqa: T201

--- a/examples/run_integ_test_source.py
+++ b/examples/run_integ_test_source.py
@@ -64,13 +64,13 @@ def main(
     cache = ab.new_local_cache()
     try:
         read_result = source.read(cache=cache)
-        print(
+        print(  # noqa: T201
             f"Read from `{connector_name}` was successful. ",
             f"Cache results were saved to: {cache.cache_dir}",
             f"Streams list: {', '.join(read_result.streams.keys())}",
         )
     except Exception:
-        print(
+        print(  # noqa: T201
             f"Read from `{connector_name}` failed. ",
             f"Cache files are located at: {cache.cache_dir}",
         )

--- a/examples/run_snowflake_faker.py
+++ b/examples/run_snowflake_faker.py
@@ -50,4 +50,4 @@ source.check()
 result = source.read(cache)
 
 for name in ["products"]:
-    print(f"Stream {name}: {len(list(result[name]))} records")
+    print(f"Stream {name}: {len(list(result[name]))} records")  # noqa: T201

--- a/examples/run_spacex.py
+++ b/examples/run_spacex.py
@@ -26,7 +26,7 @@ source.select_streams(["launches", "rockets", "capsules"])
 
 result = source.read(cache)
 
-print(islice(source.get_records("capsules"), 10))
+print(islice(source.get_records("capsules"), 10))  # noqa: T201
 
 for name, records in result.cache.streams.items():
-    print(f"Stream {name}: {len(list(records))} records")
+    print(f"Stream {name}: {len(list(records))} records")  # noqa: T201

--- a/examples/run_sync_to_destination_from_read_result.py
+++ b/examples/run_sync_to_destination_from_read_result.py
@@ -52,7 +52,7 @@ def main() -> None:
     read_result: ab.ReadResult = source.read(
         cache=ab.new_local_cache(),
     )
-    print(
+    print(  # noqa: T201
         "Completed reading from source at "
         f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}. "
         "Writing to destination..."
@@ -60,7 +60,7 @@ def main() -> None:
     write_result: ab.WriteResult = destination.write(
         source_data=read_result,
     )
-    print(
+    print(  # noqa: T201
         f"Completed writing {write_result.processed_records:,} records "
         f"to destination at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}."
     )

--- a/examples/run_sync_to_destination_w_cache.py
+++ b/examples/run_sync_to_destination_w_cache.py
@@ -52,7 +52,7 @@ def main() -> None:
         source_data=source,
         cache=ab.new_local_cache(),
     )
-    print(
+    print(  # noqa: T201
         f"Completed writing {write_result.processed_records:,} records "
         f"to destination at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}."
     )

--- a/examples/run_sync_to_destination_wo_cache.py
+++ b/examples/run_sync_to_destination_wo_cache.py
@@ -67,7 +67,7 @@ def main() -> None:
         cache=False,
         state_cache=state_cache,
     )
-    print(
+    print(  # noqa: T201
         f"Completed writing {write_result.processed_records:,} records "
         f"to destination at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}."
     )

--- a/examples/run_test_source.py
+++ b/examples/run_test_source.py
@@ -21,12 +21,12 @@ cache = ab.new_local_cache("cache_test")
 
 source.check()
 
-print(source.get_available_streams())
+print(source.get_available_streams())  # noqa: T201
 
 result = source.read(cache)
 
-print(result.processed_records)
-print(list(result["stream1"]))
+print(result.processed_records)  # noqa: T201
+print(list(result["stream1"]))  # noqa: T201
 
 different_cache = ab.new_local_cache("cache_test")
-print(list(different_cache["stream1"]))
+print(list(different_cache["stream1"]))  # noqa: T201

--- a/examples/run_test_source_single_stream.py
+++ b/examples/run_test_source_single_stream.py
@@ -19,4 +19,4 @@ os.environ["AIRBYTE_LOCAL_REGISTRY"] = (
 
 source = ab.get_source("source-test", config={"apiKey": "test"})
 
-print(list(source.read(streams=["stream1"])))
+print(list(source.read(streams=["stream1"])))  # noqa: T201

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -573,7 +573,7 @@ def generate(server_spec: str, output: Path) -> None:
     """Run `fastmcp inspect`, render Markdown, and write files to `output/`."""
     with tempfile.TemporaryDirectory() as tmp:
         report_path = Path(tmp) / "mcp-inspect.json"
-        print(f"Running `fastmcp inspect {server_spec}`...")
+        print(f"Running `fastmcp inspect {server_spec}`...")  # noqa: T201
         report = _run_fastmcp_inspect(server_spec, report_path)
 
     fallback_map = _resolve_extra_module_map(server_spec)
@@ -591,9 +591,9 @@ def generate(server_spec: str, output: Path) -> None:
 
     for name, content in pages.items():
         (resolved_output / name).write_text(content, encoding="utf-8")
-        print(f"  wrote {resolved_output / name}")
+        print(f"  wrote {resolved_output / name}")  # noqa: T201
 
-    print(
+    print(  # noqa: T201
         f"Done. {len(buckets)} module(s) documented — "
         f"{sum(len(b.tools) for b in buckets.values())} tool(s), "
         f"{sum(len(b.resources) for b in buckets.values())} resource(s), "
@@ -619,7 +619,7 @@ def main() -> int:
     try:
         generate(server_spec=args.server_spec, output=args.output)
     except (subprocess.CalledProcessError, RuntimeError) as ex:
-        print(f"MCP docs generation failed: {ex}", file=sys.stderr)
+        print(f"MCP docs generation failed: {ex}", file=sys.stderr)  # noqa: T201
         return 1
     return 0
 

--- a/tests/integration_tests/cloud/test_cloud_api_util.py
+++ b/tests/integration_tests/cloud/test_cloud_api_util.py
@@ -385,9 +385,9 @@ def test_url_construction_with_path_prefix() -> None:
         bearer_token=fake_bearer_token,
     )
 
-    print(f"\nBase URL with path prefix: {base_url_with_path}")
-    print(f"Result type: {type(result)}")
-    print(f"Result: {result}")
+    print(f"\nBase URL with path prefix: {base_url_with_path}")  # noqa: T201
+    print(f"Result type: {type(result)}")  # noqa: T201
+    print(f"Result: {result}")  # noqa: T201
 
     assert result == [], (
         f"Expected empty list from httpbin (no real sources), but got: {result}"

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -47,7 +47,7 @@ def get_connector_config(self, connector_name: str, index: int = 0) -> dict | No
         None,
     )
 
-    print(f"Found '{connector_name}' credential secret '${first_secret.secret_name}'.")
+    print(f"Found '{connector_name}' credential secret '${first_secret.secret_name}'.")  # noqa: T201
     return first_secret.get_value().parse_json()
 
 

--- a/tests/integration_tests/fixtures/source-test/source_test/run.py
+++ b/tests/integration_tests/fixtures/source-test/source_test/run.py
@@ -186,21 +186,21 @@ def get_json_file(path):
 def run():
     args = sys.argv[1:]
     if args[0] == "spec":
-        print(json.dumps(sample_connection_specification))
+        print(json.dumps(sample_connection_specification))  # noqa: T201
     elif args[0] == "discover":
-        print(json.dumps(sample_catalog))
+        print(json.dumps(sample_catalog))  # noqa: T201
     elif args[0] == "check":
         args = parse_args()
         config = get_json_file(args["--config"])
         if config.get("apiKey").startswith("test"):
-            print(json.dumps(sample_connection_check_success))
+            print(json.dumps(sample_connection_check_success))  # noqa: T201
         else:
-            print(json.dumps(sample_connection_check_failure))
+            print(json.dumps(sample_connection_check_failure))  # noqa: T201
     elif args[0] == "read":
         args = parse_args()
         catalog = get_json_file(args["--catalog"])
         config = get_json_file(args["--config"])
-        print(
+        print(  # noqa: T201
             json.dumps({
                 "type": "LOG",
                 "log": {"level": "INFO", "message": "Starting sync"},
@@ -208,11 +208,11 @@ def run():
         )
         for stream in catalog["streams"]:
             if stream["stream"]["name"] == "stream1":
-                print(json.dumps(sample_record1_stream1))
+                print(json.dumps(sample_record1_stream1))  # noqa: T201
                 if config.get("apiKey") == "test_fail_during_sync":
                     raise Exception("An error")
-                print(json.dumps(sample_record2_stream1))
+                print(json.dumps(sample_record2_stream1))  # noqa: T201
             elif stream["stream"]["name"] == "stream2":
-                print(json.dumps(sample_record_stream2))
+                print(json.dumps(sample_record_stream2))  # noqa: T201
             elif stream["stream"]["name"] == "primary-key-with-dot":
-                print(json.dumps(sample_record_primary_key_with_dot))
+                print(json.dumps(sample_record_primary_key_with_dot))  # noqa: T201

--- a/tests/integration_tests/test_config_change_callback.py
+++ b/tests/integration_tests/test_config_change_callback.py
@@ -20,7 +20,7 @@ from airbyte_protocol.models import (
 
 
 def config_change_callback(config: dict[str, Any]) -> None:
-    print(f"Updated config: {config}")
+    print(f"Updated config: {config}")  # noqa: T201
 
 
 @pytest.fixture

--- a/tests/integration_tests/test_source_faker_integration.py
+++ b/tests/integration_tests/test_source_faker_integration.py
@@ -273,7 +273,7 @@ def test_merge_insert_not_supported_for_duckdb(
         if result:
             raise AssertionError("Cache supports merge-insert, but it's set to False.")
     except Exception as e:
-        print(f"An exception occurred: {e}")
+        print(f"An exception occurred: {e}")  # noqa: T201
         if isinstance(e, AssertionError):
             raise e
 
@@ -300,6 +300,6 @@ def test_merge_insert_not_supported_for_postgres(
         if result:
             raise AssertionError("Cache supports merge-insert, but it's set to False.")
     except Exception as e:
-        print(f"An exception occurred: {e}")
+        print(f"An exception occurred: {e}")  # noqa: T201
         if isinstance(e, AssertionError):
             raise e


### PR DESCRIPTION
## Summary

This PR targets PR #1063.

Adds `# noqa: T201` / `# noqa: T203` to 78 existing `print()` / `pprint()` calls across 33 files. Each instance needs review to determine if it should be replaced with proper logging or kept with the noqa directive.

Most violations are in CLI tools, examples, and test files where print is expected. Library code violations should be migrated to `logging` over time.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers