### PR TITLE
feat(mcp): support headless bearer-token transport auth

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -144,6 +144,75 @@ are not considered to be modifications of the Airbyte Cloud workspace.
 
 Set the environment variable `AIRBYTE_CLOUD_MCP_READONLY_MODE=1` to enable read-only mode.
 
+## Authentication for Remote (HTTP) Servers
+
+The steps above run the MCP server over **stdio** — the client launches the
+server process locally, so there is no transport-layer auth and the only
+credentials that matter are your Airbyte Cloud creds in the dotenv file.
+
+When the server is instead exposed over **HTTP** (`airbyte-mcp-http` /
+`poe mcp-serve-http`), it verifies an `Authorization: Bearer <token>` on every
+request. Two client shapes are supported on the same deployment (combined
+automatically when both are configured):
+
+### Humans → interactive OIDC
+
+Set `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET`. Interactive
+clients open a browser (Keycloak Authorization Code + PKCE) and the resulting
+token is verified by the server. No bearer token to manage by hand.
+
+### Machines / agents → headless bearer token
+
+There is **no** transport mode that accepts a raw `client_id` + `client_secret`
+in a header. A headless agent **mints its own short-lived bearer token** and
+sends it as `Authorization: Bearer <token>`; the server verifies the signature
+(no browser, no stored/rotating refresh token).
+
+For Airbyte Cloud, set `MCP_AUTH_AIRBYTE_CLOUD=true` on the server so it verifies
+tokens against Airbyte Cloud's application-client realm without hand-configuring
+URLs. The agent mints an Airbyte Cloud access token from its
+`AIRBYTE_CLOUD_CLIENT_ID` / `AIRBYTE_CLOUD_CLIENT_SECRET` (the
+`https://api.airbyte.com/v1/applications/token` endpoint) and sends it as the
+bearer. That single token both authenticates transport (verified by the server)
+and authorizes downstream Cloud API calls, because an Airbyte-Cloud-issued token
+is itself a valid Cloud API bearer. Tokens are short-lived (~15 min), so
+re-mint on expiry / on a `401` rather than pinning a static token.
+
+Clients that support HTTP transports can pass the token via a `headers` block in
+their MCP config:
+
+```json
+{
+  "mcpServers": {
+    "airbyte": {
+      "url": "https://<host>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${AIRBYTE_MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Server environment variables (HTTP mode)
+
+- `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
+  callbacks); defaults to `http://localhost:8080`.
+- `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` — enable interactive
+  OIDC (all three required).
+- `MCP_AUTH_AIRBYTE_CLOUD` — set truthy to verify headless tokens against Airbyte
+  Cloud's realm (fills JWKS URI / issuer / audience / algorithm with Airbyte
+  Cloud defaults; each stays overridable).
+- `MCP_AUTH_JWKS_URI` / `MCP_AUTH_JWT_PUBLIC_KEY` — JWKS URL or static public key
+  for verifying headless tokens.
+- `MCP_AUTH_ISSUER` / `MCP_AUTH_AUDIENCE` / `MCP_AUTH_ALGORITHM` — expected `iss`
+  / `aud` claims and signing algorithm (recommended for headless).
+
+If no transport auth variables are set, the HTTP server starts
+**unauthenticated** and logs a warning — acceptable only behind a trusted
+network boundary. The verifier assembly is provided by
+[`fastmcp-extensions`](https://github.com/airbytehq/fastmcp-extensions).
+
 ## Troubleshooting
 
 ### Troubleshooting Local Connector Installation Issues

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 from fastmcp.apps import UI_EXTENSION_ID
-from fastmcp.server.dependencies import get_context
+from fastmcp.server.dependencies import get_access_token, get_context
 from fastmcp_extensions import MCPServerConfigArg, get_mcp_config
 from fastmcp_extensions import mcp_tool as _mcp_tool
 from fastmcp_extensions.decorators import (
@@ -166,14 +166,53 @@ WORKSPACE_ID_CONFIG_ARG = MCPServerConfigArg(
 )
 """Config arg for workspace ID, supporting both HTTP header and env var."""
 
+
+def _normalize_bearer_token(value: str) -> str | None:
+    """Strip an optional `Bearer ` prefix from an `Authorization` value.
+
+    Accepts either a full `Authorization` header value (`Bearer <token>`,
+    case-insensitive prefix) or a bare token, and returns the bare token so it
+    can be forwarded downstream. Returns `None` for an empty value so config
+    resolution falls through to the next source.
+    """
+    stripped = value.strip()
+    if stripped.lower().startswith("bearer "):
+        stripped = stripped[len("bearer ") :].strip()
+    return stripped or None
+
+
+def _resolve_transport_bearer_token() -> str:
+    """Resolve the verified transport bearer token for downstream Cloud calls.
+
+    FastMCP stores the access token of the current request after the transport
+    auth provider verifies it — the interactive `OIDCProxy` token or the
+    headless client-minted JWT. Both are Airbyte Cloud tokens when the server
+    verifies against Airbyte Cloud's realm, so reusing the token as the
+    downstream Cloud API bearer gives the caller delegated access without a
+    second credential. Returns an empty string when no verified token is
+    present (for example, stdio mode).
+    """
+    access_token = get_access_token()
+    if access_token and access_token.token:
+        return access_token.token
+    return ""
+
+
 BEARER_TOKEN_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_BEARER_TOKEN,
     http_header_key=MCP_BEARER_TOKEN_HEADER,
     env_var=CLOUD_BEARER_TOKEN_ENV_VAR,
+    normalize_fn=_normalize_bearer_token,
+    default=_resolve_transport_bearer_token,
     required=False,
     sensitive=True,
 )
-"""Config arg for bearer token, supporting Authorization header and env var."""
+"""Config arg for bearer token, supporting Authorization header and env var.
+
+Reads the transport `Authorization` header (stripping the `Bearer ` prefix)
+or `AIRBYTE_CLOUD_BEARER_TOKEN`, then falls back to the verified transport
+token so an interactive-OIDC or headless-JWT caller's token passes through to
+the downstream Airbyte Cloud API without a second credential."""
 
 CLIENT_ID_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CLIENT_ID,

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -3,7 +3,7 @@
 
 Starts the MCP server with HTTP transport, suitable for hosted deployment
 behind a load balancer. Transport auth is assembled in `server.py` via
-`fastmcp_extensions.build_mcp_auth`, which supports interactive OIDC and
+`fastmcp_extensions.resolve_mcp_auth`, which supports interactive OIDC and
 headless bearer-token verification (combined via `MultiAuth` when both are
 configured). See `server.py` for details.
 

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -2,17 +2,33 @@
 """HTTP transport entry point for the Airbyte MCP server.
 
 Starts the MCP server with HTTP transport, suitable for hosted deployment
-behind a load balancer. When OIDC env vars are set, authentication is
-handled by `OIDCProxy` (configured in `server.py`).
+behind a load balancer. Transport auth is assembled in `server.py` via
+`fastmcp_extensions.build_mcp_auth`, which supports interactive OIDC and
+headless bearer-token verification (combined via `MultiAuth` when both are
+configured). See `server.py` for details.
 
 Environment variables:
 
 - `MCP_SERVER_URL`: Public base URL. Used for OIDC redirect callbacks and to
   derive the MCP endpoint mount path (serves at `/` when the URL has a path
   prefix, otherwise defaults to `/mcp`).
-- `OIDC_CONFIG_URL`: Keycloak OIDC discovery URL (enables auth with all three OIDC vars)
+
+Interactive OIDC (Keycloak Authorization Code + PKCE), enabled when all three
+are set:
+
+- `OIDC_CONFIG_URL`: Keycloak OIDC discovery URL
 - `OIDC_CLIENT_ID`: OIDC client identifier
 - `OIDC_CLIENT_SECRET`: OIDC client secret
+
+Headless bearer-token verification (for agents/CI that mint their own
+short-lived token via the client credentials grant), enabled when
+`MCP_AUTH_JWKS_URI` or `MCP_AUTH_JWT_PUBLIC_KEY` is set:
+
+- `MCP_AUTH_JWKS_URI`: JWKS endpoint used to verify token signatures
+- `MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to `MCP_AUTH_JWKS_URI`)
+- `MCP_AUTH_ISSUER`: expected token issuer
+- `MCP_AUTH_AUDIENCE`: expected token audience
+- `MCP_AUTH_ALGORITHM`: signing algorithm override
 """
 
 from __future__ import annotations

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -61,6 +61,15 @@ def main() -> None:
     )
     mcp_path = "/" if urlparse(server_url).path.strip("/") else "/mcp"
 
