### PR TITLE
feat(mcp): Simplify deployment of Replication MCP server over HTTPS

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -19,6 +19,29 @@ To get started with the Airbyte Replication MCP server, follow these steps:
 2. Register the MCP server with your MCP client.
 3. Test the MCP server connection using your MCP client.
 
+### Hosted HTTPS deployment (remote MCP clients)
+
+Remote MCP clients require a public **HTTPS** endpoint. They cannot use the local
+stdio transport.
+
+Use the **`airbyte-mcp-http`** entry point instead, which serves Streamable HTTP on port
+8080. Terminate TLS at a reverse proxy or load balancer in front of the server.
+
+```bash
+# Docker (production transport)
+docker build -f Dockerfile.mcp -t airbyte-mcp .
+docker run --rm -p 8080:8080 \
+  -e AIRBYTE_MCP_ENV_FILE=/secrets/airbyte_mcp.env \
+  -v "/path/to/airbyte_mcp.env:/secrets/airbyte_mcp.env:ro" \
+  airbyte-mcp
+
+# Local dev with the same transport as production
+poe mcp-serve-streamable-http
+```
+
+For a full deployment guide (HTTPS, remote client integration, OIDC, CORS), see
+[docs/MCP_HTTP_DEPLOYMENT.md](https://github.com/airbytehq/PyAirbyte/blob/main/docs/MCP_HTTP_DEPLOYMENT.md).
+
 ### Step 1: Generate a Dotenv Secrets File
 
 To get started with the Airbyte Replication MCP server, you will need to create a dotenv

--- a/airbyte/mcp/_http_config.py
+++ b/airbyte/mcp/_http_config.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""HTTP transport configuration helpers for hosted MCP deployment."""
+
+from __future__ import annotations
+
+import os
+
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+
+
+MCP_CORS_ORIGINS_ENV = "MCP_CORS_ORIGINS"
+
+# Headers used by remote MCP clients over streamable HTTP.
+_MCP_CLIENT_HEADERS = [
+    "mcp-protocol-version",
+    "mcp-session-id",
+    "Authorization",
+    "Content-Type",
+    "X-Airbyte-Workspace-Id",
+    "X-Airbyte-Cloud-Client-Id",
+    "X-Airbyte-Cloud-Client-Secret",
+    "X-Airbyte-Cloud-Api-Url",
+    "X-Airbyte-Cloud-Config-Api-Url",
+]
+
+
+def parse_cors_origins(raw: str | None) -> list[str]:
+    """Parse a comma-separated list of CORS origins."""
+    if not raw:
+        return []
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+def build_http_middleware(
+    *,
+    cors_origins: str | None = None,
+) -> list[Middleware]:
+    """Build ASGI middleware for the hosted MCP HTTP transport.
+
+    When ``MCP_CORS_ORIGINS`` is set (comma-separated), enables CORS for
+    remote MCP clients that connect from a browser context (for example,
+    browser-based OAuth flows).
+    """
+    origins = parse_cors_origins(cors_origins or os.getenv(MCP_CORS_ORIGINS_ENV, ""))
+    if not origins:
+        return []
+
+    return [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+            allow_headers=_MCP_CLIENT_HEADERS,
+            expose_headers=["mcp-protocol-version", "mcp-session-id"],
+        ),
+    ]

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -10,9 +10,13 @@ Environment variables:
 - `MCP_SERVER_URL`: Public base URL. Used for OIDC redirect callbacks and to
   derive the MCP endpoint mount path (serves at `/` when the URL has a path
   prefix, otherwise defaults to `/mcp`).
+- `MCP_CORS_ORIGINS`: Comma-separated CORS origins for remote MCP clients
+  (for example, browser-based OAuth flows).
 - `OIDC_CONFIG_URL`: Keycloak OIDC discovery URL (enables auth with all three OIDC vars)
 - `OIDC_CLIENT_ID`: OIDC client identifier
 - `OIDC_CLIENT_SECRET`: OIDC client secret
+
+See `docs/MCP_HTTP_DEPLOYMENT.md` for HTTPS deployment and remote client integration.
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ import logging
 import os
 from urllib.parse import urlparse
 
+from airbyte.mcp._http_config import build_http_middleware
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
@@ -52,12 +57,15 @@ def main() -> None:
         mcp_path,
     )
 
+    middleware = build_http_middleware()
+
     app.run(
         transport="streamable-http",
         host=DEFAULT_HTTP_HOST,
         port=DEFAULT_HTTP_PORT,
         path=mcp_path,
         stateless_http=True,
+        middleware=middleware or None,
     )
 
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,23 @@
+# Caddy reverse proxy for the Airbyte Replication MCP server.
+#
+# Usage (with docker-compose.mcp.yml):
+#   MCP_PUBLIC_HOST=mcp.example.com docker compose -f deploy/docker-compose.mcp.yml up -d
+#
+# Caddy obtains and renews TLS certificates automatically for MCP_PUBLIC_HOST.
+
+{$MCP_PUBLIC_HOST} {
+	# Health checks for load balancers and uptime monitors.
+	handle /health {
+		reverse_proxy mcp:8080
+	}
+
+	# Streamable HTTP MCP endpoint (default mount path is /mcp).
+	handle /mcp* {
+		reverse_proxy mcp:8080
+	}
+
+	# Fallback for path-stripped deployments (MCP_SERVER_URL with a path prefix).
+	handle {
+		reverse_proxy mcp:8080
+	}
+}

--- a/deploy/docker-compose.mcp.yml
+++ b/deploy/docker-compose.mcp.yml
@@ -1,0 +1,57 @@
+# Self-hosted Airbyte Replication MCP server with automatic HTTPS via Caddy.
+#
+# Prerequisites:
+#   - DNS for MCP_PUBLIC_HOST must point to this host
+#   - A dotenv secrets file at ~/.mcp/airbyte_mcp.env (or override MCP_ENV_FILE)
+#
+# Usage:
+#   export MCP_PUBLIC_HOST=mcp.example.com
+#   docker compose -f deploy/docker-compose.mcp.yml up -d --build
+#
+# Public MCP endpoint (default mount): https://$MCP_PUBLIC_HOST/mcp
+
+services:
+  mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile.mcp
+    restart: unless-stopped
+    environment:
+      AIRBYTE_MCP_ENV_FILE: /secrets/airbyte_mcp.env
+      MCP_SERVER_URL: https://${MCP_PUBLIC_HOST:-localhost}
+      MCP_CORS_ORIGINS: ${MCP_CORS_ORIGINS:-}
+      OIDC_CONFIG_URL: ${OIDC_CONFIG_URL:-}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      AIRBYTE_CLOUD_MCP_SAFE_MODE: ${AIRBYTE_CLOUD_MCP_SAFE_MODE:-1}
+      AIRBYTE_CLOUD_MCP_READONLY_MODE: ${AIRBYTE_CLOUD_MCP_READONLY_MODE:-0}
+    volumes:
+      - ${MCP_ENV_FILE:-${HOME}/.mcp/airbyte_mcp.env}:/secrets/airbyte_mcp.env:ro
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      MCP_PUBLIC_HOST: ${MCP_PUBLIC_HOST:-localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      mcp:
+        condition: service_healthy
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -137,12 +137,16 @@ poe mcp-tool-test list_deployed_cloud_connections '{}'
 You can also invoke the server using one of these helper tasks:
 
 ```bash
-poe mcp-serve-local    # STDIO transport (default)
-poe mcp-serve-http     # HTTP transport on localhost:8000
-poe mcp-serve-sse      # Server-Sent Events transport on localhost:8000
+poe mcp-serve-local           # STDIO transport (default)
+poe mcp-serve-http            # HTTP transport on localhost:8000
+poe mcp-serve-sse             # Server-Sent Events transport on localhost:8000
+poe mcp-serve-streamable-http # Streamable HTTP on localhost:8080 (production transport)
 
 poe mcp-inspect        # Show all available MCP tools and their schemas
 ```
+
+For hosted HTTPS deployment (remote MCP clients), see
+[docs/MCP_HTTP_DEPLOYMENT.md](./MCP_HTTP_DEPLOYMENT.md).
 
 ### Generating Markdown docs for the MCP Server
 

--- a/docs/MCP_HTTP_DEPLOYMENT.md
+++ b/docs/MCP_HTTP_DEPLOYMENT.md
@@ -1,0 +1,172 @@
+# Hosting the Airbyte Replication MCP Server over HTTPS
+
+The Airbyte Replication MCP server supports remote clients that require a public HTTPS endpoint. The local stdio transport (`airbyte-mcp`) is for desktop MCP clients only.
+
+For hosted deployment, use the **`airbyte-mcp-http`** entry point, which serves the MCP protocol over **Streamable HTTP** — the transport remote MCP clients expect.
+
+## Architecture
+
+```text
+Remote MCP client (MCP Inspector, hosted agent platform, etc.)
+        │  HTTPS
+        ▼
+Reverse proxy / load balancer  (TLS termination)
+        │  HTTP :8080
+        ▼
+airbyte-mcp-http  (streamable-http, stateless)
+        │
+        ▼
+Airbyte Cloud / local connector tools
+```
+
+TLS is terminated at the reverse proxy or load balancer. The MCP server itself listens on plain HTTP (`0.0.0.0:8080`).
+
+There is **no official Airbyte-hosted public MCP endpoint** in this repository. You self-host the server in your own infrastructure and expose it at a public HTTPS URL.
+
+## Quick start with Docker
+
+Build and run the MCP server container:
+
+```bash
+docker build -f Dockerfile.mcp -t airbyte-mcp .
+docker run --rm -p 8080:8080 \
+  -e AIRBYTE_MCP_ENV_FILE=/secrets/airbyte_mcp.env \
+  -v "$HOME/.mcp/airbyte_mcp.env:/secrets/airbyte_mcp.env:ro" \
+  airbyte-mcp
+```
+
+For HTTPS with automatic certificates, use the included Compose stack:
+
+```bash
+# Set your public hostname, then start Caddy + MCP server
+export MCP_PUBLIC_HOST=mcp.example.com
+docker compose -f deploy/docker-compose.mcp.yml up -d
+```
+
+Caddy terminates TLS and proxies to the MCP server. Set `MCP_SERVER_URL=https://mcp.example.com` in the Compose file or environment so OIDC callbacks resolve correctly.
+
+Health checks: `GET /health` returns `{"status": "ok"}`.
+
+## MCP endpoint URL
+
+The public MCP URL depends on how you configure `MCP_SERVER_URL`:
+
+| `MCP_SERVER_URL` | Internal mount path | Public MCP endpoint |
+| --- | --- | --- |
+| `https://mcp.example.com` | `/mcp` | `https://mcp.example.com/mcp` |
+| `https://mcp.example.com/airbyte` | `/` (path-stripped LB) | `https://mcp.example.com/airbyte` |
+
+When configuring a remote MCP client, use the **public MCP endpoint URL** from the table above.
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `AIRBYTE_MCP_ENV_FILE` | Recommended | Path to dotenv secrets file (Airbyte Cloud credentials, connector secrets) |
+| `MCP_SERVER_URL` | Recommended | Public HTTPS base URL (used for OIDC callbacks and mount path) |
+| `MCP_CORS_ORIGINS` | Optional | Comma-separated CORS origins (e.g. `https://app.example.com`) |
+| `OIDC_CONFIG_URL` | Optional | Keycloak OIDC discovery URL (enables OAuth when all three OIDC vars are set) |
+| `OIDC_CLIENT_ID` | Optional | OIDC client ID |
+| `OIDC_CLIENT_SECRET` | Optional | OIDC client secret |
+| `AIRBYTE_CLOUD_MCP_SAFE_MODE` | Optional | Default `1`; restrict destructive ops to session-created resources |
+| `AIRBYTE_CLOUD_MCP_READONLY_MODE` | Optional | Default `0`; disable write tools when `1` |
+
+## Integrating with remote MCP clients
+
+Remote MCP clients connect over HTTPS using **Streamable HTTP** (with SSE fallback). Stdio-based servers cannot be used directly.
+
+### 1. Deploy and expose HTTPS
+
+1. Deploy `airbyte-mcp-http` (Docker image from `Dockerfile.mcp`, or run directly).
+2. Put it behind a reverse proxy with a valid TLS certificate.
+3. Confirm the endpoint responds: `curl -s https://your-host/health`.
+
+### 2. Register the server with your client
+
+In your remote MCP client's admin or integration settings:
+
+1. Add a new remote MCP server.
+2. Enter your public MCP URL (for example, `https://mcp.example.com/mcp`).
+3. Choose an authentication method (see below).
+
+### 3. Authentication options
+
+#### Option A: Bearer token (simplest)
+
+Use this when the MCP server is reachable only on your network or protected by your proxy, and you want the client to send Airbyte Cloud credentials on each request.
+
+1. Select **Bearer Token** authentication in your MCP client.
+2. Provide an Airbyte Cloud API bearer token (or the token your deployment expects in the `Authorization` header).
+
+The server resolves Airbyte Cloud credentials from HTTP headers in this order:
+
+1. `Authorization` (bearer token)
+2. `X-Airbyte-Cloud-Client-Id` / `X-Airbyte-Cloud-Client-Secret`
+3. `X-Airbyte-Workspace-Id`
+4. Environment variables from `AIRBYTE_MCP_ENV_FILE`
+
+If your MCP client supports custom headers, you can pass `X-Airbyte-Workspace-Id` and client credentials instead of a bearer token.
+
+#### Option B: OIDC (Keycloak)
+
+Use this to protect the MCP endpoint with OAuth. Configure Keycloak (or compatible OIDC provider) and set all three OIDC environment variables.
+
+Whitelist your MCP client's OAuth callback URLs in your OIDC provider. Consult your client's documentation for the exact redirect URIs to register.
+
+Set `MCP_SERVER_URL` to your public HTTPS URL before enabling OIDC so redirect URIs resolve correctly.
+
+#### Option C: Network-level protection
+
+If the MCP server has no OIDC and is exposed publicly, protect it with firewall rules, IP allowlists, or an API gateway in front of the endpoint.
+
+### 4. CORS (if needed)
+
+If your MCP client's OAuth or browser-based flows require CORS, set:
+
+```bash
+export MCP_CORS_ORIGINS="https://app.example.com,https://admin.example.com"
+```
+
+Remote clients typically connect server-to-server, so CORS is often unnecessary for tool calls. Enable it if you see CORS errors during OAuth or connection setup.
+
+## Local development with Streamable HTTP
+
+Test the same transport used in production:
+
+```bash
+poe mcp-serve-streamable-http
+```
+
+This starts the server on `http://127.0.0.1:8080/mcp`. Use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) to connect over HTTP for local testing.
+
+## Reverse proxy examples
+
+### Caddy (included in `deploy/`)
+
+See `deploy/Caddyfile` and `deploy/docker-compose.mcp.yml`.
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /health {
+        proxy_pass http://127.0.0.1:8080/health;
+    }
+}
+```
+
+## Related documentation
+
+- [MCP server setup (stdio clients)](../airbyte/mcp/__init__.py) — local Claude Desktop / Cursor configuration
+- [Contributing: MCP development](./CONTRIBUTING.md#mcp-server-development)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ fix-and-check = { shell = "poe fix && poe check" }
 mcp-serve-local = { cmd = "airbyte-mcp", help = "Start the MCP server with STDIO transport" }
 mcp-serve-http = { cmd = "python -c \"from airbyte.mcp.server import app; app.run(transport='http', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with HTTP transport" }
 mcp-serve-sse = { cmd = "python -c \"from airbyte.mcp.server import app; app.run(transport='sse', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with SSE transport" }
+mcp-serve-streamable-http = { cmd = "airbyte-mcp-http", help = "Start the MCP server with Streamable HTTP transport on localhost:8080 (production transport)" }
 mcp-inspect = { cmd = "fastmcp inspect airbyte/mcp/server.py:app", help = "Inspect MCP tools and resources (supports --tools, --health, etc.)" }
 mcp-tool-test = { cmd = "python -m fastmcp_extensions.utils.test_tool --app airbyte.mcp.server:app", help = "Test MCP tools directly with JSON arguments: poe mcp-tool-test <tool_name> '<json_args>'" }
 mcp-docs-md = { cmd = "python scripts/generate_mcp_markdown.py", help = "Generate Markdown docs for the MCP server into docs/mcp-generated/ (Docusaurus- and pdoc-compatible)" }

--- a/tests/unit_tests/test_mcp_http_config.py
+++ b/tests/unit_tests/test_mcp_http_config.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for hosted MCP HTTP configuration."""
+
+from __future__ import annotations
+
+from starlette.middleware.cors import CORSMiddleware
+
+from airbyte.mcp._http_config import build_http_middleware, parse_cors_origins
+
+
+def test_parse_cors_origins_empty() -> None:
+    """Empty or whitespace-only input returns no origins."""
+    assert parse_cors_origins("") == []
+    assert parse_cors_origins(None) == []
+    assert parse_cors_origins("  ,  , ") == []
+
+
+def test_parse_cors_origins_trims_and_splits() -> None:
+    """Origins are split on commas and trimmed."""
+    assert parse_cors_origins("https://app.example.com, https://admin.example.com") == [
+        "https://app.example.com",
+        "https://admin.example.com",
+    ]
+
+
+def test_build_http_middleware_without_origins() -> None:
+    """No CORS middleware is added when origins are unset."""
+    assert build_http_middleware(cors_origins="") == []
+
+
+def test_build_http_middleware_with_origins() -> None:
+    """CORS middleware is configured when origins are provided."""
+    middleware = build_http_middleware(cors_origins="https://app.example.com")
+    assert len(middleware) == 1
+    assert middleware[0].cls is CORSMiddleware
+    assert middleware[0].kwargs["allow_origins"] == ["https://app.example.com"]
+    assert "mcp-protocol-version" in middleware[0].kwargs["allow_headers"]


### PR DESCRIPTION
## Description

1. Add HTTPS deployment documentation
Create docs/MCP_HTTP_DEPLOYMENT.md covering:
  - Architecture: TLS at reverse proxy → airbyte-mcp-http on :8080
  - Docker quick start (Dockerfile.mcp)
  - Environment variables (MCP_SERVER_URL, OIDC, secrets file)
  - MCP endpoint URL behavior (/mcp vs path-stripped deployments)
  - Remote client integration:
   - Public URL to register in the client
   - Auth options: Bearer token, OIDC, network-level protection
   - Optional CORS for browser-based OAuth flows
2. Add self-hosted deployment examples
Add deploy/docker-compose.mcp.yml and a reverse-proxy config (e.g. Caddy) for a reference stack:
 - MCP server container (airbyte-mcp-http)
 - Reverse proxy with automatic TLS
 - Health check on /health
3. Optional CORS support
Add MCP_CORS_ORIGINS (comma-separated origins) and wire it into the HTTP transport for clients that need CORS (e.g. OAuth in the browser). Include MCP and Airbyte credential headers.

4. Improve discoverability
- Update airbyte/mcp/__init__.py with a hosted HTTPS section linking to the new guide
- Update docs/CONTRIBUTING.md with a dev task for the production transport
- Add poe mcp-serve-streamable-http in pyproject.toml

5. Tests
Unit tests for CORS origin parsing and middleware configuration.

## Relates

- relates: https://github.com/airbytehq/PyAirbyte/issues/1068

## Testing

```
uv run pytest tests/unit_tests/test_mcp_http_config.py -v
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-8.4.2, pluggy-1.6.0 -- /Users/ellarunciman/github/PyAirbyte/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/ellarunciman/github/PyAirbyte
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, docker-3.2.5, timeout-2.4.0, Faker-21.0.1, logfire-4.19.0
timeout: 600.0s
timeout method: signal
timeout func_only: False
collected 4 items                                                                                         

tests/unit_tests/test_mcp_http_config.py::test_parse_cors_origins_empty PASSED                      [ 25%]
tests/unit_tests/test_mcp_http_config.py::test_parse_cors_origins_trims_and_splits PASSED           [ 50%]
tests/unit_tests/test_mcp_http_config.py::test_build_http_middleware_without_origins PASSED         [ 75%]
tests/unit_tests/test_mcp_http_config.py::test_build_http_middleware_with_origins PASSED            [100%]

============================================ warnings summary =============================================
<frozen abc>:106
<frozen abc>:106
<frozen abc>:106
  ExperimentalClassWarning: This class is experimental. Use at your own risk.

airbyte/secrets/base.py:125: 10 warnings
  DeprecationWarning: The `field_name` argument on `with_info_after_validator_function` is deprecated, it will be passed to the function through `ValidationState` instead.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------ generated xml file: /Users/ellarunciman/github/PyAirbyte/build/test-results/test-results.xml -------
===================================== 4 passed, 13 warnings in 2.88s ======================================
```

and 

confirm successful Streamable HTTP MCP handshake:

```
curl -s http://127.0.0.1:8080/health
{"status":"ok"}%        

curl -s -X POST http://127.0.0.1:8080/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"logging":{},"prompts":{"listChanged":true},"resources":{"subscribe":false,"listChanged":true},"tools":{"listChanged":true},"extensions":{"io.modelcontextprotocol/ui":{}}},"serverInfo":{"name":"airbyte-mcp","version":"3.2.0"},"instructions":"PyAirbyte connector management and data integration server for discovering,\ndeploying, and running Airbyte connectors.\n\nUse this server for:\n- Discovering connectors from the Airbyte registry (sources and destinations)\n- Deploying sources, destinations,and connections to Airbyte Cloud\n- Running cloud syncs and monitoring sync status\n- Managing custom connector definitions in Airbyte Cloud\n- Local connector execution for data extraction without cloud deployment\n- Listing and describing environment variables for connector configuration\n\nOperational modes:\n- Cloud operations: Deploy and manage connectors on Airbyte Cloud (requires\n  AIRBYTE_CLOUD_CLIENT_ID, AIRBYTE_CLOUD_CLIENT_SECRET, AIRBYTE_CLOUD_WORKSPACE_ID)\n- Local operations: Run connectors locally for data extraction (requires\n  AIRBYTE_PROJECT_DIR for artifact storage)\n\nSafety features:\n- Safe mode (default): Restricts destructive operations to objects created in\n  the current session\n- Read-only mode: Disables all write operations for cloud resources"}}               
```

and

can List tools in MCP Inspector
```
uv run poe mcp-tool-test list_connectors '{}'
Poe => python -m fastmcp_extensions.utils.test_tool --app airbyte.mcp.server:app list_connectors '{}'
<frozen runpy>:128: RuntimeWarning: 'fastmcp_extensions.utils.test_tool' found in sys.modules after import of package 'fastmcp_extensions.utils', but prior to execution of 'fastmcp_extensions.utils.test_tool'; this may result in unpredictable behaviour
Running in MCP mode: Airbyte Replication MCP v0.49.0a2 (Python v3.12.8)
CallToolResult(content=[TextContent(type='text', text='["destination-astra","destination-aws-datalake","destination-azure-blob-storage","destination-bigquery","destination-chroma","destination-clickhouse","destination-convex","destination-csv","destination-customer-io","destination-databricks","destination-deepset","destination-dev-null","destination-duckdb","destination-dynamodb","destination-elasticsearch","destination-firebolt","destination-firestore","destination-gcs","destination-gcs-data-lake","destination-glassflow","destination-google-sheets","destination-hubspot","destination-kafka","destination-local-json","destination-milvus","destination-mongodb","destination-motherduck","destination-mssql","destination-mssql-v2","destination-mysql","destination-oracle","destination-pgvector","destination-pinecone","destination-postgres","destination-pubsub","destination-qdrant","destination-rabbitmq","destination-ragie","destination-redis","destination-redshift","destination-s3","destination-s3-data-lake","destination-s3-glue","destination-salesforce","destination-sftp-json","destination-snowflake","destination-snowflake-cortex","destination-sqlite","destination-starburst-galaxy","destination-surrealdb","destination-teradata","destination-timeplus","destination-typesense","destination-vectara","destination-weaviate","destination-yellowbrick","source-100ms","source-7shifts","source-activecampaign","source-acuity-scheduling","source-adjust","source-adobe-commerce-magento","source-agilecrm","source-aha","source-airbyte","source-aircall","source-airtable","source-akeneo","source-algolia","source-alpaca-broker-api","source-alpha-vantage","source-amazon-ads","source-amazon-seller-partner","source-amazon-sqs","source-amplitude","source-apify-dataset","source-appcues","source-appfigures","source-appfollow","source-apple-search-ads","source-appsflyer","source-apptivo","source-asana","source-ashby","source-assemblyai","source-auth0","source-aviationstack","source-avni","source-awin-advertiser","source-aws-cloudtrail","source-azure-blob-storage","source-azure-table","source-babelforce","source-bamboo-hr","source-basecamp","source-beamer","source-bigmailer","source-bigquery","source-bing-ads","source-bitly","source-blogger","source-bluetally","source-boldsign","source-box","source-box-data-extract","source-braintree","source-braze","source-breezometer","source-breezy-hr","source-brevo","source-brex","source-bugsnag","source-buildkite","source-bunny-inc","source-buzzsprout","source-cal-com","source-calendly","source-callrail","source-campaign-monitor","source-campayn","source-canny","source-capsule-crm","source-captain-data","source-care-quality-commission","source-cart","source-castor-edc","source-chameleon","source-chargebee","source-chargedesk","source-chargify","source-chartmogul","source-chift","source-churnkey","source-cimis","source-cin7","source-circa","source-circleci","source-cisco-meraki","source-clarif-ai","source-clazar","source-clickhouse","source-clickup-api","source-clockify","source-clockodo","source-close-com","source-cloudbeds","source-coassemble","source-cockroachdb","source-coda","source-codefresh","source-coin-api","source-coingecko-coins","source-coinmarketcap","source-commcare","source-commercetools","source-concord","source-configcat","source-confluence","source-convertkit","source-convex","source-copper","source-couchbase","source-countercyclical","source-criteo-marketing","source-customer-io","source-customerly","source-datadog","source-datagen","source-datascope","source-db2","source-db2-enterprise","source-dbt","source-defillama","source-delighted","source-deputy","source-devin-ai","source-ding-connect","source-discord","source-dixa","source-dockerhub","source-docuseal","source-dolibarr","source-dremio","source-drift","source-drip","source-dropbox-sign","source-dwolla","source-dynamodb","source-e-conomic","source-e2e-test","source-easypost","source-easypromos","source-ebay-finance","source-ebay-fulfillment","source-elasticemail","source-elasticsearch","source-emailoctopus","source-employment-hero","source-encharge","source-eventbrite","source-eventee","source-eventzilla","source-everhour","source-exchange-rates","source-ezofficeinventory","source-facebook-marketing","source-facebook-pages","source-factorial","source-faker","source-fastbill","source-fastly","source-fauna","source-feishu","source-file","source-fillout","source-finage","source-financial-modelling","source-finnhub","source-finnworlds","source-firebase-realtime-database","source-firebolt","source-firehydrant","source-fleetio","source-flexmail","source-flexport","source-float","source-flowlu","source-formbricks","source-free-agent-connector","source-freightview","source-freshbooks","source-freshcaller","source-freshchat","source-freshdesk","source-freshsales","source-freshservice","source-front","source-fulcrum","source-fullstory","source-gainsight-px","source-gcs","source-genesys","source-getgist","source-getlago","source-giphy","source-gitbook","source-github","source-gitlab","source-glassfrog","source-gmail","source-gnews","source-gocardless","source-goldcast","source-gologin","source-gong","source-google-ads","source-google-analytics-data-api","source-google-calendar","source-google-classroom","source-google-directory","source-google-drive","source-google-forms","source-google-pagespeed-insights","source-google-search-console","source-google-sheets","source-google-tasks","source-google-webfonts","source-gorgias","source-grafana","source-granola","source-greenhouse","source-greythr","source-gridly","source-guru","source-gutendex","source-hardcoded-records","source-harness","source-harvest","source-height","source-hellobaton","source-help-scout","source-hibob","source-high-level","source-hoorayhr","source-hubplanner","source-hubspot","source-hugging-face-datasets","source-humanitix","source-huntr","source-illumina-basespace","source-imagga","source-incident-io","source-inflowinventory","source-insightful","source-insightly","source-instagram","source-instatus","source-intercom","source-interzoid","source-intruder","source-invoiced","source-invoiceninja","source-ip2whois","source-iterable","source-jamf-pro","source-jina-ai-reader","source-jira","source-jobnimbus","source-jotform","source-judge-me-reviews","source-just-sift","source-justcall","source-k6-cloud","source-kafka","source-katana","source-keka","source-kisi","source-kissmetrics","source-klarna","source-klaus-api","source-klaviyo","source-kyriba","source-kyve","source-launchdarkly","source-leadfeeder","source-lemlist","source-less-annoying-crm","source-lever-hiring","source-lightspeed-retail","source-linear","source-linkedin-ads","source-linkedin-pages","source-linkrunner","source-linnworks","source-lob","source-lokalise","source-looker","source-luma","source-mailchimp","source-mailerlite","source-mailersend","source-mailgun","source-mailjet-mail","source-mailjet-sms","source-mailosaur","source-mailtrap","source-mantle","source-marketo","source-marketstack","source-mendeley","source-mention","source-mercado-ads","source-merge","source-metabase","source-metricool","source-microsoft-dataverse","source-microsoft-entra-id","source-microsoft-lists","source-microsoft-onedrive","source-microsoft-sharepoint","source-microsoft-teams","source-miro","source-missive","source-mixmax","source-mixpanel","source-mode","source-monday","source-mongodb-v2","source-mssql","source-mux","source-my-hours","source-mysql","source-n8n","source-nasa","source-navan","source-nebius-ai","source-netsuite","source-netsuite-enterprise","source-news-api","source-newsdata","source-newsdata-io","source-nexiopay","source-nexus-datasets","source-ninjaone-rmm","source-nocrm","source-northpass-lms","source-notion","source-nutshell","source-nylas","source-nytimes","source-okta","source-omnisend","source-oncehub","source-onepagecrm","source-onesignal","source-onfleet","source-open-data-dc","source-open-exchange-rates","source-openaq","source-openfda","source-openweather","source-opinion-stage","source-opsgenie","source-opuswatch","source-oracle","source-oracle-enterprise","source-orb","source-oura","source-outbrain-amplify","source-outlook","source-outreach","source-oveit","source-pabbly-subscriptions-billing","source-paddle","source-pagerduty","source-pandadoc","source-paperform","source-papersign","source-pardot","source-partnerize","source-partnerstack","source-payfit","source-paypal-transaction","source-paystack","source-pendo","source-pennylane","source-perigon","source-perk","source-persistiq","source-persona","source-pexels-api","source-phyllo","source-picqer","source-pingdom","source-pinterest","source-pipedrive","source-pipeliner","source-pivotal-tracker","source-piwik","source-plaid","source-planhat","source-plausible","source-pocket","source-pokeapi","source-polygon-stock-api","source-poplar","source-postgres","source-posthog","source-postmarkapp","source-prestashop","source-pretix","source-primetric","source-printify","source-productboard","source-productive","source-public-apis","source-pylon","source-pypi","source-qonto","source-qualaroo","source-quickbooks","source-railz","source-rd-station-marketing","source-recharge","source-recreation","source-recruitee","source-recurly","source-reddit","source-redshift","source-referralhero","source-rentcast","source-repairshopr","source-reply-io","source-retailexpress-by-maropost","source-retently","source-revenuecat","source-revolut-merchant","source-ringcentral","source-rki-covid","source-rocket-chat","source-rocketlane","source-rollbar","source-rootly","source-rss","source-ruddr","source-s3","source-safetyculture","source-sage-hr","source-salesflare","source-salesforce","source-salesloft","source-sap-fieldglass","source-sap-hana-enterprise","source-savvycal","source-scryfall","source-secoda","source-segment","source-sendgrid","source-sendinblue","source-sendowl","source-sendpulse","source-senseforce","source-sentry","source-serpstat","source-service-now","source-sftp","source-sftp-bulk","source-sharepoint-enterprise","source-sharepoint-lists-enterprise","source-sharetribe","source-shippo","source-shipstation","source-shopify","source-shopwired","source-shortcut","source-shortio","source-shutterstock","source-sigma-computing","source-signnow","source-simfin","source-simplecast","source-simplesat","source-singlestore","source-slack","source-smaily","source-smartengage","source-smartreach","source-smartsheets","source-smartwaiver","source-smoke-test","source-snapchat-marketing","source-snowflake","source-solarwinds-service-desk","source-sonar-cloud","source-spacex-api","source-sparkpost","source-split-io","source-spotify-ads","source-spotlercrm","source-square","source-squarespace","source-statsig","source-statuspage","source-stigg","source-stockdata","source-strava","source-stripe","source-survey-sparrow","source-surveycto","source-surveymonkey","source-survicate","source-svix","source-systeme","source-taboola","source-tavus","source-teamtailor","source-teamwork","source-tempo","source-teradata","source-testrail","source-the-guardian-api","source-thinkific","source-thinkific-courses","source-thrive-learning","source-ticketmaster","source-tickettailor","source-ticktick","source-tidb","source-tiktok-marketing","source-timely","source-tinyemail","source-tmdb","source-todoist","source-toggl","source-tplcentral","source-track-pms","source-trello","source-tremendous","source-trustpilot","source-tvmaze-schedule","source-twelve-data","source-twilio","source-twilio-taskrouter","source-twitter","source-tyntec-sms","source-typeform","source-ubidots","source-unleash","source-uppromote","source-uptick","source-us-census","source-uservoice","source-vantage","source-veeqo","source-vercel","source-visma-economic","source-vitally","source-vwo","source-waiteraid","source-wasabi-stats-api","source-watchmode","source-weatherstack","source-web-scrapper","source-webflow","source-when-i-work","source-whisky-hunter","source-wikipedia-pageviews","source-woocommerce","source-wordpress","source-workable","source-workday","source-workday-rest","source-workflowmax","source-workramp","source-wrike","source-wufoo","source-xero","source-xkcd","source-xsolla","source-yahoo-finance-price","source-yandex-metrica","source-yotpo","source-you-need-a-budget-ynab","source-younium","source-yousign","source-youtube-analytics","source-youtube-data","source-zapier-supported-storage","source-zapsign","source-zendesk-chat","source-zendesk-sunshine","source-zendesk-support","source-zendesk-talk","source-zenefits","source-zenloop","source-zoho-analytics-metadata-api","source-zoho-bigin","source-zoho-billing","source-zoho-books","source-zoho-campaign","source-zoho-crm","source-zoho-desk","source-zoho-expense","source-zoho-inventory","source-zoho-invoice","source-zonka-feedback","source-zoom"]', annotations=None, meta=None)], structured_content={'result': ['destination-astra', 'destination-aws-datalake', 'destination-azure-blob-storage', 'destination-bigquery', 'destination-chroma','destination-clickhouse', 'destination-convex', 'destination-csv', 'destination-customer-io', 'destination-databricks', 'destination-deepset', 'destination-dev-null', 'destination-duckdb', 'destination-dynamodb', 'destination-elasticsearch', 'destination-firebolt', 'destination-firestore', 'destination-gcs', 'destination-gcs-data-lake', 'destination-glassflow', 'destination-google-sheets', 'destination-hubspot', 'destination-kafka', 'destination-local-json', 'destination-milvus', 'destination-mongodb', 'destination-motherduck', 'destination-mssql', 'destination-mssql-v2', 'destination-mysql', 'destination-oracle', 'destination-pgvector', 'destination-pinecone', 'destination-postgres', 'destination-pubsub', 'destination-qdrant', 'destination-rabbitmq', 'destination-ragie', 'destination-redis', 'destination-redshift', 'destination-s3', 'destination-s3-data-lake', 'destination-s3-glue', 'destination-salesforce', 'destination-sftp-json', 'destination-snowflake', 'destination-snowflake-cortex', 'destination-sqlite', 'destination-starburst-galaxy', 'destination-surrealdb', 'destination-teradata', 'destination-timeplus', 'destination-typesense', 'destination-vectara', 'destination-weaviate', 'destination-yellowbrick', 'source-100ms', 'source-7shifts', 'source-activecampaign', 'source-acuity-scheduling', 'source-adjust', 'source-adobe-commerce-magento', 'source-agilecrm', 'source-aha', 'source-airbyte', 'source-aircall', 'source-airtable', 'source-akeneo', 'source-algolia', 'source-alpaca-broker-api', 'source-alpha-vantage', 'source-amazon-ads', 'source-amazon-seller-partner', 'source-amazon-sqs', 'source-amplitude', 'source-apify-dataset', 'source-appcues', 'source-appfigures', 'source-appfollow', 'source-apple-search-ads', 'source-appsflyer', 'source-apptivo', 'source-asana', 'source-ashby', 'source-assemblyai', 'source-auth0', 'source-aviationstack', 'source-avni', 'source-awin-advertiser','source-aws-cloudtrail', 'source-azure-blob-storage', 'source-azure-table', 'source-babelforce', 'source-bamboo-hr', 'source-basecamp', 'source-beamer', 'source-bigmailer', 'source-bigquery', 'source-bing-ads', 'source-bitly', 'source-blogger', 'source-bluetally', 'source-boldsign', 'source-box', 'source-box-data-extract', 'source-braintree', 'source-braze', 'source-breezometer', 'source-breezy-hr', 'source-brevo', 'source-brex', 'source-bugsnag', 'source-buildkite', 'source-bunny-inc', 'source-buzzsprout', 'source-cal-com', 'source-calendly', 'source-callrail', 'source-campaign-monitor', 'source-campayn', 'source-canny', 'source-capsule-crm', 'source-captain-data', 'source-care-quality-commission', 'source-cart', 'source-castor-edc', 'source-chameleon', 'source-chargebee', 'source-chargedesk', 'source-chargify', 'source-chartmogul', 'source-chift', 'source-churnkey', 'source-cimis', 'source-cin7', 'source-circa', 'source-circleci', 'source-cisco-meraki', 'source-clarif-ai', 'source-clazar', 'source-clickhouse', 'source-clickup-api', 'source-clockify', 'source-clockodo', 'source-close-com', 'source-cloudbeds', 'source-coassemble', 'source-cockroachdb', 'source-coda', 'source-codefresh', 'source-coin-api', 'source-coingecko-coins', 'source-coinmarketcap', 'source-commcare', 'source-commercetools', 'source-concord', 'source-configcat', 'source-confluence', 'source-convertkit', 'source-convex', 'source-copper', 'source-couchbase', 'source-countercyclical', 'source-criteo-marketing', 'source-customer-io', 'source-customerly', 'source-datadog', 'source-datagen', 'source-datascope', 'source-db2', 'source-db2-enterprise', 'source-dbt', 'source-defillama', 'source-delighted', 'source-deputy', 'source-devin-ai', 'source-ding-connect', 'source-discord', 'source-dixa', 'source-dockerhub', 'source-docuseal', 'source-dolibarr', 'source-dremio', 'source-drift', 'source-drip', 'source-dropbox-sign', 'source-dwolla', 'source-dynamodb', 'source-e-conomic', 'source-e2e-test', 'source-easypost', 'source-easypromos', 'source-ebay-finance', 'source-ebay-fulfillment', 'source-elasticemail', 'source-elasticsearch', 'source-emailoctopus', 'source-employment-hero', 'source-encharge', 'source-eventbrite', 'source-eventee', 'source-eventzilla', 'source-everhour', 'source-exchange-rates', 'source-ezofficeinventory', 'source-facebook-marketing', 'source-facebook-pages', 'source-factorial', 'source-faker', 'source-fastbill', 'source-fastly', 'source-fauna', 'source-feishu', 'source-file', 'source-fillout', 'source-finage', 'source-financial-modelling', 'source-finnhub', 'source-finnworlds', 'source-firebase-realtime-database', 'source-firebolt', 'source-firehydrant', 'source-fleetio', 'source-flexmail', 'source-flexport', 'source-float', 'source-flowlu', 'source-formbricks', 'source-free-agent-connector', 'source-freightview', 'source-freshbooks', 'source-freshcaller', 'source-freshchat', 'source-freshdesk', 'source-freshsales', 'source-freshservice', 'source-front', 'source-fulcrum', 'source-fullstory','source-gainsight-px', 'source-gcs', 'source-genesys', 'source-getgist', 'source-getlago', 'source-giphy', 'source-gitbook', 'source-github', 'source-gitlab', 'source-glassfrog', 'source-gmail', 'source-gnews', 'source-gocardless', 'source-goldcast', 'source-gologin', 'source-gong', 'source-google-ads', 'source-google-analytics-data-api', 'source-google-calendar', 'source-google-classroom', 'source-google-directory', 'source-google-drive', 'source-google-forms', 'source-google-pagespeed-insights', 'source-google-search-console', 'source-google-sheets', 'source-google-tasks', 'source-google-webfonts', 'source-gorgias', 'source-grafana', 'source-granola', 'source-greenhouse', 'source-greythr', 'source-gridly', 'source-guru', 'source-gutendex', 'source-hardcoded-records', 'source-harness', 'source-harvest', 'source-height', 'source-hellobaton', 'source-help-scout', 'source-hibob', 'source-high-level', 'source-hoorayhr', 'source-hubplanner', 'source-hubspot', 'source-hugging-face-datasets', 'source-humanitix', 'source-huntr', 'source-illumina-basespace', 'source-imagga', 'source-incident-io', 'source-inflowinventory', 'source-insightful', 'source-insightly', 'source-instagram', 'source-instatus','source-intercom', 'source-interzoid', 'source-intruder', 'source-invoiced', 'source-invoiceninja', 'source-ip2whois', 'source-iterable', 'source-jamf-pro', 'source-jina-ai-reader', 'source-jira', 'source-jobnimbus', 'source-jotform', 'source-judge-me-reviews', 'source-just-sift', 'source-justcall', 'source-k6-cloud', 'source-kafka', 'source-katana', 'source-keka', 'source-kisi', 'source-kissmetrics', 'source-klarna', 'source-klaus-api', 'source-klaviyo', 'source-kyriba', 'source-kyve', 'source-launchdarkly', 'source-leadfeeder', 'source-lemlist', 'source-less-annoying-crm', 'source-lever-hiring', 'source-lightspeed-retail', 'source-linear', 'source-linkedin-ads', 'source-linkedin-pages', 'source-linkrunner', 'source-linnworks', 'source-lob', 'source-lokalise', 'source-looker', 'source-luma', 'source-mailchimp', 'source-mailerlite', 'source-mailersend', 'source-mailgun', 'source-mailjet-mail', 'source-mailjet-sms', 'source-mailosaur', 'source-mailtrap', 'source-mantle', 'source-marketo', 'source-marketstack', 'source-mendeley', 'source-mention', 'source-mercado-ads', 'source-merge', 'source-metabase', 'source-metricool', 'source-microsoft-dataverse', 'source-microsoft-entra-id', 'source-microsoft-lists', 'source-microsoft-onedrive', 'source-microsoft-sharepoint', 'source-microsoft-teams', 'source-miro', 'source-missive', 'source-mixmax', 'source-mixpanel', 'source-mode', 'source-monday', 'source-mongodb-v2', 'source-mssql', 'source-mux', 'source-my-hours', 'source-mysql', 'source-n8n', 'source-nasa', 'source-navan', 'source-nebius-ai', 'source-netsuite', 'source-netsuite-enterprise', 'source-news-api', 'source-newsdata', 'source-newsdata-io', 'source-nexiopay', 'source-nexus-datasets', 'source-ninjaone-rmm', 'source-nocrm', 'source-northpass-lms', 'source-notion', 'source-nutshell', 'source-nylas', 'source-nytimes', 'source-okta', 'source-omnisend', 'source-oncehub', 'source-onepagecrm', 'source-onesignal', 'source-onfleet', 'source-open-data-dc', 'source-open-exchange-rates', 'source-openaq', 'source-openfda', 'source-openweather', 'source-opinion-stage', 'source-opsgenie', 'source-opuswatch', 'source-oracle', 'source-oracle-enterprise', 'source-orb', 'source-oura', 'source-outbrain-amplify', 'source-outlook', 'source-outreach', 'source-oveit', 'source-pabbly-subscriptions-billing', 'source-paddle', 'source-pagerduty', 'source-pandadoc', 'source-paperform', 'source-papersign', 'source-pardot', 'source-partnerize', 'source-partnerstack', 'source-payfit', 'source-paypal-transaction', 'source-paystack', 'source-pendo', 'source-pennylane', 'source-perigon', 'source-perk', 'source-persistiq', 'source-persona', 'source-pexels-api', 'source-phyllo', 'source-picqer', 'source-pingdom','source-pinterest', 'source-pipedrive', 'source-pipeliner', 'source-pivotal-tracker', 'source-piwik', 'source-plaid', 'source-planhat', 'source-plausible', 'source-pocket', 'source-pokeapi', 'source-polygon-stock-api', 'source-poplar', 'source-postgres', 'source-posthog', 'source-postmarkapp', 'source-prestashop', 'source-pretix', 'source-primetric', 'source-printify', 'source-productboard', 'source-productive', 'source-public-apis', 'source-pylon', 'source-pypi', 'source-qonto', 'source-qualaroo', 'source-quickbooks', 'source-railz', 'source-rd-station-marketing', 'source-recharge', 'source-recreation', 'source-recruitee', 'source-recurly', 'source-reddit', 'source-redshift', 'source-referralhero', 'source-rentcast', 'source-repairshopr', 'source-reply-io', 'source-retailexpress-by-maropost', 'source-retently', 'source-revenuecat', 'source-revolut-merchant', 'source-ringcentral', 'source-rki-covid', 'source-rocket-chat', 'source-rocketlane', 'source-rollbar', 'source-rootly', 'source-rss', 'source-ruddr', 'source-s3', 'source-safetyculture', 'source-sage-hr', 'source-salesflare', 'source-salesforce', 'source-salesloft', 'source-sap-fieldglass', 'source-sap-hana-enterprise', 'source-savvycal', 'source-scryfall', 'source-secoda', 'source-segment', 'source-sendgrid', 'source-sendinblue', 'source-sendowl', 'source-sendpulse', 'source-senseforce', 'source-sentry', 'source-serpstat', 'source-service-now', 'source-sftp', 'source-sftp-bulk', 'source-sharepoint-enterprise', 'source-sharepoint-lists-enterprise', 'source-sharetribe', 'source-shippo', 'source-shipstation', 'source-shopify', 'source-shopwired', 'source-shortcut', 'source-shortio', 'source-shutterstock', 'source-sigma-computing', 'source-signnow', 'source-simfin', 'source-simplecast', 'source-simplesat', 'source-singlestore', 'source-slack', 'source-smaily', 'source-smartengage', 'source-smartreach', 'source-smartsheets', 'source-smartwaiver', 'source-smoke-test', 'source-snapchat-marketing', 'source-snowflake', 'source-solarwinds-service-desk', 'source-sonar-cloud', 'source-spacex-api', 'source-sparkpost', 'source-split-io', 'source-spotify-ads', 'source-spotlercrm', 'source-square', 'source-squarespace', 'source-statsig', 'source-statuspage', 'source-stigg', 'source-stockdata', 'source-strava', 'source-stripe', 'source-survey-sparrow', 'source-surveycto', 'source-surveymonkey', 'source-survicate', 'source-svix', 'source-systeme', 'source-taboola', 'source-tavus', 'source-teamtailor', 'source-teamwork', 'source-tempo', 'source-teradata', 'source-testrail', 'source-the-guardian-api', 'source-thinkific', 'source-thinkific-courses', 'source-thrive-learning', 'source-ticketmaster', 'source-tickettailor', 'source-ticktick', 'source-tidb', 'source-tiktok-marketing', 'source-timely', 'source-tinyemail', 'source-tmdb', 'source-todoist', 'source-toggl', 'source-tplcentral', 'source-track-pms', 'source-trello', 'source-tremendous', 'source-trustpilot', 'source-tvmaze-schedule', 'source-twelve-data', 'source-twilio', 'source-twilio-taskrouter', 'source-twitter', 'source-tyntec-sms', 'source-typeform', 'source-ubidots', 'source-unleash', 'source-uppromote', 'source-uptick', 'source-us-census', 'source-uservoice', 'source-vantage', 'source-veeqo', 'source-vercel', 'source-visma-economic', 'source-vitally', 'source-vwo', 'source-waiteraid', 'source-wasabi-stats-api', 'source-watchmode', 'source-weatherstack', 'source-web-scrapper', 'source-webflow', 'source-when-i-work', 'source-whisky-hunter', 'source-wikipedia-pageviews', 'source-woocommerce', 'source-wordpress', 'source-workable', 'source-workday', 'source-workday-rest', 'source-workflowmax', 'source-workramp', 'source-wrike', 'source-wufoo', 'source-xero', 'source-xkcd', 'source-xsolla', 'source-yahoo-finance-price', 'source-yandex-metrica', 'source-yotpo', 'source-you-need-a-budget-ynab', 'source-younium', 'source-yousign', 'source-youtube-analytics', 'source-youtube-data', 'source-zapier-supported-storage', 'source-zapsign', 'source-zendesk-chat', 'source-zendesk-sunshine', 'source-zendesk-support', 'source-zendesk-talk', 'source-zenefits', 'source-zenloop', 'source-zoho-analytics-metadata-api', 'source-zoho-bigin', 'source-zoho-billing', 'source-zoho-books', 'source-zoho-campaign', 'source-zoho-crm', 'source-zoho-desk', 'source-zoho-expense', 'source-zoho-inventory', 'source-zoho-invoice', 'source-zonka-feedback', 'source-zoom']}, meta={'fastmcp': {'wrap_result':True}}, data=['destination-astra', 'destination-aws-datalake', 'destination-azure-blob-storage', 'destination-bigquery', 'destination-chroma', 'destination-clickhouse', 'destination-convex', 'destination-csv', 'destination-customer-io', 'destination-databricks', 'destination-deepset', 'destination-dev-null', 'destination-duckdb', 'destination-dynamodb', 'destination-elasticsearch', 'destination-firebolt', 'destination-firestore', 'destination-gcs', 'destination-gcs-data-lake', 'destination-glassflow', 'destination-google-sheets', 'destination-hubspot', 'destination-kafka', 'destination-local-json','destination-milvus', 'destination-mongodb', 'destination-motherduck', 'destination-mssql', 'destination-mssql-v2', 'destination-mysql', 'destination-oracle', 'destination-pgvector', 'destination-pinecone', 'destination-postgres', 'destination-pubsub', 'destination-qdrant', 'destination-rabbitmq', 'destination-ragie', 'destination-redis', 'destination-redshift', 'destination-s3', 'destination-s3-data-lake', 'destination-s3-glue', 'destination-salesforce', 'destination-sftp-json', 'destination-snowflake', 'destination-snowflake-cortex', 'destination-sqlite', 'destination-starburst-galaxy', 'destination-surrealdb', 'destination-teradata', 'destination-timeplus', 'destination-typesense', 'destination-vectara', 'destination-weaviate', 'destination-yellowbrick', 'source-100ms', 'source-7shifts', 'source-activecampaign', 'source-acuity-scheduling', 'source-adjust', 'source-adobe-commerce-magento', 'source-agilecrm', 'source-aha', 'source-airbyte', 'source-aircall', 'source-airtable', 'source-akeneo','source-algolia', 'source-alpaca-broker-api', 'source-alpha-vantage', 'source-amazon-ads', 'source-amazon-seller-partner', 'source-amazon-sqs', 'source-amplitude', 'source-apify-dataset', 'source-appcues', 'source-appfigures', 'source-appfollow', 'source-apple-search-ads', 'source-appsflyer', 'source-apptivo', 'source-asana', 'source-ashby', 'source-assemblyai', 'source-auth0', 'source-aviationstack', 'source-avni', 'source-awin-advertiser', 'source-aws-cloudtrail', 'source-azure-blob-storage', 'source-azure-table', 'source-babelforce', 'source-bamboo-hr', 'source-basecamp', 'source-beamer', 'source-bigmailer', 'source-bigquery', 'source-bing-ads', 'source-bitly', 'source-blogger', 'source-bluetally', 'source-boldsign', 'source-box', 'source-box-data-extract', 'source-braintree', 'source-braze', 'source-breezometer', 'source-breezy-hr', 'source-brevo', 'source-brex', 'source-bugsnag', 'source-buildkite', 'source-bunny-inc', 'source-buzzsprout', 'source-cal-com', 'source-calendly', 'source-callrail', 'source-campaign-monitor', 'source-campayn', 'source-canny', 'source-capsule-crm', 'source-captain-data', 'source-care-quality-commission', 'source-cart', 'source-castor-edc', 'source-chameleon', 'source-chargebee', 'source-chargedesk', 'source-chargify', 'source-chartmogul', 'source-chift', 'source-churnkey', 'source-cimis', 'source-cin7', 'source-circa', 'source-circleci', 'source-cisco-meraki', 'source-clarif-ai', 'source-clazar', 'source-clickhouse', 'source-clickup-api', 'source-clockify','source-clockodo', 'source-close-com', 'source-cloudbeds', 'source-coassemble', 'source-cockroachdb', 'source-coda', 'source-codefresh', 'source-coin-api', 'source-coingecko-coins', 'source-coinmarketcap', 'source-commcare', 'source-commercetools', 'source-concord', 'source-configcat', 'source-confluence', 'source-convertkit', 'source-convex', 'source-copper', 'source-couchbase', 'source-countercyclical', 'source-criteo-marketing', 'source-customer-io', 'source-customerly', 'source-datadog', 'source-datagen', 'source-datascope', 'source-db2', 'source-db2-enterprise', 'source-dbt', 'source-defillama', 'source-delighted', 'source-deputy', 'source-devin-ai', 'source-ding-connect', 'source-discord', 'source-dixa', 'source-dockerhub', 'source-docuseal', 'source-dolibarr', 'source-dremio', 'source-drift', 'source-drip', 'source-dropbox-sign', 'source-dwolla', 'source-dynamodb', 'source-e-conomic', 'source-e2e-test', 'source-easypost', 'source-easypromos', 'source-ebay-finance', 'source-ebay-fulfillment', 'source-elasticemail', 'source-elasticsearch', 'source-emailoctopus', 'source-employment-hero', 'source-encharge', 'source-eventbrite', 'source-eventee', 'source-eventzilla', 'source-everhour', 'source-exchange-rates', 'source-ezofficeinventory', 'source-facebook-marketing', 'source-facebook-pages', 'source-factorial', 'source-faker', 'source-fastbill', 'source-fastly', 'source-fauna', 'source-feishu', 'source-file', 'source-fillout', 'source-finage', 'source-financial-modelling', 'source-finnhub', 'source-finnworlds', 'source-firebase-realtime-database', 'source-firebolt', 'source-firehydrant', 'source-fleetio', 'source-flexmail', 'source-flexport', 'source-float', 'source-flowlu', 'source-formbricks', 'source-free-agent-connector', 'source-freightview', 'source-freshbooks', 'source-freshcaller', 'source-freshchat', 'source-freshdesk', 'source-freshsales', 'source-freshservice', 'source-front', 'source-fulcrum', 'source-fullstory', 'source-gainsight-px', 'source-gcs', 'source-genesys', 'source-getgist', 'source-getlago', 'source-giphy', 'source-gitbook', 'source-github', 'source-gitlab', 'source-glassfrog', 'source-gmail', 'source-gnews', 'source-gocardless', 'source-goldcast', 'source-gologin', 'source-gong', 'source-google-ads', 'source-google-analytics-data-api', 'source-google-calendar', 'source-google-classroom', 'source-google-directory', 'source-google-drive', 'source-google-forms', 'source-google-pagespeed-insights', 'source-google-search-console', 'source-google-sheets', 'source-google-tasks', 'source-google-webfonts', 'source-gorgias', 'source-grafana', 'source-granola', 'source-greenhouse', 'source-greythr', 'source-gridly', 'source-guru', 'source-gutendex', 'source-hardcoded-records', 'source-harness', 'source-harvest', 'source-height', 'source-hellobaton', 'source-help-scout', 'source-hibob', 'source-high-level', 'source-hoorayhr', 'source-hubplanner', 'source-hubspot', 'source-hugging-face-datasets', 'source-humanitix', 'source-huntr', 'source-illumina-basespace', 'source-imagga', 'source-incident-io', 'source-inflowinventory', 'source-insightful', 'source-insightly', 'source-instagram', 'source-instatus', 'source-intercom', 'source-interzoid', 'source-intruder', 'source-invoiced', 'source-invoiceninja', 'source-ip2whois', 'source-iterable', 'source-jamf-pro', 'source-jina-ai-reader', 'source-jira', 'source-jobnimbus', 'source-jotform', 'source-judge-me-reviews', 'source-just-sift', 'source-justcall', 'source-k6-cloud', 'source-kafka', 'source-katana', 'source-keka', 'source-kisi', 'source-kissmetrics', 'source-klarna', 'source-klaus-api', 'source-klaviyo', 'source-kyriba', 'source-kyve', 'source-launchdarkly', 'source-leadfeeder', 'source-lemlist', 'source-less-annoying-crm', 'source-lever-hiring', 'source-lightspeed-retail', 'source-linear', 'source-linkedin-ads', 'source-linkedin-pages', 'source-linkrunner', 'source-linnworks', 'source-lob', 'source-lokalise', 'source-looker', 'source-luma', 'source-mailchimp', 'source-mailerlite', 'source-mailersend', 'source-mailgun', 'source-mailjet-mail', 'source-mailjet-sms', 'source-mailosaur', 'source-mailtrap','source-mantle', 'source-marketo', 'source-marketstack', 'source-mendeley', 'source-mention', 'source-mercado-ads', 'source-merge', 'source-metabase', 'source-metricool', 'source-microsoft-dataverse', 'source-microsoft-entra-id', 'source-microsoft-lists', 'source-microsoft-onedrive', 'source-microsoft-sharepoint', 'source-microsoft-teams', 'source-miro', 'source-missive', 'source-mixmax', 'source-mixpanel', 'source-mode', 'source-monday', 'source-mongodb-v2', 'source-mssql', 'source-mux', 'source-my-hours', 'source-mysql', 'source-n8n', 'source-nasa', 'source-navan', 'source-nebius-ai', 'source-netsuite', 'source-netsuite-enterprise', 'source-news-api', 'source-newsdata', 'source-newsdata-io', 'source-nexiopay', 'source-nexus-datasets', 'source-ninjaone-rmm', 'source-nocrm', 'source-northpass-lms', 'source-notion', 'source-nutshell', 'source-nylas', 'source-nytimes', 'source-okta', 'source-omnisend', 'source-oncehub', 'source-onepagecrm', 'source-onesignal', 'source-onfleet', 'source-open-data-dc', 'source-open-exchange-rates', 'source-openaq', 'source-openfda', 'source-openweather', 'source-opinion-stage', 'source-opsgenie', 'source-opuswatch', 'source-oracle', 'source-oracle-enterprise', 'source-orb', 'source-oura', 'source-outbrain-amplify', 'source-outlook', 'source-outreach', 'source-oveit', 'source-pabbly-subscriptions-billing', 'source-paddle', 'source-pagerduty', 'source-pandadoc', 'source-paperform', 'source-papersign', 'source-pardot', 'source-partnerize', 'source-partnerstack', 'source-payfit', 'source-paypal-transaction', 'source-paystack', 'source-pendo', 'source-pennylane', 'source-perigon', 'source-perk', 'source-persistiq', 'source-persona', 'source-pexels-api', 'source-phyllo', 'source-picqer', 'source-pingdom', 'source-pinterest', 'source-pipedrive', 'source-pipeliner', 'source-pivotal-tracker', 'source-piwik', 'source-plaid', 'source-planhat', 'source-plausible', 'source-pocket', 'source-pokeapi', 'source-polygon-stock-api', 'source-poplar', 'source-postgres', 'source-posthog', 'source-postmarkapp', 'source-prestashop', 'source-pretix', 'source-primetric', 'source-printify', 'source-productboard', 'source-productive', 'source-public-apis', 'source-pylon', 'source-pypi', 'source-qonto', 'source-qualaroo', 'source-quickbooks', 'source-railz', 'source-rd-station-marketing', 'source-recharge', 'source-recreation', 'source-recruitee', 'source-recurly', 'source-reddit', 'source-redshift', 'source-referralhero', 'source-rentcast', 'source-repairshopr', 'source-reply-io', 'source-retailexpress-by-maropost', 'source-retently', 'source-revenuecat', 'source-revolut-merchant', 'source-ringcentral', 'source-rki-covid', 'source-rocket-chat', 'source-rocketlane', 'source-rollbar', 'source-rootly', 'source-rss', 'source-ruddr', 'source-s3', 'source-safetyculture', 'source-sage-hr', 'source-salesflare', 'source-salesforce', 'source-salesloft', 'source-sap-fieldglass', 'source-sap-hana-enterprise', 'source-savvycal', 'source-scryfall', 'source-secoda', 'source-segment', 'source-sendgrid', 'source-sendinblue', 'source-sendowl', 'source-sendpulse', 'source-senseforce', 'source-sentry', 'source-serpstat', 'source-service-now', 'source-sftp', 'source-sftp-bulk', 'source-sharepoint-enterprise', 'source-sharepoint-lists-enterprise', 'source-sharetribe', 'source-shippo', 'source-shipstation', 'source-shopify', 'source-shopwired', 'source-shortcut', 'source-shortio', 'source-shutterstock', 'source-sigma-computing', 'source-signnow', 'source-simfin', 'source-simplecast', 'source-simplesat', 'source-singlestore', 'source-slack', 'source-smaily', 'source-smartengage', 'source-smartreach', 'source-smartsheets', 'source-smartwaiver', 'source-smoke-test', 'source-snapchat-marketing', 'source-snowflake', 'source-solarwinds-service-desk', 'source-sonar-cloud', 'source-spacex-api', 'source-sparkpost', 'source-split-io', 'source-spotify-ads', 'source-spotlercrm', 'source-square', 'source-squarespace', 'source-statsig', 'source-statuspage', 'source-stigg', 'source-stockdata', 'source-strava', 'source-stripe', 'source-survey-sparrow', 'source-surveycto', 'source-surveymonkey', 'source-survicate', 'source-svix', 'source-systeme', 'source-taboola', 'source-tavus', 'source-teamtailor', 'source-teamwork', 'source-tempo', 'source-teradata', 'source-testrail', 'source-the-guardian-api','source-thinkific', 'source-thinkific-courses', 'source-thrive-learning', 'source-ticketmaster', 'source-tickettailor', 'source-ticktick', 'source-tidb', 'source-tiktok-marketing', 'source-timely', 'source-tinyemail', 'source-tmdb', 'source-todoist', 'source-toggl', 'source-tplcentral', 'source-track-pms', 'source-trello', 'source-tremendous', 'source-trustpilot', 'source-tvmaze-schedule', 'source-twelve-data', 'source-twilio', 'source-twilio-taskrouter', 'source-twitter', 'source-tyntec-sms', 'source-typeform', 'source-ubidots', 'source-unleash', 'source-uppromote', 'source-uptick', 'source-us-census', 'source-uservoice', 'source-vantage', 'source-veeqo', 'source-vercel', 'source-visma-economic','source-vitally', 'source-vwo', 'source-waiteraid', 'source-wasabi-stats-api', 'source-watchmode', 'source-weatherstack', 'source-web-scrapper', 'source-webflow', 'source-when-i-work', 'source-whisky-hunter', 'source-wikipedia-pageviews', 'source-woocommerce', 'source-wordpress', 'source-workable', 'source-workday', 'source-workday-rest', 'source-workflowmax', 'source-workramp', 'source-wrike', 'source-wufoo', 'source-xero', 'source-xkcd', 'source-xsolla', 'source-yahoo-finance-price', 'source-yandex-metrica', 'source-yotpo', 'source-you-need-a-budget-ynab', 'source-younium', 'source-yousign', 'source-youtube-analytics', 'source-youtube-data', 'source-zapier-supported-storage', 'source-zapsign', 'source-zendesk-chat', 'source-zendesk-sunshine', 'source-zendesk-support', 'source-zendesk-talk', 'source-zenefits', 'source-zenloop', 'source-zoho-analytics-metadata-api', 'source-zoho-bigin', 'source-zoho-billing', 'source-zoho-books', 'source-zoho-campaign', 'source-zoho-crm', 'source-zoho-desk', 'source-zoho-expense', 'source-zoho-inventory', 'source-zoho-invoice', 'source-zonka-feedback', 'source-zoom'], is_error=False)
```

That shows both the HTTP transport and MCP protocol working.
<img width="1704" height="812" alt="Screenshot 2026-07-07 at 2 34 58 PM" src="https://github.com/user-attachments/assets/7d530989-01ba-4eee-b068-d9b6bde43027" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for hosting the MCP server over HTTPS for remote clients.
  * Introduced a new Streamable HTTP startup option and expanded local testing commands.

* **Bug Fixes**
  * Improved HTTP handling for remote access by enabling configurable CORS support and required response headers.
  * Added reverse-proxy and container deployment examples for secure public access.

* **Documentation**
  * Expanded setup docs with HTTPS deployment, authentication, health checks, and local development instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->