### PR TITLE
feat(mcp): reuse caller's verified token for Airbyte Cloud API passthrough

### DIFF
--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -267,6 +267,16 @@ def _get_cloud_workspace(
     return _get_cloud_client(ctx).get_workspace(resolved_workspace_id)
 
 
+def _none_if_empty(value: str) -> str | None:
+    """Return `value` unless it is empty, in which case return `None`.
+
+    Emptiness is checked with `len` rather than truthiness because a
+    `SecretString` overrides `__bool__` to always be truthy, so an empty secret
+    would otherwise be mistaken for a present value.
+    """
+    return value if len(value) > 0 else None
+
+
 def _get_cloud_client(
     ctx: Context,
     *,
@@ -283,20 +293,23 @@ def _get_cloud_client(
     receiving both at once, so the client credentials are dropped when a bearer
     token is available.
     """
-    bearer_token = get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN) or None
-    client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID) or None
-    client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET) or None
+    bearer_token = _none_if_empty(get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN))
+    client_id = _none_if_empty(get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID))
+    client_secret = _none_if_empty(get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET))
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL)
     config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
 
-    if bearer_token:
-        client_id = None
-        client_secret = None
+    if bearer_token is not None:
+        return CloudClient(
+            bearer_token=bearer_token,
+            public_api_root=api_url,
+            config_api_root=config_api_url,
+            organization_id=organization_id,
+        )
 
     return CloudClient(
         client_id=client_id,
         client_secret=client_secret,
-        bearer_token=bearer_token,
         public_api_root=api_url,
         config_api_root=config_api_url,
         organization_id=organization_id,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -272,12 +272,26 @@ def _get_cloud_client(
     *,
     organization_id: str | None = None,
 ) -> CloudClient:
-    """Get an authenticated `CloudClient` from MCP config."""
-    bearer_token = get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN)
-    client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID)
-    client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET)
+    """Get an authenticated `CloudClient` from MCP config.
+
+    A bearer token takes precedence over `client_id`/`client_secret`. When the
+    server verifies transport against Airbyte Cloud's realm, the verified
+    transport token (surfaced through `BEARER_TOKEN_CONFIG_ARG`) is itself a
+    valid Cloud API bearer, so reusing it delegates downstream Cloud calls to the
+    caller's identity. Client credentials remain the fallback when no bearer
+    token is present (for example, stdio/local mode). `CloudClient` rejects
+    receiving both at once, so the client credentials are dropped when a bearer
+    token is available.
+    """
+    bearer_token = get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN) or None
+    client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID) or None
+    client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET) or None
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL)
     config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
+
+    if bearer_token:
+        client_id = None
+        client_secret = None
 
     return CloudClient(
         client_id=client_id,

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -291,11 +291,25 @@ def _secret_or_none(value: SecretString | None) -> str | None:
             "client-secret",
             id="falls_back_to_client_credentials_without_bearer_token",
         ),
+        pytest.param(
+            SecretString(""),
+            None,
+            "client-id",
+            "client-secret",
+            id="empty_secret_string_bearer_falls_back_to_client_credentials",
+        ),
+        pytest.param(
+            SecretString("transport-jwt"),
+            "transport-jwt",
+            None,
+            None,
+            id="secret_string_bearer_wins_over_client_credentials",
+        ),
     ],
 )
 def test_get_cloud_client_prefers_bearer_token_over_client_credentials(
     monkeypatch: pytest.MonkeyPatch,
-    bearer_token: str,
+    bearer_token: str | SecretString,
     expected_bearer: str | None,
     expected_client_id: str | None,
     expected_client_secret: str | None,
@@ -303,7 +317,9 @@ def test_get_cloud_client_prefers_bearer_token_over_client_credentials(
     """Verify `_get_cloud_client` uses the bearer token when present, else client creds.
 
     An empty bearer token models stdio mode, where `_resolve_transport_bearer_token`
-    yields `""` and client credentials remain the fallback.
+    yields `""` and client credentials remain the fallback. The `SecretString`
+    cases guard the empty-string comparison against `SecretString.__bool__`, which
+    is always `True` and would otherwise treat an empty secret as present.
     """
     config = {
         MCP_CONFIG_BEARER_TOKEN: bearer_token,

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -9,12 +9,21 @@ from typing import Callable, cast
 
 import pytest
 from airbyte.cloud.models import JobStatusEnum
+from airbyte.constants import (
+    MCP_CONFIG_API_URL,
+    MCP_CONFIG_BEARER_TOKEN,
+    MCP_CONFIG_CLIENT_ID,
+    MCP_CONFIG_CLIENT_SECRET,
+    MCP_CONFIG_CONFIG_API_URL,
+)
 from airbyte.mcp import cloud as cloud_mcp
 from airbyte.mcp.cloud import (
     CloudConnectionResult,
     CloudDestinationResult,
     CloudSourceResult,
+    _get_cloud_client,
 )
+from airbyte.secrets.base import SecretString
 from fastmcp import Context
 
 
@@ -258,3 +267,59 @@ def test_mcp_cloud_connections_apply_limit_after_status_filter(
     assert workspace.limits["connections"] is None
     assert len(results) == 1
     assert results[0].id == "connection-2"
+
+
+def _secret_or_none(value: SecretString | None) -> str | None:
+    """Return the plain string of a `SecretString`, or `None`."""
+    return None if value is None else str(value)
+
+
+@pytest.mark.parametrize(
+    "bearer_token, expected_bearer, expected_client_id, expected_client_secret",
+    [
+        pytest.param(
+            "transport-jwt",
+            "transport-jwt",
+            None,
+            None,
+            id="bearer_token_wins_over_client_credentials",
+        ),
+        pytest.param(
+            "",
+            None,
+            "client-id",
+            "client-secret",
+            id="falls_back_to_client_credentials_without_bearer_token",
+        ),
+    ],
+)
+def test_get_cloud_client_prefers_bearer_token_over_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    bearer_token: str,
+    expected_bearer: str | None,
+    expected_client_id: str | None,
+    expected_client_secret: str | None,
+) -> None:
+    """Verify `_get_cloud_client` uses the bearer token when present, else client creds.
+
+    An empty bearer token models stdio mode, where `_resolve_transport_bearer_token`
+    yields `""` and client credentials remain the fallback.
+    """
+    config = {
+        MCP_CONFIG_BEARER_TOKEN: bearer_token,
+        MCP_CONFIG_CLIENT_ID: "client-id",
+        MCP_CONFIG_CLIENT_SECRET: "client-secret",
+        MCP_CONFIG_API_URL: None,
+        MCP_CONFIG_CONFIG_API_URL: None,
+    }
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_mcp_config",
+        lambda _ctx, key: config.get(key),
+    )
+
+    client = _get_cloud_client(cast(Context, object()))
+
+    assert _secret_or_none(client.bearer_token) == expected_bearer
+    assert _secret_or_none(client.client_id) == expected_client_id
+    assert _secret_or_none(client.client_secret) == expected_client_secret

--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -10,6 +10,7 @@ import pytest
 from airbyte.mcp._tool_utils import (
     SafeModeError,
     _GUIDS_CREATED_IN_SESSION,
+    _resolve_transport_bearer_token,
     check_guid_created_in_session,
     register_guid_created_in_session,
 )
@@ -66,3 +67,40 @@ def test_duplicate_guid_registration_is_idempotent() -> None:
     register_guid_created_in_session("duplicate-guid")
     register_guid_created_in_session("duplicate-guid")
     assert "duplicate-guid" in _GUIDS_CREATED_IN_SESSION
+
+
+class _FakeAccessToken:
+    """Minimal stand-in for a FastMCP `AccessToken` carrying a token string."""
+
+    def __init__(self, token: str) -> None:
+        """Store the token value exposed via the `token` attribute."""
+        self.token = token
+
+
+@pytest.mark.parametrize(
+    "access_token, expected",
+    [
+        pytest.param(None, "", id="stdio_mode_returns_empty_string"),
+        pytest.param(_FakeAccessToken(""), "", id="empty_token_returns_empty_string"),
+        pytest.param(
+            _FakeAccessToken("verified-jwt"),
+            "verified-jwt",
+            id="verified_token_is_returned",
+        ),
+    ],
+)
+def test_resolve_transport_bearer_token(
+    access_token: _FakeAccessToken | None,
+    expected: str,
+) -> None:
+    """Verify the transport-token resolver returns the verified token or `""`.
+
+    `get_access_token` returns `None` outside a request (stdio mode), so the
+    resolver yields `""` and downstream config resolution falls back to client
+    credentials.
+    """
+    with patch(
+        "airbyte.mcp._tool_utils.get_access_token",
+        return_value=access_token,
+    ):
+        assert _resolve_transport_bearer_token() == expected


### PR DESCRIPTION
## Summary

The Cloud MCP (hosted at `cloud-mcp`) should call the Airbyte Cloud API as the **caller**, not solely as a statically-configured application. When an agent authenticates the MCP transport with an Airbyte-Cloud-issued bearer token (verified against the `_airbyte-application-clients` realm when `MCP_AUTH_AIRBYTE_CLOUD=true`), that same JWT is itself a valid Cloud API bearer — so it should flow through to downstream Cloud calls, delegating them to the caller's identity. Configured `client_id`/`client_secret` remain the fallback for stdio/local mode where there is no caller token.

The transport-side wiring for this already landed in #1073 (`_resolve_transport_bearer_token` → `BEARER_TOKEN_CONFIG_ARG` defaulting to the verified transport token, plus the Airbyte Cloud realm defaults). The **missing piece** was the "bearer wins over client creds" resolution at the point the MCP tools build a `CloudClient`.

`_get_cloud_client` read all three of `bearer_token`, `client_id`, `client_secret` from MCP config and passed them together to `CloudClient`. But `CloudClient` (via `_AirbyteCredentials.from_auth`) rejects receiving both a bearer token and client credentials at once. In hosted mode — transport token present *and* `AIRBYTE_CLOUD_CLIENT_ID`/`SECRET` set in the environment — this raised `Cannot use both client credentials and bearer token authentication`, breaking the passthrough.

This PR makes the MCP client-construction helper prefer the bearer token, mirroring Ops MCP's `_get_access_token` ("if `bearer_token` is provided, use it directly; otherwise exchange client credentials"):

```python
# airbyte/mcp/cloud.py :: _get_cloud_client
bearer_token = get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN) or None
client_id = get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID) or None
client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET) or None
...
if bearer_token:            # bearer wins; CloudClient rejects both at once
    client_id = None
    client_secret = None
return CloudClient(client_id=..., client_secret=..., bearer_token=bearer_token, ...)
```

### How it mirrors Ops MCP

- **Realm-verified token + `BEARER_TOKEN` config arg defaulting to the transport token** — already present in PyAirbyte from #1073 (`server.py::_create_auth`, `_tool_utils.py::_resolve_transport_bearer_token` / `BEARER_TOKEN_CONFIG_ARG`), identical in shape to `airbyte_ops_mcp/mcp/server.py`.
- **`_get_access_token`-style "bearer wins over client creds"** — Ops MCP centralizes this in `cloud_admin/api_client.py::_get_access_token`. In PyAirbyte the low-level `api_util.get_airbyte_server_instance` intentionally requires *exactly one* of bearer vs. client creds (a documented `CloudClient`/`CloudClientConfig` invariant), so the analogous, scoped place to apply "bearer wins" is the MCP client-construction helper `_get_cloud_client`. This keeps the change confined to the MCP auth layer without altering the public Cloud client's mutual-exclusivity contract.

### Expected behavior

- **Hosted (`cloud-mcp`)**: caller's verified Airbyte Cloud token → used directly as the Cloud API bearer (delegated identity). Env client creds present but ignored while a token is passed.
- **stdio / local**: no transport token (`_resolve_transport_bearer_token` returns `""`) → falls back to `AIRBYTE_CLOUD_CLIENT_ID`/`AIRBYTE_CLOUD_CLIENT_SECRET`.

Requested by AJ Steers (@aaronsteers).

## Test Plan

Added focused unit tests:

- `tests/unit_tests/test_mcp_cloud.py::test_get_cloud_client_prefers_bearer_token_over_client_credentials` — parametrized: bearer token present → `CloudClient` gets the bearer and `client_id`/`client_secret` are dropped (no mutual-exclusivity error); empty bearer (stdio) → falls back to client creds.
- `tests/unit_tests/test_mcp_tool_utils.py::test_resolve_transport_bearer_token` — parametrized: `get_access_token()` returns `None` (stdio) or an empty token → `""`; a verified token → returned as-is.

Local checks (all green):

- `uv run ruff format --check .` (changed files)
- `uv run ruff check .` (changed files)
- `uv run pyrefly check` (0 errors; the 3 warnings are pre-existing `redundant-cast` in `cloud.py`)
- `uv run pytest tests/unit_tests/test_mcp_cloud.py tests/unit_tests/test_mcp_tool_utils.py` → 18 passed


Link to Devin session: https://app.devin.ai/sessions/a8d355a69ca34409bd3b13d2a8122123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for cloud connections by prioritizing bearer-token authentication when available.
  * Added a reliable fallback to client ID and secret authentication when no bearer token is provided.
  * Improved handling of empty or unavailable access tokens.

* **Tests**
  * Added coverage for authentication precedence and access-token resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->