### PR TITLE
fix(mcp): forward verified upstream token, not proxy reference JWT, to Cloud API

### DIFF
--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 from fastmcp.apps import UI_EXTENSION_ID
-from fastmcp.server.dependencies import get_access_token, get_context
+from fastmcp.server.dependencies import get_access_token, get_context, get_http_headers
 from fastmcp_extensions import MCPServerConfigArg, get_mcp_config
 from fastmcp_extensions import mcp_tool as _mcp_tool
 from fastmcp_extensions.decorators import (
@@ -182,37 +182,49 @@ def _normalize_bearer_token(value: str) -> str | None:
 
 
 def _resolve_transport_bearer_token() -> str:
-    """Resolve the verified transport bearer token for downstream Cloud calls.
+    """Resolve the bearer token to forward to the downstream Airbyte Cloud API.
 
-    FastMCP stores the access token of the current request after the transport
-    auth provider verifies it — the interactive `OIDCProxy` token or the
-    headless client-minted JWT. Both are Airbyte Cloud tokens when the server
-    verifies against Airbyte Cloud's realm, so reusing the token as the
-    downstream Cloud API bearer gives the caller delegated access without a
-    second credential. Returns an empty string when no verified token is
-    present (for example, stdio mode).
+    Prefers the token the transport auth provider *verified* for the request,
+    exposed by `get_access_token`. Behind a token-swapping proxy (`OAuthProxy`/
+    `OIDCProxy`) this is the upstream Airbyte access token, not the reference
+    JWT the proxy minted for the MCP client and put in the raw `Authorization`
+    header — forwarding that reference JWT downstream yields a `401` because
+    Airbyte never issued it.
+
+    Falls back to the raw `Authorization` header only when there is no verified
+    token (a server with no transport auth provider, where the client passes a
+    real Airbyte token directly), and to an empty string when neither is present
+    (for example stdio mode), so config resolution can reach client-credentials.
     """
     access_token = get_access_token()
     if access_token and access_token.token:
         return access_token.token
+
+    headers = get_http_headers()
+    header_lower = MCP_BEARER_TOKEN_HEADER.lower()
+    for key, value in headers.items():
+        if key.lower() == header_lower:
+            normalized = _normalize_bearer_token(value)
+            if normalized:
+                return normalized
     return ""
 
 
 BEARER_TOKEN_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_BEARER_TOKEN,
-    http_header_key=MCP_BEARER_TOKEN_HEADER,
     env_var=CLOUD_BEARER_TOKEN_ENV_VAR,
     normalize_fn=_normalize_bearer_token,
     default=_resolve_transport_bearer_token,
     required=False,
     sensitive=True,
 )
-"""Config arg for bearer token, supporting Authorization header and env var.
+"""Config arg for the downstream Airbyte Cloud bearer token.
 
-Reads the transport `Authorization` header (stripping the `Bearer ` prefix)
-or `AIRBYTE_CLOUD_BEARER_TOKEN`, then falls back to the verified transport
-token so an interactive-OIDC or headless-JWT caller's token passes through to
-the downstream Airbyte Cloud API without a second credential."""
+Resolves an explicit `AIRBYTE_CLOUD_BEARER_TOKEN` override first, then defers to
+`_resolve_transport_bearer_token`. The raw `Authorization` header is
+deliberately *not* a first-class source: behind `OAuthProxy`/`OIDCProxy` it
+carries the proxy's self-minted reference JWT, which Airbyte Cloud rejects with
+`401`; the resolver consults it only as a last-resort fallback."""
 
 CLIENT_ID_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CLIENT_ID,

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -200,7 +200,7 @@ def _resolve_transport_bearer_token() -> str:
     if access_token and access_token.token:
         return access_token.token
 
-    headers = get_http_headers()
+    headers = get_http_headers(include={MCP_BEARER_TOKEN_HEADER.lower()})
     header_lower = MCP_BEARER_TOKEN_HEADER.lower()
     for key, value in headers.items():
         if key.lower() == header_lower:

--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -75,9 +75,16 @@ def test_resolve_transport_bearer_token(
     )
     with (
         patch("airbyte.mcp._tool_utils.get_access_token", return_value=access_token),
-        patch("airbyte.mcp._tool_utils.get_http_headers", return_value=headers),
+        patch(
+            "airbyte.mcp._tool_utils.get_http_headers", return_value=headers
+        ) as mock_get_http_headers,
     ):
         assert _resolve_transport_bearer_token() == expected
+
+    if verified_token:
+        mock_get_http_headers.assert_not_called()
+    else:
+        mock_get_http_headers.assert_called_once_with(include={"authorization"})
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
@@ -10,9 +11,73 @@ import pytest
 from airbyte.mcp._tool_utils import (
     SafeModeError,
     _GUIDS_CREATED_IN_SESSION,
+    _resolve_transport_bearer_token,
     check_guid_created_in_session,
     register_guid_created_in_session,
 )
+
+
+@dataclass
+class _FakeAccessToken:
+    """Minimal stand-in for a FastMCP `AccessToken` (only `token` is read)."""
+
+    token: str
+
+
+@pytest.mark.parametrize(
+    ("verified_token", "headers", "expected"),
+    [
+        pytest.param(
+            "upstream-airbyte-token",
+            {"authorization": "Bearer minted-mcp-reference-jwt"},
+            "upstream-airbyte-token",
+            id="verified_token_wins_over_authorization_header",
+        ),
+        pytest.param(
+            None,
+            {"authorization": "Bearer real-airbyte-token"},
+            "real-airbyte-token",
+            id="falls_back_to_bearer_prefixed_header",
+        ),
+        pytest.param(
+            None,
+            {"Authorization": "bare-token-no-prefix"},
+            "bare-token-no-prefix",
+            id="header_lookup_is_case_insensitive_and_accepts_bare_token",
+        ),
+        pytest.param(
+            "",
+            {"authorization": "Bearer header-token"},
+            "header-token",
+            id="empty_verified_token_falls_back_to_header",
+        ),
+        pytest.param(
+            None,
+            {},
+            "",
+            id="no_verified_token_and_no_header_returns_empty",
+        ),
+    ],
+)
+def test_resolve_transport_bearer_token(
+    verified_token: str | None,
+    headers: dict[str, str],
+    expected: str,
+) -> None:
+    """The downstream bearer prefers the verified token over the raw header.
+
+    Regression guard for the `OAuthProxy` `401`: the raw `Authorization` header
+    carries the proxy's minted reference JWT, so it must never win over the
+    upstream token exposed by `get_access_token`.
+    """
+    access_token = (
+        _FakeAccessToken(verified_token) if verified_token is not None else None
+    )
+    with (
+        patch("airbyte.mcp._tool_utils.get_access_token", return_value=access_token),
+        patch("airbyte.mcp._tool_utils.get_http_headers", return_value=headers),
+    ):
+        assert _resolve_transport_bearer_token() == expected
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Hosted Cloud MCP (`cloud-mcp`) was forwarding the **wrong token** to the Airbyte Cloud API, causing every authenticated Cloud tool call to `401` after credential resolution succeeded.

`cloud-mcp` runs FastMCP's `OAuthProxy`/`OIDCProxy`, which brokers the caller's Keycloak → Okta login but then mints its **own** short-lived reference JWT for the MCP client (`iss`/`aud` = the MCP server itself, `scope="email profile"`). That reference JWT is what lands in the raw `Authorization` header. The Airbyte Cloud API never issued it, so it rejects it with `401`.

The bug was one of **source precedence** in how the downstream bearer was resolved. `BEARER_TOKEN_CONFIG_ARG` declared `http_header_key=MCP_BEARER_TOKEN_HEADER`, and `fastmcp_extensions`'s resolver checks the HTTP header *before* the `default`. So the raw `Authorization` header (the reference JWT) always won over `_resolve_transport_bearer_token`, which returns the verified token from `get_access_token()`.

FastMCP already does the right thing internally — `OAuthProxy.load_access_token()` swaps the reference JWT for the **upstream** Airbyte access token and exposes it via `get_access_token()`. This is the same class of token the Ops Webapp uses successfully against the Cloud public/config APIs. The fix simply forwards that verified token instead of the raw header.

```diff
 BEARER_TOKEN_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_BEARER_TOKEN,
-    http_header_key=MCP_BEARER_TOKEN_HEADER,   # raw header (reference JWT) won → 401
     env_var=CLOUD_BEARER_TOKEN_ENV_VAR,
     normalize_fn=_normalize_bearer_token,
     default=_resolve_transport_bearer_token,   # now the primary source
     ...
 )
```

```python
def _resolve_transport_bearer_token() -> str:
    access_token = get_access_token()          # verified upstream Airbyte token
    if access_token and access_token.token:
        return access_token.token
    # fallback: raw Authorization header, for servers with no transport auth
    # provider (client passes a real Airbyte token directly)
    headers = get_http_headers()
    ...
    return ""
```

Precedence after this change: explicit `AIRBYTE_CLOUD_BEARER_TOKEN` env override → verified transport token (`get_access_token`) → raw `Authorization` header fallback → empty (falls through to client-credentials auth for stdio/local).

### Why the verified token is the right one (source trace)

- `OIDCProxy._get_verification_token()` returns `upstream_token_set.access_token`.
- `JWTVerifier.verify_token(token)` returns `AccessToken(token=token, ...)`.
- Therefore `get_access_token().token` is the upstream Airbyte access token, not the proxy's minted reference JWT.

## Test Plan

Added `tests/unit_tests/test_mcp_tool_utils.py::test_resolve_transport_bearer_token` (parametrized):

- verified token present + `Authorization` header present → returns the verified token (regression guard for the `401`)
- no verified token + `Bearer <tok>` header → returns `<tok>`
- no verified token + bare-token header (case-insensitive) → returned as-is
- empty verified token + header present → falls back to header
- neither present → `""`

Local checks (all green):

- `uv run --no-sync pytest tests/unit_tests/test_mcp_tool_utils.py` → 11 passed
- `uv run --no-sync ruff format` / `ruff check` (changed files) → clean
- `uv run --no-sync pyrefly check airbyte/mcp/_tool_utils.py` → 0 errors

Live end-to-end confirmation (verified upstream token accepted by the Cloud API) will come from a hosted retest once this deploys, or a local OAuth round trip — the source trace above establishes the correct token now flows.

Requested by AJ Steers (@aaronsteers).


Link to Devin session: https://app.devin.ai/sessions/9274bd4f3e0a4b0880795fc1ef9c806b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bearer-token resolution by prioritizing verified transport authentication credentials.
  * When no verified token is available, the system now falls back to the request’s `Authorization` header (case-insensitive lookup).
  * Supports bearer tokens both with and without the `Bearer` prefix, including correct empty-token behavior.
* **Tests**
  * Added unit test coverage for token precedence, header variations, and fallback/empty scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->