### PR TITLE
feat(cloud): prefer bearer token over client credentials in auth resolution

### DIFF
--- a/airbyte/cloud/_credentials.py
+++ b/airbyte/cloud/_credentials.py
@@ -72,20 +72,19 @@ class _AirbyteCredentials:
             _env_value(CLIENT_SECRET_ENV_VAR, CLOUD_CLIENT_SECRET_ENV_VAR) if env_vars else None,
         )
 
-        if resolved_bearer_token and (resolved_client_id or resolved_client_secret):
-            raise PyAirbyteInputError(
-                message="Cannot use both client credentials and bearer token authentication.",
-                guidance=(
-                    "Provide either client_id and client_secret together, "
-                    "or bearer_token alone, but not both."
-                ),
-            )
-        if bool(resolved_client_id) != bool(resolved_client_secret):
+        if resolved_bearer_token:
+            # A bearer token takes precedence over client credentials. When a caller
+            # supplies both (for example, a passthrough bearer alongside static
+            # fallback client credentials), authenticate as the bearer's identity and
+            # drop the credentials rather than rejecting the combination.
+            resolved_client_id = None
+            resolved_client_secret = None
+        elif bool(resolved_client_id) != bool(resolved_client_secret):
             raise PyAirbyteInputError(
                 message="Client ID and client secret are both required.",
                 guidance="Provide both client ID and client secret, or use a bearer token.",
             )
-        if not resolved_bearer_token and not resolved_client_id:
+        elif not resolved_client_id:
             guidance = (
                 "Set Airbyte Cloud credentials in environment variables."
                 if env_vars

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -92,14 +92,17 @@ def test_airbyte_credentials_missing_credentials_guidance_matches_resolution_mod
     assert exc_info.value.guidance == expected_guidance
 
 
-def test_airbyte_credentials_rejects_mixed_auth_methods() -> None:
-    with pytest.raises(PyAirbyteInputError, match="Cannot use both"):
-        cloud_credentials._AirbyteCredentials.from_auth(
-            bearer_token="token",
-            client_id="client-id",
-            client_secret="client-secret",
-            env_vars=False,
-        )
+def test_airbyte_credentials_prefers_bearer_token_over_client_credentials() -> None:
+    credentials = cloud_credentials._AirbyteCredentials.from_auth(
+        bearer_token="token",
+        client_id="client-id",
+        client_secret="client-secret",
+        env_vars=False,
+    )
+
+    assert credentials.bearer_token == "token"
+    assert credentials.client_id is None
+    assert credentials.client_secret is None
 
 
 @pytest.mark.parametrize(
@@ -111,13 +114,6 @@ def test_airbyte_credentials_rejects_mixed_auth_methods() -> None:
             None,
             "Client ID and client secret are both required.",
             id="missing_client_secret",
-        ),
-        pytest.param(
-            "client-id",
-            "client-secret",
-            "token",
-            "Cannot use both client credentials and bearer token authentication.",
-            id="mixed_auth_methods",
         ),
     ],
 )
@@ -133,6 +129,18 @@ def test_cloud_client_init_validates_auth_inputs(
             client_secret=client_secret,
             bearer_token=bearer_token,
         )
+
+
+def test_cloud_client_init_prefers_bearer_token_over_client_credentials() -> None:
+    client = CloudClient(
+        client_id="client-id",
+        client_secret="client-secret",
+        bearer_token="token",
+    )
+
+    assert client.bearer_token == "token"
+    assert client.client_id is None
+    assert client.client_secret is None
 
 
 def test_cloud_client_list_workspaces_forwards_limit(


### PR DESCRIPTION
## Summary

Requested by AJ (@aaronsteers), replacing the closed airbytehq/PyAirbyte#1078.

`_AirbyteCredentials.from_auth` previously *rejected* the combination of a bearer token and client credentials:

```python
if resolved_bearer_token and (resolved_client_id or resolved_client_secret):
    raise PyAirbyteInputError("Cannot use both client credentials and bearer token authentication.")
```

For Cloud MCP passthrough this is the wrong default: a hosted deployment can legitimately carry a caller-provided bearer token (the verified transport token) *alongside* statically configured `AIRBYTE_CLOUD_CLIENT_ID`/`AIRBYTE_CLOUD_CLIENT_SECRET` fallback creds. Rejecting that combination breaks passthrough and forces awkward call-site juggling.

This makes the shared credential resolver **prefer the bearer token** instead of raising — the single chokepoint every `CloudClient` caller (including the MCP layer) flows through:

```python
if resolved_bearer_token:
    # Bearer wins; drop client creds so we auth as the bearer's identity.
    resolved_client_id = None
    resolved_client_secret = None
elif bool(resolved_client_id) != bool(resolved_client_secret):
    raise ...  # both required
elif not resolved_client_id:
    raise ...  # no credentials found
```

Because the creds are nulled here, the lower-level `api_util.get_airbyte_server_instance` guard (which still enforces *exactly one* auth method) cleanly takes the bearer path — no change to that invariant. All other resolution semantics (empty strings → absent via `_first_value`, "both client fields required", "no credentials found") are unchanged.

This is why the earlier MCP-only fix (airbytehq/PyAirbyte#1078) was misguided: passthrough already worked for the pure-bearer and pure-creds cases; the only thing that failed was the *both-present* case, and the right place to fix that is the shared resolver, not a special-cased MCP helper.

## Behavior

- Bearer only → bearer used (unchanged).
- Client creds only → creds used (unchanged).
- Both present → **bearer wins, creds dropped** (was: `PyAirbyteInputError`).
- Client id/secret mismatch, or nothing at all → still raises as before.

## Tests

- `test_airbyte_credentials_prefers_bearer_token_over_client_credentials` — `from_auth` drops creds when a bearer is present.
- `test_cloud_client_init_prefers_bearer_token_over_client_credentials` — same, end-to-end through `CloudClient`.
- Updated the two tests that previously asserted the "Cannot use both" rejection to reflect the new contract.

Local checks: `ruff format` / `ruff check` / `pyrefly check` clean; `pytest tests/unit_tests/test_cloud_credentials.py` → 21 passed.

Link to Devin session: https://app.devin.ai/sessions/a8d355a69ca34409bd3b13d2a8122123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bearer-token authentication now takes precedence when provided alongside client credentials.
  * Mixed authentication inputs no longer produce an error; client credentials are ignored in favor of the bearer token.
  * Existing validation remains for incomplete client credential pairs and missing authentication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->