+    if getattr(app, "auth", None) is None:
+        logger.warning(
+            "HTTP transport starting without authentication: no interactive "
+            "OIDC or headless bearer-token auth is configured, so every "
+            "request is unauthenticated. Set `OIDC_CONFIG_URL`/`OIDC_CLIENT_ID`/"
+            "`OIDC_CLIENT_SECRET` (interactive) or `MCP_AUTH_JWKS_URI`/"
+            "`MCP_AUTH_JWT_PUBLIC_KEY` (headless) to require auth."
+        )
+
     logger.info(
         "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",
         DEFAULT_HTTP_HOST,

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -174,6 +174,14 @@ def _create_auth() -> AuthProvider | None:
             client_secret=oidc_client_secret,
             base_url=server_url,
         )
+    elif config_url or oidc_client_id or oidc_client_secret:
+        logger.warning(
+            "Incomplete interactive OIDC configuration: set all of `%s`, `%s`, "
+            "and `%s` to enable it. Interactive OIDC auth is disabled.",
+            OIDC_CONFIG_URL_ENV,
+            OIDC_CLIENT_ID_ENV,
+            OIDC_CLIENT_SECRET_ENV,
+        )
 
     jwt: JWTAuthConfig | None = None
     use_cloud_defaults = os.getenv(MCP_AUTH_AIRBYTE_CLOUD_ENV, "").strip().lower() in {

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -5,9 +5,18 @@ Supports two transport modes:
 
 - **stdio** (default): For local MCP clients (Claude Desktop, etc.)
 - **HTTP**: For hosted deployment. Start via `airbyte-mcp-http` entry point or
-  `poe mcp-serve-http`. When `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and
-  `OIDC_CLIENT_SECRET` are all set, enables Keycloak OIDC authentication
-  via `OIDCProxy`.
+  `poe mcp-serve-http`. Transport auth is assembled by
+  `fastmcp_extensions.build_mcp_auth`, which supports two client shapes on the
+  same deployment:
+    - **Interactive** (humans in a browser): Keycloak Authorization Code + PKCE
+      via `OIDCProxy`, enabled when `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and
+      `OIDC_CLIENT_SECRET` are all set.
+    - **Headless** (agents, CI): the client mints its own short-lived bearer
+      token via the OAuth 2.0 client credentials grant and sends it as
+      `Authorization: Bearer <token>`. The server verifies it with a
+      `JWTVerifier` (no browser, no stored/rotating refresh token), enabled
+      when `MCP_AUTH_JWKS_URI` (or `MCP_AUTH_JWT_PUBLIC_KEY`) is set.
+  When both are configured they are combined via `MultiAuth`.
 """
 
 from __future__ import annotations
@@ -18,12 +27,17 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
-from fastmcp.server.auth.oidc_proxy import OIDCProxy
-from fastmcp_extensions import mcp_server
+from fastmcp_extensions import (
+    JWTAuthConfig,
+    OIDCAuthConfig,
+    build_mcp_auth,
+    mcp_server,
+)
 from starlette.responses import JSONResponse
 
 
 if TYPE_CHECKING:
+    from fastmcp.server.auth import AuthProvider
     from starlette.requests import Request
 
 from airbyte._util.meta import set_mcp_mode
@@ -85,46 +99,83 @@ Safety features:
 
 logger = logging.getLogger(__name__)
 
+# OIDC environment variable names (interactive Authorization Code + PKCE)
 OIDC_CONFIG_URL_ENV = "OIDC_CONFIG_URL"
 OIDC_CLIENT_ID_ENV = "OIDC_CLIENT_ID"
 OIDC_CLIENT_SECRET_ENV = "OIDC_CLIENT_SECRET"
 MCP_SERVER_URL_ENV = "MCP_SERVER_URL"
 
+# Headless bearer-token verification environment variable names.
+# Agents/CI mint a short-lived token via the client credentials grant and the
+# server verifies it here — no interactive flow, no refresh token to rotate.
+MCP_AUTH_JWKS_URI_ENV = "MCP_AUTH_JWKS_URI"
+MCP_AUTH_JWT_PUBLIC_KEY_ENV = "MCP_AUTH_JWT_PUBLIC_KEY"
+MCP_AUTH_ISSUER_ENV = "MCP_AUTH_ISSUER"
+MCP_AUTH_AUDIENCE_ENV = "MCP_AUTH_AUDIENCE"
+MCP_AUTH_ALGORITHM_ENV = "MCP_AUTH_ALGORITHM"
+
 DEFAULT_HTTP_HOST = "0.0.0.0"
 DEFAULT_HTTP_PORT = 8080
 
 
-def _create_oidc_auth() -> OIDCProxy | None:
-    """Create an `OIDCProxy` auth provider when OIDC env vars are configured.
+def _create_auth() -> AuthProvider | None:
+    """Assemble the transport auth provider from environment configuration.
 
-    When `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` are all
-    set, returns an `OIDCProxy` that handles the Keycloak Authorization Code +
-    PKCE flow. Otherwise returns `None` (no auth, standard local behavior).
+    Supports two client shapes on the same deployment, combined via `MultiAuth`
+    when both are configured (see `fastmcp_extensions.build_mcp_auth`):
+
+    - **Interactive** `OIDCProxy` (Keycloak Authorization Code + PKCE) when
+      `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` are set.
+    - **Headless** `JWTVerifier` for pre-minted bearer tokens when
+      `MCP_AUTH_JWKS_URI` or `MCP_AUTH_JWT_PUBLIC_KEY` is set.
+
+    Returns `None` when neither is configured, so the server falls back to
+    standard local (no-auth) behavior.
     """
-    config_url = os.getenv(OIDC_CONFIG_URL_ENV, "")
-    client_id = os.getenv(OIDC_CLIENT_ID_ENV, "")
-    client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "")
-
-    if not config_url or not client_id or not client_secret:
-        return None
-
     server_url = os.getenv(
         MCP_SERVER_URL_ENV,
         f"http://localhost:{DEFAULT_HTTP_PORT}",
     )
 
