### PR TITLE
docs(mcp): document MCP server distribution + auth retest in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,30 @@ MCP_AUTH_AIRBYTE_CLOUD=true MCP_SERVER_URL=http://localhost:8080 \
   uv run airbyte-mcp-http    # serves on http://localhost:8080/mcp
 ```
 
-Mint a short-lived app token from `AIRBYTE_CLOUD_CLIENT_ID`/`AIRBYTE_CLOUD_CLIENT_SECRET`
-via `POST https://api.airbyte.com/v1/applications/token`, then POST a
-`tools/list` JSON-RPC body to `/mcp`. Expected: no token → `401`, valid token →
-`200`, tampered token → `401`. In stdio mode there is no transport auth, so no
-bearer is required.
+Then run the matrix (mints a short-lived app token from
+`AIRBYTE_CLOUD_CLIENT_ID`/`AIRBYTE_CLOUD_CLIENT_SECRET` and exercises the `/mcp`
+endpoint). Expected: no token → `401`, valid token → `200`, tampered → `401`:
+
+```bash
+TOKEN=$(curl -s -X POST https://api.airbyte.com/v1/applications/token \
+  -H 'Content-Type: application/json' \
+  -d "{\"client_id\":\"$AIRBYTE_CLOUD_CLIENT_ID\",\"client_secret\":\"$AIRBYTE_CLOUD_CLIENT_SECRET\"}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+
+req() {  # $1 = optional Authorization header value
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/mcp \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    ${1:+-H "Authorization: $1"} \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+}
+
+req                              # no token   -> 401
+req "Bearer $TOKEN"              # valid       -> 200
+req "Bearer ${TOKEN%????}XXXX"   # tampered    -> 401
+```
+
+In stdio mode there is no transport auth, so no bearer is required.
 
 ## MCP UI Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,37 @@
 # Agents
 
+## MCP Server: Deployment and Auth Retesting
+
+PyAirbyte ships the MCP server *as part of the published PyPI package* — there
+is **no hosted deployment** in this repo (unlike `airbyte-ops-mcp`, which runs on
+Cloud Run). Consumers run it themselves:
+
+- **stdio** (default, no transport auth): `uvx --from=airbyte airbyte-mcp`
+- **HTTP** (for remote/hosted use, behind their own load balancer):
+  `airbyte-mcp-http` (entry point `airbyte.mcp.http_main:main`, serves on
+  `/mcp` by default).
+
+"Redeploy" therefore means **publish a new release** to PyPI (via
+`.github/workflows/pypi_publish.yml` on a GitHub Release) — merging to `main`
+does not deploy anything. Retesting is done locally.
+
+**Retesting transport auth.** Transport auth is assembled in
+`airbyte/mcp/server.py` via `fastmcp_extensions.resolve_mcp_auth` (interactive
+OIDC and/or headless bearer, combined with `MultiAuth`). To retest the headless
+bearer path locally, boot the HTTP server with the Airbyte Cloud realm defaults
+enabled:
+
+```bash
+MCP_AUTH_AIRBYTE_CLOUD=true MCP_SERVER_URL=http://localhost:8080 \
+  uv run airbyte-mcp-http    # serves on http://localhost:8080/mcp
+```
+
+Mint a short-lived app token from `AIRBYTE_CLOUD_CLIENT_ID`/`AIRBYTE_CLOUD_CLIENT_SECRET`
+via `POST https://api.airbyte.com/v1/applications/token`, then POST a
+`tools/list` JSON-RPC body to `/mcp`. Expected: no token → `401`, valid token →
+`200`, tampered token → `401`. In stdio mode there is no transport auth, so no
+bearer is required.
+
 ## MCP UI Development
 
 When adding or changing MCP tools that return UI elements, use the


### PR DESCRIPTION
## Summary

Complements the ops-mcp AGENTS.md docs PR. Agents were unsure how the PyAirbyte MCP server "deploys" and how to retest its auth. The key fact: unlike `airbyte-ops-mcp` (Cloud Run), **PyAirbyte ships the MCP server inside the published PyPI package — there is no hosted deployment here**. So "redeploy" = cut a PyPI release (`.github/workflows/pypi_publish.yml`); merging to `main` deploys nothing, and retesting is local.

Adds a **MCP Server: Deployment and Auth Retesting** section to `AGENTS.md` covering:
- the stdio (`airbyte-mcp`, no transport auth) and HTTP (`airbyte-mcp-http`, serves `/mcp`) entrypoints,
- that transport auth is assembled via `fastmcp_extensions.resolve_mcp_auth`,
- the local headless-bearer retest matrix (`MCP_AUTH_AIRBYTE_CLOUD=true` → no-token `401` / valid `200` / tampered `401`).

Docs-only. No behavior change.

## Test plan
Verified the documented retest against merged `main` locally: `MCP_AUTH_AIRBYTE_CLOUD=true uv run airbyte-mcp-http` → no-token `401`, valid app token `200`, tampered `401`.

Requested by AJ Steers.

Link to Devin session: https://app.devin.ai/sessions/81e484fd25e7425a81ddb731eb038a26
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for distributing and running the MCP server in standard (stdio) and remote (HTTP) modes.
  * Documented transport authentication behavior, including how to run auth retesting and validate `/mcp` authorization responses.
  * Clarified that standard input/output mode does not require transport authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->