### PR TITLE
chore(lint): enable DOC501 rule (document raised exceptions)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,6 +18,7 @@ select = [
     "COM",   # flake8-commas
     "CPY",   # missing copyright notice
     "D",     # pydocstyle (Docstring conventions)
+    "DOC501", # pydoclint: raised exceptions missing from docstring
     "DTZ",   # flake8-datetimez
     "E",     # pycodestyle (errors)
     "ERA",   # flake8-eradicate (commented out code)


### PR DESCRIPTION
## Summary

Add `DOC501` (pydoclint) to the select list. Flags functions that `raise` exceptions not documented in their docstring `Raises:` section.

Only `DOC501` is added — not the full `DOC` category — since `DOC201` was explicitly rejected.

Existing violations will be addressed by a stacked compliance PR with `noqa` directives.

Link to Devin session: https://app.devin.ai/sessions/6ae2048fc77a4f278aee3dd022384f4a
Requested by: @aaronsteers