-    logger.info(
-        "OIDC auth enabled (issuer=%s, client_id=%s, base_url=%s)",
-        config_url,
-        client_id,
-        server_url,
-    )
-    return OIDCProxy(
-        config_url=config_url,
-        client_id=client_id,
-        client_secret=client_secret,
-        base_url=server_url,
-    )
+    oidc: OIDCAuthConfig | None = None
+    config_url = os.getenv(OIDC_CONFIG_URL_ENV, "")
+    oidc_client_id = os.getenv(OIDC_CLIENT_ID_ENV, "")
+    oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "")
+    if config_url and oidc_client_id and oidc_client_secret:
+        logger.info(
+            "Interactive OIDC auth enabled (issuer=%s, client_id=%s, base_url=%s)",
+            config_url,
+            oidc_client_id,
+            server_url,
+        )
+        oidc = OIDCAuthConfig(
+            config_url=config_url,
+            client_id=oidc_client_id,
+            client_secret=oidc_client_secret,
+            base_url=server_url,
+        )
+
+    jwt: JWTAuthConfig | None = None
+    jwks_uri = os.getenv(MCP_AUTH_JWKS_URI_ENV, "")
+    jwt_public_key = os.getenv(MCP_AUTH_JWT_PUBLIC_KEY_ENV, "")
+    if jwks_uri or jwt_public_key:
+        issuer = os.getenv(MCP_AUTH_ISSUER_ENV) or None
+        audience = os.getenv(MCP_AUTH_AUDIENCE_ENV) or None
+        logger.info(
+            "Headless bearer-token auth enabled (jwks_uri=%s, issuer=%s, audience=%s)",
+            jwks_uri or "<static public key>",
+            issuer,
+            audience,
+        )
+        jwt = JWTAuthConfig(
+            jwks_uri=jwks_uri or None,
+            public_key=jwt_public_key or None,
+            issuer=issuer,
+            audience=audience,
+            algorithm=os.getenv(MCP_AUTH_ALGORITHM_ENV) or None,
+        )
+
+    return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=server_url)
 
 
 set_mcp_mode()
