### PR TITLE
fix(mcp): stop accepting API base URLs from caller-controlled HTTP headers

### DIFF
--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -327,7 +327,7 @@ MCP_CLIENT_ID_HEADER: str = "X-Airbyte-Cloud-Client-Id"
 MCP_CLIENT_SECRET_HEADER: str = "X-Airbyte-Cloud-Client-Secret"
 """HTTP header key for client secret."""
 
-# Note: The API root and Config API root are intentionally NOT exposed as HTTP
+# Security Note: The API root and Config API root are intentionally NOT exposed as HTTP
 # headers. Each hosted MCP deployment is paired to a single backend, so allowing
 # a caller to override these URLs per-request would let them redirect the
 # server's credentialed requests to an arbitrary host and exfiltrate secrets.

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -327,8 +327,8 @@ MCP_CLIENT_ID_HEADER: str = "X-Airbyte-Cloud-Client-Id"
 MCP_CLIENT_SECRET_HEADER: str = "X-Airbyte-Cloud-Client-Secret"
 """HTTP header key for client secret."""
 
-MCP_API_URL_HEADER: str = "X-Airbyte-Cloud-Api-Url"
-"""HTTP header key for API URL."""
-
-MCP_CONFIG_API_URL_HEADER: str = "X-Airbyte-Cloud-Config-Api-Url"
-"""HTTP header key for Config API URL."""
+# Note: The API root and Config API root are intentionally NOT exposed as HTTP
+# headers. Each hosted MCP deployment is paired to a single backend, so allowing
+# a caller to override these URLs per-request would let them redirect the
+# server's credentialed requests to an arbitrary host and exfiltrate secrets.
+# These base URLs remain configurable via env var for local (stdio) use only.

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -37,12 +37,10 @@ from airbyte.constants import (
     CLOUD_CLIENT_SECRET_ENV_VAR,
     CLOUD_CONFIG_API_ROOT_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
-    MCP_API_URL_HEADER,
     MCP_BEARER_TOKEN_HEADER,
     MCP_CLIENT_ID_HEADER,
     MCP_CLIENT_SECRET_HEADER,
     MCP_CONFIG_API_URL,
-    MCP_CONFIG_API_URL_HEADER,
     MCP_CONFIG_BEARER_TOKEN,
     MCP_CONFIG_CLIENT_ID,
     MCP_CONFIG_CLIENT_SECRET,
@@ -234,21 +232,29 @@ CLIENT_SECRET_CONFIG_ARG = MCPServerConfigArg(
 
 API_URL_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_API_URL,
-    http_header_key=MCP_API_URL_HEADER,
     env_var=CLOUD_API_ROOT_ENV_VAR,
     required=False,
     sensitive=False,
 )
-"""Config arg for API URL, supporting HTTP header and env var."""
+"""Config arg for API URL, supporting env var only.
+
+Deliberately has no `http_header_key`: each hosted deployment is paired to a
+single backend, so the API root must not be caller-controllable via an HTTP
+header. Accepting it from a header would let a caller redirect the server's
+credentialed requests to an arbitrary URL and exfiltrate them. The base URLs
+are still configurable via env var for local (stdio) deployments.
+"""
 
 CONFIG_API_URL_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CONFIG_API_URL,
-    http_header_key=MCP_CONFIG_API_URL_HEADER,
     env_var=CLOUD_CONFIG_API_ROOT_ENV_VAR,
     required=False,
     sensitive=False,
 )
-"""Config arg for Config API URL, supporting HTTP header and env var."""
+"""Config arg for Config API URL, supporting env var only.
+
+See `API_URL_CONFIG_ARG` for why no `http_header_key` is exposed.
+"""
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes [SEC-25](https://linear.app/airbyteio/issue/SEC-25/hosted-pyairbyte-mcp-server-leaks-airbyte-cloud-client-credentials-via): the hosted PyAirbyte MCP server let a caller override the Airbyte Cloud API base URLs per request via HTTP headers (`X-Airbyte-Cloud-Api-Url`, `X-Airbyte-Cloud-Config-Api-Url`). Combined with server-held credentials (client id/secret from env), a caller could redirect the server's credentialed requests to an attacker-controlled host and exfiltrate those secrets.

Each hosted deployment is paired to exactly one backend, so the API roots never need to be caller-controllable. This drops the `http_header_key` from the two URL config args, leaving them env-var only:

```diff
 API_URL_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_API_URL,
-    http_header_key=MCP_API_URL_HEADER,
     env_var=CLOUD_API_ROOT_ENV_VAR,
     ...
 )
 CONFIG_API_URL_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CONFIG_API_URL,
-    http_header_key=MCP_CONFIG_API_URL_HEADER,
     env_var=CLOUD_CONFIG_API_ROOT_ENV_VAR,
     ...
 )
```

Credential and workspace-id headers are unchanged — only the URL headers are removed. The `MCP_API_URL_HEADER` / `MCP_CONFIG_API_URL_HEADER` constants (unused anywhere else) are deleted from `airbyte/constants.py`.

Local (stdio) deployments still configure both base URLs through `AIRBYTE_CLOUD_API_ROOT` / `AIRBYTE_CLOUD_CONFIG_API_ROOT` env vars, so that use case is preserved.

Requested by AJ (`aaronsteers`).


Link to Devin session: https://app.devin.ai/sessions/0561341dbb4f4ad888b902621a11cba9
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Cloud API and configuration API root URLs are no longer accepted through per-request HTTP headers.
  * These URLs remain configurable through environment variables for local use, helping prevent redirect-based secret exposure.
  * Configuration guidance now clarifies that header-based URL overrides are intentionally unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._