### PR TITLE
chore(deps): Upgrade snowflake connector to prevent security issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0",
     "requests!=3.32.0",  # 3.32.0 breaks docker tests
     "rich>=13.7.0,<14.0",
-    "snowflake-connector-python>=3.12.2,<4.0",
+    "snowflake-connector-python>=3.12.2,<5.0",
     "snowflake-sqlalchemy>=1.6.1,<2.0",
     "structlog>=24.4.0,<25.0",
     # TODO: Restore broader version constraints after verifying compatibility

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2,<7.0" },
     { name = "requests", specifier = "!=3.32.0" },
     { name = "rich", specifier = ">=13.7.0,<14.0" },
-    { name = "snowflake-connector-python", specifier = ">=3.12.2,<4.0" },
+    { name = "snowflake-connector-python", specifier = ">=3.12.2,<5.0" },
     { name = "snowflake-sqlalchemy", specifier = ">=1.6.1,<2.0" },
     { name = "sqlalchemy", specifier = "==2.0.43" },
     { name = "sqlalchemy-bigquery", specifier = "==1.12.0" },


### PR DESCRIPTION
The existing Snowflake connector specified in the pyproject file (<4.0) uses an old cryptography/OpenSSL packages that has some security issues:

https://nvd.nist.gov/vuln/detail/CVE-2026-34073
https://nvd.nist.gov/vuln/detail/CVE-2026-26007
https://github.com/advisories/ghsa-537c-gmf6-5ccf

The idea is to allow snowflake-connector  < 5 To prevent these issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the supported version range for the Snowflake connector, allowing compatibility with newer releases while keeping the current minimum version unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->