@@ -151,7 +202,7 @@ app = mcp_server(
         airbyte_module_filter,
         airbyte_ui_support_filter,
     ],
-    auth=_create_oidc_auth(),
+    auth=_create_auth(),
 )
 """The Airbyte MCP Server application instance."""
 

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -6,7 +6,7 @@ Supports two transport modes:
 - **stdio** (default): For local MCP clients (Claude Desktop, etc.)
 - **HTTP**: For hosted deployment. Start via `airbyte-mcp-http` entry point or
   `poe mcp-serve-http`. Transport auth is assembled by
-  `fastmcp_extensions.build_mcp_auth`, which supports two client shapes on the
+  `fastmcp_extensions.resolve_mcp_auth`, which supports two client shapes on the
   same deployment:
     - **Interactive** (humans in a browser): Keycloak Authorization Code + PKCE
       via `OIDCProxy`, enabled when `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and
@@ -38,9 +38,8 @@ from typing import TYPE_CHECKING
 
 from fastmcp_extensions import (
     JWTAuthConfig,
-    OIDCAuthConfig,
-    build_mcp_auth,
     mcp_server,
+    resolve_mcp_auth,
 )
 from starlette.responses import JSONResponse
 
@@ -108,20 +107,13 @@ Safety features:
 
 logger = logging.getLogger(__name__)
 
-# OIDC environment variable names (interactive Authorization Code + PKCE)
-OIDC_CONFIG_URL_ENV = "OIDC_CONFIG_URL"
-OIDC_CLIENT_ID_ENV = "OIDC_CLIENT_ID"
-OIDC_CLIENT_SECRET_ENV = "OIDC_CLIENT_SECRET"
+# Public base URL of this deployment; consumed by `http_main` to derive the
+# mounted MCP path. All other transport auth env vars (`OIDC_*` interactive,
+# `MCP_AUTH_*` headless) are read by `fastmcp_extensions.resolve_mcp_auth`.
 MCP_SERVER_URL_ENV = "MCP_SERVER_URL"
 
-# Headless bearer-token verification environment variable names.
-# Agents/CI mint a short-lived token via the client credentials grant and the
-# server verifies it here — no interactive flow, no refresh token to rotate.
-MCP_AUTH_JWKS_URI_ENV = "MCP_AUTH_JWKS_URI"
-MCP_AUTH_JWT_PUBLIC_KEY_ENV = "MCP_AUTH_JWT_PUBLIC_KEY"
-MCP_AUTH_ISSUER_ENV = "MCP_AUTH_ISSUER"
-MCP_AUTH_AUDIENCE_ENV = "MCP_AUTH_AUDIENCE"
-MCP_AUTH_ALGORITHM_ENV = "MCP_AUTH_ALGORITHM"
+# Flag that opts headless verification into Airbyte Cloud's application-client
+# realm; this server owns only this provider literal.
 MCP_AUTH_AIRBYTE_CLOUD_ENV = "MCP_AUTH_AIRBYTE_CLOUD"
 
 # Airbyte Cloud's application-client realm. Tokens minted from an Airbyte Cloud
@@ -141,81 +133,26 @@ DEFAULT_HTTP_PORT = 8080
 def _create_auth() -> AuthProvider | None:
     """Assemble the transport auth provider from environment configuration.
 
-    Supports two client shapes on the same deployment, combined via `MultiAuth`
-    when both are configured (see `fastmcp_extensions.build_mcp_auth`):
+    Delegates env parsing to `fastmcp_extensions.resolve_mcp_auth`, which wires
+    up interactive `OIDCProxy` (from `OIDC_*`) and/or headless `JWTVerifier`
+    (from `MCP_AUTH_*`), combining them via `MultiAuth` when both are set and
+    returning `None` when neither is — so the server falls back to standard
+    local (no-auth) behavior.
 
-    - **Interactive** `OIDCProxy` (Keycloak Authorization Code + PKCE) when
-      `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` are set.
-    - **Headless** `JWTVerifier` for pre-minted bearer tokens when
-      `MCP_AUTH_JWKS_URI` or `MCP_AUTH_JWT_PUBLIC_KEY` is set.
-
-    Returns `None` when neither is configured, so the server falls back to
-    standard local (no-auth) behavior.
+    When `MCP_AUTH_AIRBYTE_CLOUD` is truthy, the headless verifier defaults to
+    Airbyte Cloud's application-client realm (JWKS / issuer / audience /
+    algorithm); individual `MCP_AUTH_*` vars still override those fields. This
+    is the only provider literal the server owns.
     """
-    server_url = os.getenv(
-        MCP_SERVER_URL_ENV,
-        f"http://localhost:{DEFAULT_HTTP_PORT}",
-    )
-
-    oidc: OIDCAuthConfig | None = None
-    config_url = os.getenv(OIDC_CONFIG_URL_ENV, "")
-    oidc_client_id = os.getenv(OIDC_CLIENT_ID_ENV, "")
-    oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "")
-    if config_url and oidc_client_id and oidc_client_secret:
-        logger.info(
-            "Interactive OIDC auth enabled (config_url=%s, client_id=%s, base_url=%s)",
-            config_url,
-            oidc_client_id,
-            server_url,
+    jwt_defaults: JWTAuthConfig | None = None
+    if os.getenv(MCP_AUTH_AIRBYTE_CLOUD_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        jwt_defaults = JWTAuthConfig(
+            jwks_uri=AIRBYTE_CLOUD_JWKS_URI,
+            issuer=AIRBYTE_CLOUD_REALM_ISSUER,
+            audience=AIRBYTE_CLOUD_JWT_AUDIENCE,
+            algorithm=AIRBYTE_CLOUD_JWT_ALGORITHM,
         )
-        oidc = OIDCAuthConfig(
-            config_url=config_url,
-            client_id=oidc_client_id,
-            client_secret=oidc_client_secret,
-            base_url=server_url,
-        )
-    elif config_url or oidc_client_id or oidc_client_secret:
-        logger.warning(
-            "Incomplete interactive OIDC configuration: set all of "
-            "OIDC_CONFIG_URL, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET to enable "
-            "it. Interactive OIDC auth is disabled."
-        )
-
-    jwt: JWTAuthConfig | None = None
-    use_cloud_defaults = os.getenv(MCP_AUTH_AIRBYTE_CLOUD_ENV, "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }
-    jwks_uri = os.getenv(MCP_AUTH_JWKS_URI_ENV, "")
-    jwt_public_key = os.getenv(MCP_AUTH_JWT_PUBLIC_KEY_ENV, "")
-    if use_cloud_defaults and not jwks_uri and not jwt_public_key:
-        jwks_uri = AIRBYTE_CLOUD_JWKS_URI
-    if jwks_uri or jwt_public_key:
-        issuer = os.getenv(MCP_AUTH_ISSUER_ENV) or (
-            AIRBYTE_CLOUD_REALM_ISSUER if use_cloud_defaults else None
-        )
-        audience = os.getenv(MCP_AUTH_AUDIENCE_ENV) or (
-            AIRBYTE_CLOUD_JWT_AUDIENCE if use_cloud_defaults else None
-        )
-        algorithm = os.getenv(MCP_AUTH_ALGORITHM_ENV) or (
-            AIRBYTE_CLOUD_JWT_ALGORITHM if use_cloud_defaults else None
-        )
-        logger.info(
-            "Headless bearer-token auth enabled (jwks_uri=%s, issuer=%s, audience=%s)",
-            jwks_uri or "<static public key>",
-            issuer,
-            audience,
-        )
-        jwt = JWTAuthConfig(
-            jwks_uri=jwks_uri or None,
-            public_key=jwt_public_key or None,
-            issuer=issuer,
-            audience=audience,
-            algorithm=algorithm,
-        )
-
-    return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=server_url)
+    return resolve_mcp_auth(jwt_defaults=jwt_defaults)
 
 
 set_mcp_mode()

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -129,9 +129,7 @@ MCP_AUTH_AIRBYTE_CLOUD_ENV = "MCP_AUTH_AIRBYTE_CLOUD"
 # issued by this realm, and the same token is a valid Airbyte Cloud API bearer.
 # Verifying against this realm lets one token both authenticate transport and
 # authorize downstream Cloud calls. Enable with `MCP_AUTH_AIRBYTE_CLOUD=true`.
-AIRBYTE_CLOUD_REALM_ISSUER = (
-    "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
-)
+AIRBYTE_CLOUD_REALM_ISSUER = "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
 AIRBYTE_CLOUD_JWKS_URI = f"{AIRBYTE_CLOUD_REALM_ISSUER}/protocol/openid-connect/certs"
 AIRBYTE_CLOUD_JWT_AUDIENCE = "account"
 AIRBYTE_CLOUD_JWT_ALGORITHM = "RS256"

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -17,6 +17,15 @@ Supports two transport modes:
       `JWTVerifier` (no browser, no stored/rotating refresh token), enabled
       when `MCP_AUTH_JWKS_URI` (or `MCP_AUTH_JWT_PUBLIC_KEY`) is set.
   When both are configured they are combined via `MultiAuth`.
+
+For Airbyte Cloud, set `MCP_AUTH_AIRBYTE_CLOUD=true` to verify against Airbyte
+Cloud's application-client realm without hand-configuring URLs. An agent then
+mints an Airbyte Cloud access token from its `AIRBYTE_CLOUD_CLIENT_ID` /
+`AIRBYTE_CLOUD_CLIENT_SECRET` (the `<api_root>/applications/token` endpoint) and
+sends it as `Authorization: Bearer`. That single token both authenticates
+transport (verified here) and authorizes downstream Cloud API calls (the same
+header feeds the Cloud bearer token), because an Airbyte-Cloud-issued JWT is
+itself a valid Cloud API bearer.
 """
 
 from __future__ import annotations
@@ -113,6 +122,19 @@ MCP_AUTH_JWT_PUBLIC_KEY_ENV = "MCP_AUTH_JWT_PUBLIC_KEY"
 MCP_AUTH_ISSUER_ENV = "MCP_AUTH_ISSUER"
 MCP_AUTH_AUDIENCE_ENV = "MCP_AUTH_AUDIENCE"
 MCP_AUTH_ALGORITHM_ENV = "MCP_AUTH_ALGORITHM"
+MCP_AUTH_AIRBYTE_CLOUD_ENV = "MCP_AUTH_AIRBYTE_CLOUD"
+
+# Airbyte Cloud's application-client realm. Tokens minted from an Airbyte Cloud
+# `client_id`/`client_secret` via `<api_root>/applications/token` are RS256 JWTs
+# issued by this realm, and the same token is a valid Airbyte Cloud API bearer.
+# Verifying against this realm lets one token both authenticate transport and
+# authorize downstream Cloud calls. Enable with `MCP_AUTH_AIRBYTE_CLOUD=true`.
+AIRBYTE_CLOUD_REALM_ISSUER = (
+    "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
+)
+AIRBYTE_CLOUD_JWKS_URI = f"{AIRBYTE_CLOUD_REALM_ISSUER}/protocol/openid-connect/certs"
+AIRBYTE_CLOUD_JWT_AUDIENCE = "account"
+AIRBYTE_CLOUD_JWT_ALGORITHM = "RS256"
 
 DEFAULT_HTTP_HOST = "0.0.0.0"
 DEFAULT_HTTP_PORT = 8080
@@ -143,7 +165,7 @@ def _create_auth() -> AuthProvider | None:
     oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "")
     if config_url and oidc_client_id and oidc_client_secret:
         logger.info(
-            "Interactive OIDC auth enabled (issuer=%s, client_id=%s, base_url=%s)",
+            "Interactive OIDC auth enabled (config_url=%s, client_id=%s, base_url=%s)",
             config_url,
             oidc_client_id,
             server_url,
@@ -156,11 +178,25 @@ def _create_auth() -> AuthProvider | None:
         )
 
     jwt: JWTAuthConfig | None = None
+    use_cloud_defaults = os.getenv(MCP_AUTH_AIRBYTE_CLOUD_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     jwks_uri = os.getenv(MCP_AUTH_JWKS_URI_ENV, "")
     jwt_public_key = os.getenv(MCP_AUTH_JWT_PUBLIC_KEY_ENV, "")
+    if use_cloud_defaults and not jwks_uri and not jwt_public_key:
+        jwks_uri = AIRBYTE_CLOUD_JWKS_URI
     if jwks_uri or jwt_public_key:
-        issuer = os.getenv(MCP_AUTH_ISSUER_ENV) or None
-        audience = os.getenv(MCP_AUTH_AUDIENCE_ENV) or None
+        issuer = os.getenv(MCP_AUTH_ISSUER_ENV) or (
+            AIRBYTE_CLOUD_REALM_ISSUER if use_cloud_defaults else None
+        )
+        audience = os.getenv(MCP_AUTH_AUDIENCE_ENV) or (
+            AIRBYTE_CLOUD_JWT_AUDIENCE if use_cloud_defaults else None
+        )
+        algorithm = os.getenv(MCP_AUTH_ALGORITHM_ENV) or (
+            AIRBYTE_CLOUD_JWT_ALGORITHM if use_cloud_defaults else None
+        )
         logger.info(
             "Headless bearer-token auth enabled (jwks_uri=%s, issuer=%s, audience=%s)",
             jwks_uri or "<static public key>",
@@ -172,7 +208,7 @@ def _create_auth() -> AuthProvider | None:
             public_key=jwt_public_key or None,
             issuer=issuer,
             audience=audience,
-            algorithm=os.getenv(MCP_AUTH_ALGORITHM_ENV) or None,
+            algorithm=algorithm,
         )
 
     return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=server_url)

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -176,11 +176,9 @@ def _create_auth() -> AuthProvider | None:
         )
     elif config_url or oidc_client_id or oidc_client_secret:
         logger.warning(
-            "Incomplete interactive OIDC configuration: set all of `%s`, `%s`, "
-            "and `%s` to enable it. Interactive OIDC auth is disabled.",
-            OIDC_CONFIG_URL_ENV,
-            OIDC_CLIENT_ID_ENV,
-            OIDC_CLIENT_SECRET_ENV,
+            "Incomplete interactive OIDC configuration: set all of "
+            "OIDC_CONFIG_URL, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET to enable "
+            "it. Interactive OIDC auth is disabled."
         )
 
     jwt: JWTAuthConfig | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.8.0.dev0,<1.0.0",
+    "fastmcp-extensions>=0.8.0,<1.0.0",
     "starlette",
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.7.0,<1.0.0",
+    "fastmcp-extensions>=0.8.0,<1.0.0",
     "starlette",
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.8.0,<1.0.0",
+    "fastmcp-extensions>=0.10.0,<1.0.0",
     "starlette",
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.8.0,<1.0.0",
+    "fastmcp-extensions>=0.8.0.dev0,<1.0.0",
     "starlette",
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
     { name = "fastmcp", specifier = ">=3.0,<4.0" },
-    { name = "fastmcp-extensions", specifier = ">=0.7.0,<1.0.0" },
+    { name = "fastmcp-extensions", specifier = ">=0.8.0.dev0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.27.0,<3.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.12.0,<4.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0,<3.0" },
@@ -1129,18 +1129,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.7.0"
+version = "0.8.0.dev202607132331"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "segment-analytics-python" },
     { name = "sentry-sdk" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/62/8ff5abef165be10811847900d33b4b101d14f54fa2cc537c3b7be8a2e933/fastmcp_extensions-0.7.0.tar.gz", hash = "sha256:bab24601c9fe48c9e5ef9c4704bbb3553192ee05815740bac0faaa40fefd99b1", size = 183069, upload-time = "2026-06-29T18:16:00.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ec/b6cb2ac62840408a7e98a59892c27dfe98a73cd9307efe027e315ec87336/fastmcp_extensions-0.8.0.dev202607132331.tar.gz", hash = "sha256:bedf6c29d9dfe106868e9c2acd497803aa1ffcfd8a8be69737d45ab504ef0570", size = 189321, upload-time = "2026-07-13T23:31:35.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/bd/a4b801ed298c11b30595f188fdffecaff0f3a01cab04e0cedc25c2f225c6/fastmcp_extensions-0.7.0-py3-none-any.whl", hash = "sha256:374a227d682e4fbdce948c1e255110dcb2dc76aafc9581c90e502e6eeacb3fe2", size = 51956, upload-time = "2026-06-29T18:15:59.052Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b4/f8806d013e1e3e71a2592305ea70c99c7ceeb1cb1892f6296d2efaeb90cd/fastmcp_extensions-0.8.0.dev202607132331-py3-none-any.whl", hash = "sha256:3c416eeb7c90f9897929e932a313c878f619baffca73727f2c0a5cbfea492db6", size = 56908, upload-time = "2026-07-13T23:31:34.343Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
     { name = "fastmcp", specifier = ">=3.0,<4.0" },
-    { name = "fastmcp-extensions", specifier = ">=0.8.0,<1.0.0" },
+    { name = "fastmcp-extensions", specifier = ">=0.10.0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.27.0,<3.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.12.0,<4.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0,<3.0" },
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.8.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
@@ -1137,11 +1137,12 @@ dependencies = [
     { name = "mcp" },
     { name = "segment-analytics-python" },
     { name = "sentry-sdk" },
+    { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/06/45a95610e89672b195b7fcc1472a0c15e0afd8adf5946c011e7a4f792a48/fastmcp_extensions-0.8.0.tar.gz", hash = "sha256:c208bdff5f2cb806ef4b43335540a15be4c21aa3953b98f22e376a658e882ec1", size = 189660, upload-time = "2026-07-14T01:04:20.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/0d/609ea92685e25443c3b23fa1fa5ae8b5b90dc5a5af07ad1082a4f6b7d134/fastmcp_extensions-0.10.0.tar.gz", hash = "sha256:8a3350ae6728e1fbe04d57c355133641a529367bca0c7ed718c7b098062966b5", size = 196638, upload-time = "2026-07-14T06:07:11.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/30/39ffeb3635557dd3b9f2c97aaa8408254acf56899c63fe1ea4334fc54dd8/fastmcp_extensions-0.8.0-py3-none-any.whl", hash = "sha256:e11c9f28ffbcb42d268245b97b3d7a8c9572059ca49cb784cc779d1d6e4169cd", size = 56751, upload-time = "2026-07-14T01:04:19.116Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/02a5c9e1a5614096392f07aa961945fbb789747885ca8755f911921bcc42/fastmcp_extensions-0.10.0-py3-none-any.whl", hash = "sha256:c856fc7992ff99ea42839fd32043b5ac400914e2e21b8e57b1b0cac08b145240", size = 63268, upload-time = "2026-07-14T06:07:09.408Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
     { name = "fastmcp", specifier = ">=3.0,<4.0" },
-    { name = "fastmcp-extensions", specifier = ">=0.8.0.dev0,<1.0.0" },
+    { name = "fastmcp-extensions", specifier = ">=0.8.0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.27.0,<3.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.12.0,<4.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0,<3.0" },
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.8.0.dev202607132331"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
@@ -1139,9 +1139,9 @@ dependencies = [
     { name = "sentry-sdk" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/ec/b6cb2ac62840408a7e98a59892c27dfe98a73cd9307efe027e315ec87336/fastmcp_extensions-0.8.0.dev202607132331.tar.gz", hash = "sha256:bedf6c29d9dfe106868e9c2acd497803aa1ffcfd8a8be69737d45ab504ef0570", size = 189321, upload-time = "2026-07-13T23:31:35.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/06/45a95610e89672b195b7fcc1472a0c15e0afd8adf5946c011e7a4f792a48/fastmcp_extensions-0.8.0.tar.gz", hash = "sha256:c208bdff5f2cb806ef4b43335540a15be4c21aa3953b98f22e376a658e882ec1", size = 189660, upload-time = "2026-07-14T01:04:20.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/b4/f8806d013e1e3e71a2592305ea70c99c7ceeb1cb1892f6296d2efaeb90cd/fastmcp_extensions-0.8.0.dev202607132331-py3-none-any.whl", hash = "sha256:3c416eeb7c90f9897929e932a313c878f619baffca73727f2c0a5cbfea492db6", size = 56908, upload-time = "2026-07-13T23:31:34.343Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/30/39ffeb3635557dd3b9f2c97aaa8408254acf56899c63fe1ea4334fc54dd8/fastmcp_extensions-0.8.0-py3-none-any.whl", hash = "sha256:e11c9f28ffbcb42d268245b97b3d7a8c9572059ca49cb784cc779d1d6e4169cd", size = 56751, upload-time = "2026-07-14T01:04:19.116Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lets headless clients (agents, CI) authenticate to the PyAirbyte (Cloud) MCP HTTP transport without an interactive browser flow and without the refresh-token fragility of reusing an interactive OAuth session. A headless client mints its own short-lived access token via the OAuth 2.0 client credentials grant and sends `Authorization: Bearer <token>`; the server just verifies it. Nothing long-lived is stored or rotated.

Adopts the shared `fastmcp_extensions.build_mcp_auth` factory (companion PR airbytehq/fastmcp-extensions#63, released as `fastmcp-extensions` 0.8.0). The OIDC-only `_create_oidc_auth()` is replaced by `_create_auth()`:

```python
def _create_auth() -> AuthProvider | None:
    oidc = OIDCAuthConfig(...) if OIDC_CONFIG_URL/CLIENT_ID/SECRET set else None   # interactive humans
    jwt  = JWTAuthConfig(...)  if MCP_AUTH_JWKS_URI/MCP_AUTH_JWT_PUBLIC_KEY set else None  # headless agents/CI
    return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=server_url)
```

When both are configured they're combined via `MultiAuth`. When neither is set, returns `None` (fully backward compatible — stdio mode and existing OIDC-only deployments unchanged).

### One token, both jobs (Airbyte Cloud)

Set `MCP_AUTH_AIRBYTE_CLOUD=true` to verify headless tokens against Airbyte Cloud's application-client realm with zero URL wrangling — it fills the JWKS URI, issuer, audience, and algorithm with Airbyte Cloud defaults (each still overridable via the individual `MCP_AUTH_*` vars):

```
issuer  = https://cloud.airbyte.com/auth/realms/_airbyte-application-clients
jwks    = <issuer>/protocol/openid-connect/certs
aud     = account        # Keycloak's generic account audience (not per-service)
alg     = RS256
```

An Airbyte-Cloud-issued application token (minted from `AIRBYTE_CLOUD_CLIENT_ID`/`SECRET` at `<api_root>/applications/token`) is a real RS256 JWT **and** a valid Cloud API bearer. So the same token authenticates transport (verified here) and authorizes downstream Cloud calls (the existing `Authorization` → Cloud bearer pass-through). No separate IdP, no A/B/C ambiguity.

New env vars (all optional; headless path is opt-in): `MCP_AUTH_AIRBYTE_CLOUD`, `MCP_AUTH_JWKS_URI`, `MCP_AUTH_JWT_PUBLIC_KEY`, `MCP_AUTH_ISSUER`, `MCP_AUTH_AUDIENCE`, `MCP_AUTH_ALGORITHM`. `http_main.py` docstring documents them. Bumps `fastmcp-extensions` floor to `>=0.8.0`.

## Testing

Verified against **live Airbyte Cloud** with a real `AIRBYTE_CLOUD_CLIENT_ID`/`SECRET`:
- `<api_root>/applications/token` returns an RS256 JWT (iss = Airbyte Cloud realm, aud = `account`); JWKS reachable, `kid` matches.
- Same token works as a downstream Cloud API bearer: `GET /v1/workspaces` and `/v1/jobs` → 200.
- The shared `build_mcp_auth(jwt=...)` `JWTVerifier` accepts the real Cloud token and rejects a tampered one.

Earlier HTTP smoke test (client-minted RSA JWT against the real PyAirbyte MCP app): no token → 401, bad token → 401, valid token → connected, 51 tools listed.

`ruff check`, `ruff format --check`, and `pyrefly check` pass for the modified `server.py`. Requested by AJ (@aaronsteers).

Link to Devin session: https://app.devin.ai/sessions/81e484fd25e7425a81ddb731eb038a26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HTTP authentication support for interactive OIDC and headless bearer-token verification.
  - Added support for combining multiple authentication methods, including Airbyte Cloud configuration.
  - Automatically uses verified transport bearer tokens for authenticated downstream requests.

- **Bug Fixes**
  - Improved bearer-token handling by normalizing authorization headers and handling missing or empty tokens safely.

- **Documentation**
  - Expanded HTTP authentication setup guidance, configuration examples, and supported environment variables.
  - Added a startup warning when the HTTP server runs without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->