### PR TITLE
feat(mcp): wire trusted-execution gate and function-layer guards

### DIFF
--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -281,6 +281,17 @@ Accepts a comma-separated list of domain names (e.g., "cloud,registry").
 If set, only tools from these domains will be advertised by the MCP server.
 """
 
+MCP_TRUSTED_EXECUTION_ENV_VAR: str = "AIRBYTE_MCP_TRUSTED_EXECUTION"
+"""Environment variable that enables trusted (local) execution for the MCP server.
+
+When set to `1`/`true`/`yes`, the server may use its trusted-machine capabilities: local
+filesystem access, local connector installation/execution, and server-side secret
+resolution. It defaults to *off* on every transport and is permanently unavailable over
+the HTTP transport (a hosted deployment can never enable it). This gate is server-owned
+and is deliberately never read from a request header, because it *widens* the surface and
+so must never be caller-controllable.
+"""
+
 MCP_WORKSPACE_ID_HEADER: str = "X-Airbyte-Workspace-Id"
 """HTTP header key for passing workspace ID to the MCP server.
 

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -222,6 +222,34 @@ class PyAirbyteNoStreamsSelectedError(PyAirbyteInputError):
     available_streams: list[str] | None = None
 
 
+# MCP Server Errors
+
+
+@dataclass
+class PyAirbyteMCPError(PyAirbyteError):
+    """An error occurred in the PyAirbyte MCP server."""
+
+
+@dataclass
+class PyAirbyteTrustedExecutionRequiredError(PyAirbyteMCPError):
+    """A trusted-execution-only capability was invoked while trusted execution is disabled.
+
+    Trusted execution grants the MCP server its trusted-machine capabilities: local
+    filesystem access, local connector installation/execution, and server-side secret
+    resolution. It defaults to *off* on every transport and is permanently unavailable
+    over the HTTP transport, so a backend helper that exposes one of those capabilities
+    hard-fails when the gate is disabled -- independently of whether the corresponding
+    tool was hidden from the tool listing.
+    """
+
+    guidance = (
+        "Set `AIRBYTE_MCP_TRUSTED_EXECUTION=1` on the MCP server process and restart it. "
+        "Trusted execution is only available on the stdio transport; it can never be "
+        "enabled for an HTTP/hosted deployment."
+    )
+    feature: str | None = None
+
+
 # Normalization Errors
 
 

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -227,7 +227,7 @@ class PyAirbyteNoStreamsSelectedError(PyAirbyteInputError):
 
 @dataclass
 class AirbyteMCPError(PyAirbyteError):
-    """An error occurred in the PyAirbyte MCP server."""
+    """An error occurred in the Airbyte MCP server."""
 
 
 @dataclass

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -226,12 +226,12 @@ class PyAirbyteNoStreamsSelectedError(PyAirbyteInputError):
 
 
 @dataclass
-class PyAirbyteMCPError(PyAirbyteError):
+class AirbyteMCPError(PyAirbyteError):
     """An error occurred in the PyAirbyte MCP server."""
 
 
 @dataclass
-class PyAirbyteTrustedExecutionRequiredError(PyAirbyteMCPError):
+class AirbyteTrustedExecutionRequiredError(AirbyteMCPError):
     """A trusted-execution-only capability was invoked while trusted execution is disabled.
 
     Trusted execution grants the MCP server its trusted-machine capabilities: local

--- a/airbyte/mcp/_arg_resolvers.py
+++ b/airbyte/mcp/_arg_resolvers.py
@@ -14,7 +14,7 @@ from typing import Any, overload
 import yaml
 
 from airbyte.constants import SECRETS_HYDRATION_PREFIX
-from airbyte.mcp._guards import require_trusted_execution
+from airbyte.mcp._guards import raise_if_untrusted_execution_context
 from airbyte.secrets.hydration import deep_update, detect_hardcoded_secrets
 from airbyte.secrets.util import get_secret
 
@@ -103,7 +103,7 @@ def resolve_connector_config(  # noqa: PLR0912
     We reject hardcoded secrets in a config dict if we detect them.
 
     The trusted-machine inputs are gated by trusted execution
-    (`airbyte.mcp._guards.require_trusted_execution`): reading a local `config_file`,
+    (`airbyte.mcp._guards.raise_if_untrusted_execution_context`): reading a local `config_file`,
     resolving a server-side `config_secret_name`, and hydrating inline
     `secret_reference::` values each hard-fail when trusted execution is disabled. Passing
     an already-resolved inline `config` dict remains available to untrusted callers (for
@@ -116,7 +116,9 @@ def resolve_connector_config(  # noqa: PLR0912
         return {}
 
     if config_file is not None:
-        require_trusted_execution("Reading connector config from a local file (`config_file`)")
+        raise_if_untrusted_execution_context(
+            "Reading connector config from a local file (`config_file`)"
+        )
         if isinstance(config_file, str):
             config_file = Path(config_file)
 
@@ -160,7 +162,7 @@ def resolve_connector_config(  # noqa: PLR0912
             raise ValueError(f"Config must be a dict or JSON string, got: {type(config).__name__}")
 
     if _contains_secret_reference(config_dict):
-        require_trusted_execution(
+        raise_if_untrusted_execution_context(
             "Resolving inline secret references (`secret_reference::`) in connector config"
         )
 
@@ -183,7 +185,7 @@ def resolve_connector_config(  # noqa: PLR0912
             raise ValueError(error_msg)
 
     if config_secret_name is not None:
-        require_trusted_execution(
+        raise_if_untrusted_execution_context(
             "Resolving connector config from a server-side secret (`config_secret_name`)"
         )
         # Assume this is a secret name that points to a JSON/YAML config.

--- a/airbyte/mcp/_arg_resolvers.py
+++ b/airbyte/mcp/_arg_resolvers.py
@@ -13,8 +13,21 @@ from typing import Any, overload
 
 import yaml
 
+from airbyte.constants import SECRETS_HYDRATION_PREFIX
+from airbyte.mcp._guards import require_trusted_execution
 from airbyte.secrets.hydration import deep_update, detect_hardcoded_secrets
 from airbyte.secrets.util import get_secret
+
+
+def _contains_secret_reference(value: object) -> bool:
+    """Return whether `value` contains a `secret_reference::` string at any depth."""
+    if isinstance(value, str):
+        return value.startswith(SECRETS_HYDRATION_PREFIX)
+    if isinstance(value, dict):
+        return any(_contains_secret_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_secret_reference(item) for item in value)
+    return False
 
 
 # Hint: Null result if input is Null
@@ -88,6 +101,14 @@ def resolve_connector_config(  # noqa: PLR0912
         ValueError: If JSON parsing fails or a provided input is invalid
 
     We reject hardcoded secrets in a config dict if we detect them.
+
+    The trusted-machine inputs are gated by trusted execution
+    (`airbyte.mcp._guards.require_trusted_execution`): reading a local `config_file`,
+    resolving a server-side `config_secret_name`, and hydrating inline
+    `secret_reference::` values each hard-fail when trusted execution is disabled. Passing
+    an already-resolved inline `config` dict remains available to untrusted callers (for
+    example hosted cloud tools), so only the paths that touch the server's filesystem or
+    secret store are restricted.
     """
     config_dict: dict[str, Any] = {}
 
@@ -95,6 +116,7 @@ def resolve_connector_config(  # noqa: PLR0912
         return {}
 
     if config_file is not None:
+        require_trusted_execution("Reading connector config from a local file (`config_file`)")
         if isinstance(config_file, str):
             config_file = Path(config_file)
 
@@ -137,6 +159,11 @@ def resolve_connector_config(  # noqa: PLR0912
         else:
             raise ValueError(f"Config must be a dict or JSON string, got: {type(config).__name__}")
 
+    if _contains_secret_reference(config_dict):
+        require_trusted_execution(
+            "Resolving inline secret references (`secret_reference::`) in connector config"
+        )
+
     if config_dict and config_spec_jsonschema is not None:
         hardcoded_secrets: list[list[str]] = detect_hardcoded_secrets(
             config=config_dict,
@@ -156,6 +183,9 @@ def resolve_connector_config(  # noqa: PLR0912
             raise ValueError(error_msg)
 
     if config_secret_name is not None:
+        require_trusted_execution(
+            "Resolving connector config from a server-side secret (`config_secret_name`)"
+        )
         # Assume this is a secret name that points to a JSON/YAML config.
         secret_config = yaml.safe_load(str(get_secret(config_secret_name)))
         if not isinstance(secret_config, dict):

--- a/airbyte/mcp/_config.py
+++ b/airbyte/mcp/_config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import dotenv
 
 from airbyte._util.meta import is_interactive
+from airbyte.mcp._guards import is_trusted_execution_enabled
 from airbyte.secrets import (
     DotenvSecretManager,
     GoogleGSMSecretManager,
@@ -39,25 +40,39 @@ def load_secrets_to_env_vars() -> None:
     from the loaded environment variables.
 
     Note: Later secret manager registrations have higher priority than earlier ones.
+
+    When trusted execution is disabled (`airbyte.mcp._guards.is_trusted_execution_enabled`),
+    the dotenv and Google Secret Manager backends are *not* registered as secret sources.
+    This prevents an untrusted (for example hosted HTTP) deployment from resolving
+    server-side secrets into connector config via `config_secret_name` /
+    `secret_reference::`. Ordinary environment variables are still loaded from any
+    referenced dotenv file so that safe, non-secret-manager configuration continues to
+    work.
     """
+    trusted = is_trusted_execution_enabled()
+
     # Load the .env file from the current working directory.
     envrc_path = Path.cwd() / ".envrc"
     if envrc_path.exists():
-        envrc_secret_mgr = DotenvSecretManager(envrc_path)
         _load_dotenv_file(envrc_path)
-        register_secret_manager(
-            envrc_secret_mgr,
-        )
+        if trusted:
+            register_secret_manager(
+                DotenvSecretManager(envrc_path),
+            )
 
     if AIRBYTE_MCP_DOTENV_PATH_ENVVAR in os.environ:
         dotenv_path = Path(os.environ[AIRBYTE_MCP_DOTENV_PATH_ENVVAR]).absolute()
-        custom_dotenv_secret_mgr = DotenvSecretManager(dotenv_path)
         _load_dotenv_file(dotenv_path)
-        register_secret_manager(
-            custom_dotenv_secret_mgr,
-        )
+        if trusted:
+            register_secret_manager(
+                DotenvSecretManager(dotenv_path),
+            )
 
-    if is_secret_available("GCP_GSM_CREDENTIALS") and is_secret_available("GCP_GSM_PROJECT_ID"):
+    if (
+        trusted
+        and is_secret_available("GCP_GSM_CREDENTIALS")
+        and is_secret_available("GCP_GSM_PROJECT_ID")
+    ):
         # Initialize the GoogleGSMSecretManager if the credentials and project are set.
         register_secret_manager(
             GoogleGSMSecretManager(

--- a/airbyte/mcp/_config.py
+++ b/airbyte/mcp/_config.py
@@ -43,11 +43,16 @@ def load_secrets_to_env_vars() -> None:
 
     When trusted execution is disabled (`airbyte.mcp._guards.is_trusted_execution_enabled`),
     the dotenv and Google Secret Manager backends are *not* registered as secret sources.
-    This prevents an untrusted (for example hosted HTTP) deployment from resolving
-    server-side secrets into connector config via `config_secret_name` /
-    `secret_reference::`. Ordinary environment variables are still loaded from any
-    referenced dotenv file so that safe, non-secret-manager configuration continues to
-    work.
+    This stops an untrusted (for example hosted HTTP) deployment from resolving server-side
+    secrets into connector config via `config_secret_name` / `secret_reference::`.
+
+    The dotenv file itself is still loaded into `os.environ` even when untrusted, so ordinary
+    environment-variable configuration keeps working. Note this loads *every* key from the
+    file (secret values included) into the process environment; that is acceptable because
+    both dotenv sources are server-owned (a server-side `.envrc` or the operator-set
+    `AIRBYTE_MCP_ENV_FILE`) and are never caller-controllable, and the function-layer guards
+    in `airbyte.mcp._arg_resolvers.resolve_connector_config` are what actually block an
+    untrusted caller from resolving those values.
     """
     trusted = is_trusted_execution_enabled()
 

--- a/airbyte/mcp/_guards.py
+++ b/airbyte/mcp/_guards.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 
 from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
-from airbyte.exceptions import PyAirbyteTrustedExecutionRequiredError
+from airbyte.exceptions import AirbyteTrustedExecutionRequiredError
 
 
 _TRUTHY_VALUES = frozenset({"1", "true", "yes"})
@@ -41,9 +41,9 @@ def raise_if_untrusted_execution_context(feature: str) -> None:
 
     Call this from any backend helper that exposes a trusted-machine capability (local
     filesystem access, connector installation/execution, or server-side secret
-    resolution). It raises `airbyte.exceptions.PyAirbyteTrustedExecutionRequiredError`
+    resolution). It raises `airbyte.exceptions.AirbyteTrustedExecutionRequiredError`
     when the gate is off, independently of whether the corresponding tool was hidden from
     the listing.
     """
     if not is_trusted_execution_enabled():
-        raise PyAirbyteTrustedExecutionRequiredError(feature=feature)
+        raise AirbyteTrustedExecutionRequiredError(feature=feature)

--- a/airbyte/mcp/_guards.py
+++ b/airbyte/mcp/_guards.py
@@ -9,7 +9,7 @@ environment variable (`airbyte.constants.MCP_TRUSTED_EXECUTION_ENV_VAR`) and def
 
 `fastmcp_extensions` already hides trusted-machine tools from the tool listing when the
 gate is off, but that is a *visibility* control. The guards here are an independent
-*function-layer* control: backend helpers call `require_trusted_execution` so a direct
+*function-layer* control: backend helpers call `raise_if_untrusted_execution_context` so a direct
 call hard-fails when the gate is disabled, even if a future registration mistake left the
 tool visible. Because the two layers are independent, a mistake in either one alone cannot
 expose a trusted-machine capability to an untrusted (for example hosted HTTP) caller.
@@ -36,7 +36,7 @@ def is_trusted_execution_enabled() -> bool:
     return os.environ.get(MCP_TRUSTED_EXECUTION_ENV_VAR, "0").strip().lower() in _TRUTHY_VALUES
 
 
-def require_trusted_execution(feature: str) -> None:
+def raise_if_untrusted_execution_context(feature: str) -> None:
     """Hard-fail when `feature` is invoked while trusted execution is disabled.
 
     Call this from any backend helper that exposes a trusted-machine capability (local

--- a/airbyte/mcp/_guards.py
+++ b/airbyte/mcp/_guards.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Trusted-execution guards for Airbyte MCP backend helpers.
+
+Trusted execution is the master gate for the MCP server's *trusted-machine* capabilities:
+local filesystem access, local connector installation/execution, and server-side secret
+resolution. It is controlled solely by the `AIRBYTE_MCP_TRUSTED_EXECUTION` server
+environment variable (`airbyte.constants.MCP_TRUSTED_EXECUTION_ENV_VAR`) and defaults to
+*off* on every transport.
+
+`fastmcp_extensions` already hides trusted-machine tools from the tool listing when the
+gate is off, but that is a *visibility* control. The guards here are an independent
+*function-layer* control: backend helpers call `require_trusted_execution` so a direct
+call hard-fails when the gate is disabled, even if a future registration mistake left the
+tool visible. Because the two layers are independent, a mistake in either one alone cannot
+expose a trusted-machine capability to an untrusted (for example hosted HTTP) caller.
+"""
+
+from __future__ import annotations
+
+import os
+
+from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
+from airbyte.exceptions import PyAirbyteTrustedExecutionRequiredError
+
+
+_TRUTHY_VALUES = frozenset({"1", "true", "yes"})
+
+
+def is_trusted_execution_enabled() -> bool:
+    """Return whether trusted execution is enabled for the MCP server.
+
+    Reads `AIRBYTE_MCP_TRUSTED_EXECUTION` from the server environment only. A value of
+    `1`/`true`/`yes` (case-insensitive) enables it; anything else -- including unset --
+    leaves it disabled.
+    """
+    return os.environ.get(MCP_TRUSTED_EXECUTION_ENV_VAR, "0").strip().lower() in _TRUTHY_VALUES
+
+
+def require_trusted_execution(feature: str) -> None:
+    """Hard-fail when `feature` is invoked while trusted execution is disabled.
+
+    Call this from any backend helper that exposes a trusted-machine capability (local
+    filesystem access, connector installation/execution, or server-side secret
+    resolution). It raises `airbyte.exceptions.PyAirbyteTrustedExecutionRequiredError`
+    when the gate is off, independently of whether the corresponding tool was hidden from
+    the listing.
+    """
+    if not is_trusted_execution_enabled():
+        raise PyAirbyteTrustedExecutionRequiredError(feature=feature)

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -27,6 +27,7 @@ from fastmcp_extensions.registration import _ProviderToolAnnotations  # noqa: PL
 from fastmcp_extensions.tool_filters import (
     ANNOTATION_MCP_MODULE,
     ANNOTATION_READ_ONLY_HINT,
+    CONFIG_TRUSTED_EXECUTION,
     get_annotation,
 )
 
@@ -52,8 +53,10 @@ from airbyte.constants import (
     MCP_DOMAINS_DISABLED_ENV_VAR,
     MCP_DOMAINS_ENV_VAR,
     MCP_READONLY_MODE_ENV_VAR,
+    MCP_TRUSTED_EXECUTION_ENV_VAR,
     MCP_WORKSPACE_ID_HEADER,
 )
+from airbyte.exceptions import PyAirbyteInputError
 
 
 if TYPE_CHECKING:
@@ -154,6 +157,20 @@ AIRBYTE_INCLUDE_MODULES_CONFIG_ARG = MCPServerConfigArg(
     required=False,
 )
 """Config arg for legacy AIRBYTE_MCP_DOMAINS env var."""
+
+TRUSTED_EXECUTION_CONFIG_ARG = MCPServerConfigArg(
+    name=CONFIG_TRUSTED_EXECUTION,
+    env_var=MCP_TRUSTED_EXECUTION_ENV_VAR,
+    default="0",
+    required=False,
+)
+"""Config arg mapping the generic `trusted_execution` gate to `AIRBYTE_MCP_TRUSTED_EXECUTION`.
+
+Registering this lets `fastmcp_extensions` resolve the trusted-execution gate from the
+Airbyte-specific env var while keeping the generic library Airbyte-agnostic. It
+deliberately has no `http_header_key`: the gate *widens* the tool surface, so it must never
+be caller-controllable.
+"""
 
 WORKSPACE_ID_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_WORKSPACE_ID,
@@ -416,6 +433,77 @@ def airbyte_module_filter(tool: Tool, app: FastMCP) -> bool:
         return bool(tool_module and tool_module in include_modules)
 
     return True
+
+
+def _known_mcp_modules() -> set[str]:
+    """Return the set of Airbyte MCP domain (module) names that have registered tools."""
+    modules: set[str] = set()
+    for _func, tool_annotations in _REGISTERED_TOOLS:
+        module = tool_annotations.get(ANNOTATION_MCP_MODULE)
+        if module:
+            modules.add(_normalize_mcp_module(str(module)))
+    for _provider_factory, tool_annotations in _REGISTERED_PROVIDERS:
+        module = tool_annotations.get(ANNOTATION_MCP_MODULE)
+        if module:
+            modules.add(_normalize_mcp_module(str(module)))
+    return modules
+
+
+def validate_airbyte_domains(app: FastMCP) -> None:
+    """Validate the `AIRBYTE_MCP_DOMAINS` / `AIRBYTE_MCP_DOMAINS_DISABLED` selection.
+
+    Hard-fails at startup instead of silently dropping a domain that was explicitly
+    requested. Two incompatibilities are rejected:
+
+    1. Setting both `AIRBYTE_MCP_DOMAINS` (include) and `AIRBYTE_MCP_DOMAINS_DISABLED`
+       (exclude), which are mutually exclusive -- `airbyte_module_filter` would otherwise
+       silently honor only the exclude list and drop the requested includes.
+    2. Naming a domain that has no registered tools (typically a typo), which would
+       otherwise silently expose or hide nothing for that name.
+
+    Call this once at startup, after all tools are registered.
+
+    Args:
+        app: The FastMCP app instance.
+
+    Raises:
+        PyAirbyteInputError: If the domain configuration is incompatible.
+    """
+    exclude_modules = _parse_csv_config(get_mcp_config(app, MCP_CONFIG_EXCLUDE_MODULES) or "")
+    include_modules = _parse_csv_config(get_mcp_config(app, MCP_CONFIG_INCLUDE_MODULES) or "")
+
+    if include_modules and exclude_modules:
+        raise PyAirbyteInputError(
+            message=(
+                "AIRBYTE_MCP_DOMAINS and AIRBYTE_MCP_DOMAINS_DISABLED are mutually exclusive."
+            ),
+            guidance=(
+                "Clear one of `AIRBYTE_MCP_DOMAINS` (include) or `AIRBYTE_MCP_DOMAINS_DISABLED` "
+                "(exclude) so only one is set, then restart the MCP server process."
+            ),
+            context={
+                "include_domains": include_modules,
+                "exclude_domains": exclude_modules,
+            },
+        )
+
+    known_modules = _known_mcp_modules()
+    unknown_modules = sorted(
+        {module for module in (*include_modules, *exclude_modules) if module not in known_modules}
+    )
+    if unknown_modules:
+        raise PyAirbyteInputError(
+            message="One or more requested MCP domains are not recognized.",
+            guidance=(
+                "Correct the unknown domain name(s) in `AIRBYTE_MCP_DOMAINS` / "
+                "`AIRBYTE_MCP_DOMAINS_DISABLED` (or clear the variable), then restart the MCP "
+                "server process."
+            ),
+            context={
+                "unknown_domains": unknown_modules,
+                "known_domains": sorted(known_modules),
+            },
+        )
 
 
 def airbyte_ui_support_filter(tool: Tool, _app: FastMCP) -> bool:

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -37,7 +37,10 @@ import logging
 import os
 from urllib.parse import urlparse
 
-from fastmcp_extensions import register_landing_page
+from fastmcp_extensions import (
+    assert_http_trusted_execution_disabled,
+    register_landing_page,
+)
 
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
@@ -102,6 +105,12 @@ def main() -> None:
         DEFAULT_HTTP_PORT,
         mcp_path,
     )
+
+    # Trusted execution grants local filesystem, connector-execution, and
+    # server-side secret-resolution capability, which must never be reachable
+    # over HTTP. Hard-fail startup if it was explicitly enabled on this hosted
+    # entrypoint (a permanent gate; the per-request filter also forces it off).
+    assert_http_trusted_execution_disabled(app)
 
     app.run(
         transport="streamable-http",

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -29,7 +29,7 @@ from airbyte._util.meta import is_docker_installed
 from airbyte.caches.util import get_default_cache
 from airbyte.destinations.util import get_destination
 from airbyte.mcp._arg_resolvers import resolve_connector_config, resolve_list_of_strings
-from airbyte.mcp._guards import require_trusted_execution
+from airbyte.mcp._guards import raise_if_untrusted_execution_context
 from airbyte.registry import get_connector_metadata
 from airbyte.secrets.config import _get_secret_sources
 from airbyte.secrets.env_vars import DotenvSecretManager
@@ -79,7 +79,7 @@ def _get_mcp_source(
     execution and hard-fails when trusted execution is disabled, independently of whether
     the calling tool was hidden from the tool listing.
     """
-    require_trusted_execution("Local connector execution (`_get_mcp_source`)")
+    raise_if_untrusted_execution_context("Local connector execution (`_get_mcp_source`)")
     if manifest_path:
         override_execution_mode = "yaml"
     elif override_execution_mode == "auto" and is_docker_installed():
@@ -223,7 +223,9 @@ def list_connector_config_secrets(
     for a given connector. The return value is a list of secret names, but it will not
     return the actual secret values.
     """
-    require_trusted_execution("Listing connector config secrets (`list_connector_config_secrets`)")
+    raise_if_untrusted_execution_context(
+        "Listing connector config secrets (`list_connector_config_secrets`)"
+    )
     secrets_names: list[str] = []
     for secrets_mgr in _get_secret_sources():
         if isinstance(secrets_mgr, GoogleGSMSecretManager):
@@ -249,7 +251,7 @@ def list_dotenv_secrets() -> dict[str, list[str]]:
     This returns a dictionary mapping the .env file name to a list of environment
     variable names. The values of the environment variables are not returned.
     """
-    require_trusted_execution("Listing dotenv secret names (`list_dotenv_secrets`)")
+    raise_if_untrusted_execution_context("Listing dotenv secret names (`list_dotenv_secrets`)")
     result: dict[str, list[str]] = {}
     for secrets_mgr in _get_secret_sources():
         if isinstance(secrets_mgr, DotenvSecretManager) and secrets_mgr.dotenv_path:
@@ -714,7 +716,7 @@ class CachedDatasetInfo(BaseModel):
 )
 def list_cached_streams() -> list[CachedDatasetInfo]:
     """List all streams available in the default DuckDB cache."""
-    require_trusted_execution("Reading the local default cache (`list_cached_streams`)")
+    raise_if_untrusted_execution_context("Reading the local default cache (`list_cached_streams`)")
     cache: DuckDBCache = get_default_cache()
     result = [
         CachedDatasetInfo(
@@ -736,7 +738,9 @@ def list_cached_streams() -> list[CachedDatasetInfo]:
 )
 def describe_default_cache() -> dict[str, Any]:
     """Describe the currently configured default cache."""
-    require_trusted_execution("Describing the local default cache (`describe_default_cache`)")
+    raise_if_untrusted_execution_context(
+        "Describing the local default cache (`describe_default_cache`)"
+    )
     cache = get_default_cache()
     return {
         "cache_type": type(cache).__name__,
@@ -811,7 +815,7 @@ def run_sql_query(
 
     For security reasons, only read-only operations are allowed: SELECT, DESCRIBE, SHOW, EXPLAIN.
     """
-    require_trusted_execution("Querying the local default cache (`run_sql_query`)")
+    raise_if_untrusted_execution_context("Querying the local default cache (`run_sql_query`)")
     # Check if the query is safe to execute
     if not _is_safe_sql(sql_query):
         return [
@@ -961,7 +965,7 @@ def destination_smoke_test(  # noqa: PLR0913, PLR0917
     per-column null/non-null counts. Results are included in the response
     as `table_statistics` and `tables_not_found`.
     """
-    require_trusted_execution("Destination smoke test (`destination_smoke_test`)")
+    raise_if_untrusted_execution_context("Destination smoke test (`destination_smoke_test`)")
     # Resolve destination config
     config_dict = resolve_connector_config(
         config=config,

--- a/airbyte/mcp/local.py
+++ b/airbyte/mcp/local.py
@@ -29,6 +29,7 @@ from airbyte._util.meta import is_docker_installed
 from airbyte.caches.util import get_default_cache
 from airbyte.destinations.util import get_destination
 from airbyte.mcp._arg_resolvers import resolve_connector_config, resolve_list_of_strings
+from airbyte.mcp._guards import require_trusted_execution
 from airbyte.registry import get_connector_metadata
 from airbyte.secrets.config import _get_secret_sources
 from airbyte.secrets.env_vars import DotenvSecretManager
@@ -72,7 +73,13 @@ def _get_mcp_source(
     install_if_missing: bool = True,
     manifest_path: str | Path | None,
 ) -> Source:
-    """Get the MCP source for a connector."""
+    """Get the MCP source for a connector.
+
+    This installs and executes a connector on the server, so it is gated by trusted
+    execution and hard-fails when trusted execution is disabled, independently of whether
+    the calling tool was hidden from the tool listing.
+    """
+    require_trusted_execution("Local connector execution (`_get_mcp_source`)")
     if manifest_path:
         override_execution_mode = "yaml"
     elif override_execution_mode == "auto" and is_docker_installed():
@@ -216,6 +223,7 @@ def list_connector_config_secrets(
     for a given connector. The return value is a list of secret names, but it will not
     return the actual secret values.
     """
+    require_trusted_execution("Listing connector config secrets (`list_connector_config_secrets`)")
     secrets_names: list[str] = []
     for secrets_mgr in _get_secret_sources():
         if isinstance(secrets_mgr, GoogleGSMSecretManager):
@@ -241,6 +249,7 @@ def list_dotenv_secrets() -> dict[str, list[str]]:
     This returns a dictionary mapping the .env file name to a list of environment
     variable names. The values of the environment variables are not returned.
     """
+    require_trusted_execution("Listing dotenv secret names (`list_dotenv_secrets`)")
     result: dict[str, list[str]] = {}
     for secrets_mgr in _get_secret_sources():
         if isinstance(secrets_mgr, DotenvSecretManager) and secrets_mgr.dotenv_path:
@@ -705,6 +714,7 @@ class CachedDatasetInfo(BaseModel):
 )
 def list_cached_streams() -> list[CachedDatasetInfo]:
     """List all streams available in the default DuckDB cache."""
+    require_trusted_execution("Reading the local default cache (`list_cached_streams`)")
     cache: DuckDBCache = get_default_cache()
     result = [
         CachedDatasetInfo(
@@ -726,6 +736,7 @@ def list_cached_streams() -> list[CachedDatasetInfo]:
 )
 def describe_default_cache() -> dict[str, Any]:
     """Describe the currently configured default cache."""
+    require_trusted_execution("Describing the local default cache (`describe_default_cache`)")
     cache = get_default_cache()
     return {
         "cache_type": type(cache).__name__,
@@ -800,6 +811,7 @@ def run_sql_query(
 
     For security reasons, only read-only operations are allowed: SELECT, DESCRIBE, SHOW, EXPLAIN.
     """
+    require_trusted_execution("Querying the local default cache (`run_sql_query`)")
     # Check if the query is safe to execute
     if not _is_safe_sql(sql_query):
         return [
@@ -949,6 +961,7 @@ def destination_smoke_test(  # noqa: PLR0913, PLR0917
     per-column null/non-null counts. Results are included in the response
     as `table_statistics` and `tables_not_found`.
     """
+    require_trusted_execution("Destination smoke test (`destination_smoke_test`)")
     # Resolve destination config
     config_dict = resolve_connector_config(
         config=config,

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -59,10 +59,12 @@ from airbyte.mcp._tool_utils import (
     CLIENT_ID_CONFIG_ARG,
     CLIENT_SECRET_CONFIG_ARG,
     CONFIG_API_URL_CONFIG_ARG,
+    TRUSTED_EXECUTION_CONFIG_ARG,
     WORKSPACE_ID_CONFIG_ARG,
     airbyte_module_filter,
     airbyte_readonly_mode_filter,
     airbyte_ui_support_filter,
+    validate_airbyte_domains,
 )
 from airbyte.mcp.cloud import register_cloud_tools
 from airbyte.mcp.interactive import register_interactive_tools
@@ -173,6 +175,7 @@ app = mcp_server(
         CLIENT_SECRET_CONFIG_ARG,
         API_URL_CONFIG_ARG,
         CONFIG_API_URL_CONFIG_ARG,
+        TRUSTED_EXECUTION_CONFIG_ARG,
     ],
     tool_filters=[
         airbyte_readonly_mode_filter,
@@ -189,6 +192,8 @@ register_local_tools(app)
 register_registry_tools(app)
 register_interactive_tools(app)
 register_prompts(app)
+
+validate_airbyte_domains(app)
 
 
 @app.custom_route("/health", methods=["GET"])

--- a/tests/unit_tests/test_mcp_trusted_execution.py
+++ b/tests/unit_tests/test_mcp_trusted_execution.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
@@ -11,8 +12,8 @@ import pytest
 
 from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
 from airbyte.exceptions import (
-    PyAirbyteInputError,
     AirbyteTrustedExecutionRequiredError,
+    PyAirbyteInputError,
 )
 from airbyte.mcp import local
 from airbyte.mcp._arg_resolvers import resolve_connector_config
@@ -37,6 +38,12 @@ def _set_trusted(monkeypatch: MonkeyPatch, *, enabled: bool) -> None:
         monkeypatch.delenv(MCP_TRUSTED_EXECUTION_ENV_VAR, raising=False)
 
 
+def _write_config_json(tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"host": "example.com"}))
+    return config_file
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -48,110 +55,114 @@ def _set_trusted(monkeypatch: MonkeyPatch, *, enabled: bool) -> None:
         pytest.param("false", False, id="false"),
         pytest.param("", False, id="empty"),
         pytest.param("nope", False, id="arbitrary"),
+        pytest.param(None, False, id="unset_defaults_off"),
     ],
 )
 def test_is_trusted_execution_enabled(
     monkeypatch: MonkeyPatch,
-    value: str,
+    value: str | None,
     expected: bool,
 ) -> None:
-    """`is_trusted_execution_enabled` parses only explicit truthy env values."""
-    monkeypatch.setenv(MCP_TRUSTED_EXECUTION_ENV_VAR, value)
+    """`is_trusted_execution_enabled` parses only explicit truthy env values and defaults off."""
+    if value is None:
+        monkeypatch.delenv(MCP_TRUSTED_EXECUTION_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(MCP_TRUSTED_EXECUTION_ENV_VAR, value)
     assert is_trusted_execution_enabled() is expected
 
 
-def test_is_trusted_execution_enabled_defaults_off(monkeypatch: MonkeyPatch) -> None:
-    """The gate defaults to off when the env var is unset."""
-    monkeypatch.delenv(MCP_TRUSTED_EXECUTION_ENV_VAR, raising=False)
-    assert is_trusted_execution_enabled() is False
-
-
-def test_raise_if_untrusted_execution_context_raises_when_disabled(
+@pytest.mark.parametrize("enabled", [False, True], ids=["disabled", "enabled"])
+def test_raise_if_untrusted_execution_context(
     monkeypatch: MonkeyPatch,
+    enabled: bool,
 ) -> None:
-    """`raise_if_untrusted_execution_context` hard-fails and records the feature when disabled."""
-    _set_trusted(monkeypatch, enabled=False)
+    """The guard hard-fails (recording the feature) when disabled and is a no-op when enabled."""
+    _set_trusted(monkeypatch, enabled=enabled)
+    if enabled:
+        raise_if_untrusted_execution_context("some feature")
+        return
     with pytest.raises(AirbyteTrustedExecutionRequiredError) as exc_info:
         raise_if_untrusted_execution_context("some feature")
     assert exc_info.value.feature == "some feature"
 
 
-def test_raise_if_untrusted_execution_context_passes_when_enabled(
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        pytest.param(
+            {"config": {"host": "example.com"}},
+            {"host": "example.com"},
+            id="inline_dict",
+        ),
+        pytest.param({}, {}, id="empty"),
+    ],
+)
+def test_resolve_connector_config_allows_when_untrusted(
     monkeypatch: MonkeyPatch,
+    kwargs: dict[str, object],
+    expected: dict[str, object],
 ) -> None:
-    """`raise_if_untrusted_execution_context` is a no-op when trusted execution is enabled."""
-    _set_trusted(monkeypatch, enabled=True)
-    raise_if_untrusted_execution_context("some feature")
-
-
-def test_resolve_connector_config_allows_inline_config_when_untrusted(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """A plain inline config dict does not require trusted execution (cloud tools rely on it)."""
+    """Plain inline/empty config never requires trusted execution (cloud tools rely on it)."""
     _set_trusted(monkeypatch, enabled=False)
-    assert resolve_connector_config(config={"host": "example.com"}) == {
-        "host": "example.com"
-    }
+    assert resolve_connector_config(**kwargs) == expected
 
 
-def test_resolve_connector_config_empty_when_untrusted(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """Resolving with no inputs is always allowed and returns an empty dict."""
-    _set_trusted(monkeypatch, enabled=False)
-    assert resolve_connector_config() == {}
-
-
-def test_resolve_connector_config_rejects_config_file_when_untrusted(
+@pytest.mark.parametrize(
+    "build_kwargs",
+    [
+        pytest.param(
+            lambda tmp_path: {"config_file": _write_config_json(tmp_path)},
+            id="config_file",
+        ),
+        pytest.param(
+            lambda tmp_path: {"config_secret_name": "MY_SECRET_CONFIG"},
+            id="config_secret_name",
+        ),
+        pytest.param(
+            lambda tmp_path: {"config": {"password": "secret_reference::MY_ENV_VAR"}},
+            id="secret_reference",
+        ),
+    ],
+)
+def test_resolve_connector_config_rejects_when_untrusted(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
+    build_kwargs: Callable[[Path], dict[str, object]],
 ) -> None:
-    """Reading config from a local file is gated behind trusted execution."""
+    """Filesystem, server-side-secret, and `secret_reference::` paths are gated when untrusted."""
     _set_trusted(monkeypatch, enabled=False)
-    config_file = tmp_path / "config.json"
-    config_file.write_text(json.dumps({"host": "example.com"}))
     with pytest.raises(AirbyteTrustedExecutionRequiredError):
-        resolve_connector_config(config_file=config_file)
+        resolve_connector_config(**build_kwargs(tmp_path))
 
 
-def test_resolve_connector_config_reads_config_file_when_trusted(
+@pytest.mark.parametrize(
+    "build_case",
+    [
+        pytest.param(
+            lambda tmp_path: (
+                {"config_file": _write_config_json(tmp_path)},
+                {"host": "example.com"},
+            ),
+            id="config_file",
+        ),
+        pytest.param(
+            lambda tmp_path: (
+                {"config": {"password": "secret_reference::MY_ENV_VAR"}},
+                {"password": "secret_reference::MY_ENV_VAR"},
+            ),
+            id="secret_reference",
+        ),
+    ],
+)
+def test_resolve_connector_config_allows_when_trusted(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
+    build_case: Callable[[Path], tuple[dict[str, object], dict[str, object]]],
 ) -> None:
-    """When trusted, reading a local config file works as before."""
+    """When trusted, gated paths pass the guard (`secret_reference::` is resolved downstream)."""
     _set_trusted(monkeypatch, enabled=True)
-    config_file = tmp_path / "config.json"
-    config_file.write_text(json.dumps({"host": "example.com"}))
-    assert resolve_connector_config(config_file=config_file) == {"host": "example.com"}
-
-
-def test_resolve_connector_config_rejects_config_secret_name_when_untrusted(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """Resolving config from a server-side secret is gated behind trusted execution."""
-    _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(AirbyteTrustedExecutionRequiredError):
-        resolve_connector_config(config_secret_name="MY_SECRET_CONFIG")
-
-
-def test_resolve_connector_config_rejects_secret_reference_when_untrusted(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """Inline `secret_reference::` values are gated behind trusted execution."""
-    _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(AirbyteTrustedExecutionRequiredError):
-        resolve_connector_config(config={"password": "secret_reference::MY_ENV_VAR"})
-
-
-def test_resolve_connector_config_allows_secret_reference_when_trusted(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """When trusted, an inline `secret_reference::` passes the guard (resolved downstream)."""
-    _set_trusted(monkeypatch, enabled=True)
-    resolved = resolve_connector_config(
-        config={"password": "secret_reference::MY_ENV_VAR"}
-    )
-    assert resolved == {"password": "secret_reference::MY_ENV_VAR"}
+    kwargs, expected = build_case(tmp_path)
+    assert resolve_connector_config(**kwargs) == expected
 
 
 _UNTRUSTED_LOCAL_HELPERS: list[Callable[[], object]] = [
@@ -200,39 +211,34 @@ def test_local_helpers_reject_when_untrusted(
         call_helper()
 
 
-def test_assert_http_trusted_execution_disabled_raises_when_enabled(
+@pytest.mark.parametrize("enabled", [False, True], ids=["disabled", "enabled"])
+def test_assert_http_trusted_execution_disabled(
     monkeypatch: MonkeyPatch,
+    enabled: bool,
 ) -> None:
-    """The HTTP entrypoint hard-fails at startup if trusted execution is explicitly enabled."""
+    """The HTTP startup guard hard-fails only when trusted execution is explicitly enabled."""
     from fastmcp_extensions import assert_http_trusted_execution_disabled
 
     from airbyte.mcp.server import app
 
-    _set_trusted(monkeypatch, enabled=True)
-    with pytest.raises(RuntimeError):
+    _set_trusted(monkeypatch, enabled=enabled)
+    if enabled:
+        with pytest.raises(RuntimeError):
+            assert_http_trusted_execution_disabled(app)
+    else:
         assert_http_trusted_execution_disabled(app)
 
 
-def test_assert_http_trusted_execution_disabled_passes_when_off(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """The HTTP startup guard is a no-op when trusted execution is disabled (the default)."""
-    from fastmcp_extensions import assert_http_trusted_execution_disabled
-
-    from airbyte.mcp.server import app
-
-    _set_trusted(monkeypatch, enabled=False)
-    assert_http_trusted_execution_disabled(app)
-
-
-def test_load_secrets_suppresses_secret_managers_when_untrusted(
+@pytest.mark.parametrize("trusted", [False, True], ids=["untrusted", "trusted"])
+def test_load_secrets_registers_secret_managers_only_when_trusted(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
+    trusted: bool,
 ) -> None:
-    """When untrusted, dotenv/GSM secret managers are not registered, but env still loads."""
+    """Dotenv/GSM secret managers register only when trusted; env vars always load either way."""
     from airbyte.mcp import _config
 
-    _set_trusted(monkeypatch, enabled=False)
+    _set_trusted(monkeypatch, enabled=trusted)
     env_file = tmp_path / "custom.env"
     env_file.write_text("MY_SAFE_VAR=hello\n")
     monkeypatch.setenv(_config.AIRBYTE_MCP_DOTENV_PATH_ENVVAR, str(env_file))
@@ -243,31 +249,12 @@ def test_load_secrets_suppresses_secret_managers_when_untrusted(
 
     _config.load_secrets_to_env_vars()
 
-    assert registered == []
-    # The env var is still loaded so safe, non-secret-manager config keeps working.
-    import os
-
+    # The env var loads regardless so safe, non-secret-manager config keeps working.
     assert os.environ["MY_SAFE_VAR"] == "hello"
-
-
-def test_load_secrets_registers_dotenv_manager_when_trusted(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """When trusted, a custom dotenv file is registered as a secret manager source."""
-    from airbyte.mcp import _config
-
-    _set_trusted(monkeypatch, enabled=True)
-    env_file = tmp_path / "custom.env"
-    env_file.write_text("MY_SAFE_VAR=hello\n")
-    monkeypatch.setenv(_config.AIRBYTE_MCP_DOTENV_PATH_ENVVAR, str(env_file))
-
-    registered: list[object] = []
-    monkeypatch.setattr(_config, "register_secret_manager", registered.append)
-
-    _config.load_secrets_to_env_vars()
-
-    assert any(isinstance(mgr, _config.DotenvSecretManager) for mgr in registered)
+    if trusted:
+        assert any(isinstance(mgr, _config.DotenvSecretManager) for mgr in registered)
+    else:
+        assert registered == []
 
 
 def test_validate_airbyte_domains_rejects_include_and_exclude(

--- a/tests/unit_tests/test_mcp_trusted_execution.py
+++ b/tests/unit_tests/test_mcp_trusted_execution.py
@@ -164,6 +164,21 @@ _UNTRUSTED_LOCAL_HELPERS: list[Callable[[], object]] = [
         lambda: local.list_connector_config_secrets("source-faker"),
         id="list_connector_config_secrets",
     ),
+    pytest.param(
+        lambda: local.destination_smoke_test(
+            "destination-dev-null",
+            None,
+            None,
+            None,
+            "fast",
+            None,
+            None,
+            None,
+            None,
+            False,
+        ),
+        id="destination_smoke_test",
+    ),
 ]
 
 

--- a/tests/unit_tests/test_mcp_trusted_execution.py
+++ b/tests/unit_tests/test_mcp_trusted_execution.py
@@ -12,7 +12,7 @@ import pytest
 from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
 from airbyte.exceptions import (
     PyAirbyteInputError,
-    PyAirbyteTrustedExecutionRequiredError,
+    AirbyteTrustedExecutionRequiredError,
 )
 from airbyte.mcp import local
 from airbyte.mcp._arg_resolvers import resolve_connector_config
@@ -71,7 +71,7 @@ def test_raise_if_untrusted_execution_context_raises_when_disabled(
 ) -> None:
     """`raise_if_untrusted_execution_context` hard-fails and records the feature when disabled."""
     _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(PyAirbyteTrustedExecutionRequiredError) as exc_info:
+    with pytest.raises(AirbyteTrustedExecutionRequiredError) as exc_info:
         raise_if_untrusted_execution_context("some feature")
     assert exc_info.value.feature == "some feature"
 
@@ -110,7 +110,7 @@ def test_resolve_connector_config_rejects_config_file_when_untrusted(
     _set_trusted(monkeypatch, enabled=False)
     config_file = tmp_path / "config.json"
     config_file.write_text(json.dumps({"host": "example.com"}))
-    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+    with pytest.raises(AirbyteTrustedExecutionRequiredError):
         resolve_connector_config(config_file=config_file)
 
 
@@ -130,7 +130,7 @@ def test_resolve_connector_config_rejects_config_secret_name_when_untrusted(
 ) -> None:
     """Resolving config from a server-side secret is gated behind trusted execution."""
     _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+    with pytest.raises(AirbyteTrustedExecutionRequiredError):
         resolve_connector_config(config_secret_name="MY_SECRET_CONFIG")
 
 
@@ -139,7 +139,7 @@ def test_resolve_connector_config_rejects_secret_reference_when_untrusted(
 ) -> None:
     """Inline `secret_reference::` values are gated behind trusted execution."""
     _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+    with pytest.raises(AirbyteTrustedExecutionRequiredError):
         resolve_connector_config(config={"password": "secret_reference::MY_ENV_VAR"})
 
 
@@ -196,7 +196,7 @@ def test_local_helpers_reject_when_untrusted(
     though a registration mistake could leave the tool listed.
     """
     _set_trusted(monkeypatch, enabled=False)
-    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+    with pytest.raises(AirbyteTrustedExecutionRequiredError):
         call_helper()
 
 

--- a/tests/unit_tests/test_mcp_trusted_execution.py
+++ b/tests/unit_tests/test_mcp_trusted_execution.py
@@ -16,7 +16,10 @@ from airbyte.exceptions import (
 )
 from airbyte.mcp import local
 from airbyte.mcp._arg_resolvers import resolve_connector_config
-from airbyte.mcp._guards import is_trusted_execution_enabled, require_trusted_execution
+from airbyte.mcp._guards import (
+    is_trusted_execution_enabled,
+    raise_if_untrusted_execution_context,
+)
 
 
 if TYPE_CHECKING:
@@ -63,22 +66,22 @@ def test_is_trusted_execution_enabled_defaults_off(monkeypatch: MonkeyPatch) -> 
     assert is_trusted_execution_enabled() is False
 
 
-def test_require_trusted_execution_raises_when_disabled(
+def test_raise_if_untrusted_execution_context_raises_when_disabled(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """`require_trusted_execution` hard-fails and records the feature when disabled."""
+    """`raise_if_untrusted_execution_context` hard-fails and records the feature when disabled."""
     _set_trusted(monkeypatch, enabled=False)
     with pytest.raises(PyAirbyteTrustedExecutionRequiredError) as exc_info:
-        require_trusted_execution("some feature")
+        raise_if_untrusted_execution_context("some feature")
     assert exc_info.value.feature == "some feature"
 
 
-def test_require_trusted_execution_passes_when_enabled(
+def test_raise_if_untrusted_execution_context_passes_when_enabled(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """`require_trusted_execution` is a no-op when trusted execution is enabled."""
+    """`raise_if_untrusted_execution_context` is a no-op when trusted execution is enabled."""
     _set_trusted(monkeypatch, enabled=True)
-    require_trusted_execution("some feature")
+    raise_if_untrusted_execution_context("some feature")
 
 
 def test_resolve_connector_config_allows_inline_config_when_untrusted(

--- a/tests/unit_tests/test_mcp_trusted_execution.py
+++ b/tests/unit_tests/test_mcp_trusted_execution.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for the MCP trusted-execution gate and its function-layer guards."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import pytest
+
+from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
+from airbyte.exceptions import (
+    PyAirbyteInputError,
+    PyAirbyteTrustedExecutionRequiredError,
+)
+from airbyte.mcp import local
+from airbyte.mcp._arg_resolvers import resolve_connector_config
+from airbyte.mcp._guards import is_trusted_execution_enabled, require_trusted_execution
+
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+TRUSTED_DOMAINS_INCLUDE_ENV = "AIRBYTE_MCP_DOMAINS"
+TRUSTED_DOMAINS_EXCLUDE_ENV = "AIRBYTE_MCP_DOMAINS_DISABLED"
+
+
+def _set_trusted(monkeypatch: MonkeyPatch, *, enabled: bool) -> None:
+    if enabled:
+        monkeypatch.setenv(MCP_TRUSTED_EXECUTION_ENV_VAR, "1")
+    else:
+        monkeypatch.delenv(MCP_TRUSTED_EXECUTION_ENV_VAR, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("1", True, id="one"),
+        pytest.param("true", True, id="true"),
+        pytest.param("YES", True, id="yes_uppercase"),
+        pytest.param(" 1 ", True, id="whitespace_padded"),
+        pytest.param("0", False, id="zero"),
+        pytest.param("false", False, id="false"),
+        pytest.param("", False, id="empty"),
+        pytest.param("nope", False, id="arbitrary"),
+    ],
+)
+def test_is_trusted_execution_enabled(
+    monkeypatch: MonkeyPatch,
+    value: str,
+    expected: bool,
+) -> None:
+    """`is_trusted_execution_enabled` parses only explicit truthy env values."""
+    monkeypatch.setenv(MCP_TRUSTED_EXECUTION_ENV_VAR, value)
+    assert is_trusted_execution_enabled() is expected
+
+
+def test_is_trusted_execution_enabled_defaults_off(monkeypatch: MonkeyPatch) -> None:
+    """The gate defaults to off when the env var is unset."""
+    monkeypatch.delenv(MCP_TRUSTED_EXECUTION_ENV_VAR, raising=False)
+    assert is_trusted_execution_enabled() is False
+
+
+def test_require_trusted_execution_raises_when_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """`require_trusted_execution` hard-fails and records the feature when disabled."""
+    _set_trusted(monkeypatch, enabled=False)
+    with pytest.raises(PyAirbyteTrustedExecutionRequiredError) as exc_info:
+        require_trusted_execution("some feature")
+    assert exc_info.value.feature == "some feature"
+
+
+def test_require_trusted_execution_passes_when_enabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """`require_trusted_execution` is a no-op when trusted execution is enabled."""
+    _set_trusted(monkeypatch, enabled=True)
+    require_trusted_execution("some feature")
+
+
+def test_resolve_connector_config_allows_inline_config_when_untrusted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A plain inline config dict does not require trusted execution (cloud tools rely on it)."""
+    _set_trusted(monkeypatch, enabled=False)
+    assert resolve_connector_config(config={"host": "example.com"}) == {
+        "host": "example.com"
+    }
+
+
+def test_resolve_connector_config_empty_when_untrusted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Resolving with no inputs is always allowed and returns an empty dict."""
+    _set_trusted(monkeypatch, enabled=False)
+    assert resolve_connector_config() == {}
+
+
+def test_resolve_connector_config_rejects_config_file_when_untrusted(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reading config from a local file is gated behind trusted execution."""
+    _set_trusted(monkeypatch, enabled=False)
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"host": "example.com"}))
+    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+        resolve_connector_config(config_file=config_file)
+
+
+def test_resolve_connector_config_reads_config_file_when_trusted(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When trusted, reading a local config file works as before."""
+    _set_trusted(monkeypatch, enabled=True)
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"host": "example.com"}))
+    assert resolve_connector_config(config_file=config_file) == {"host": "example.com"}
+
+
+def test_resolve_connector_config_rejects_config_secret_name_when_untrusted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Resolving config from a server-side secret is gated behind trusted execution."""
+    _set_trusted(monkeypatch, enabled=False)
+    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+        resolve_connector_config(config_secret_name="MY_SECRET_CONFIG")
+
+
+def test_resolve_connector_config_rejects_secret_reference_when_untrusted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Inline `secret_reference::` values are gated behind trusted execution."""
+    _set_trusted(monkeypatch, enabled=False)
+    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+        resolve_connector_config(config={"password": "secret_reference::MY_ENV_VAR"})
+
+
+def test_resolve_connector_config_allows_secret_reference_when_trusted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """When trusted, an inline `secret_reference::` passes the guard (resolved downstream)."""
+    _set_trusted(monkeypatch, enabled=True)
+    resolved = resolve_connector_config(
+        config={"password": "secret_reference::MY_ENV_VAR"}
+    )
+    assert resolved == {"password": "secret_reference::MY_ENV_VAR"}
+
+
+_UNTRUSTED_LOCAL_HELPERS: list[Callable[[], object]] = [
+    pytest.param(
+        lambda: local._get_mcp_source("source-faker", manifest_path=None),
+        id="_get_mcp_source",
+    ),
+    pytest.param(lambda: local.list_cached_streams(), id="list_cached_streams"),
+    pytest.param(lambda: local.describe_default_cache(), id="describe_default_cache"),
+    pytest.param(lambda: local.run_sql_query("SELECT 1", 10), id="run_sql_query"),
+    pytest.param(lambda: local.list_dotenv_secrets(), id="list_dotenv_secrets"),
+    pytest.param(
+        lambda: local.list_connector_config_secrets("source-faker"),
+        id="list_connector_config_secrets",
+    ),
+]
+
+
+@pytest.mark.parametrize("call_helper", _UNTRUSTED_LOCAL_HELPERS)
+def test_local_helpers_reject_when_untrusted(
+    monkeypatch: MonkeyPatch,
+    call_helper: Callable[[], object],
+) -> None:
+    """Trusted-machine local helpers hard-fail when trusted execution is disabled.
+
+    This is independent of tool visibility: calling the backend directly must raise even
+    though a registration mistake could leave the tool listed.
+    """
+    _set_trusted(monkeypatch, enabled=False)
+    with pytest.raises(PyAirbyteTrustedExecutionRequiredError):
+        call_helper()
+
+
+def test_assert_http_trusted_execution_disabled_raises_when_enabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The HTTP entrypoint hard-fails at startup if trusted execution is explicitly enabled."""
+    from fastmcp_extensions import assert_http_trusted_execution_disabled
+
+    from airbyte.mcp.server import app
+
+    _set_trusted(monkeypatch, enabled=True)
+    with pytest.raises(RuntimeError):
+        assert_http_trusted_execution_disabled(app)
+
+
+def test_assert_http_trusted_execution_disabled_passes_when_off(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The HTTP startup guard is a no-op when trusted execution is disabled (the default)."""
+    from fastmcp_extensions import assert_http_trusted_execution_disabled
+
+    from airbyte.mcp.server import app
+
+    _set_trusted(monkeypatch, enabled=False)
+    assert_http_trusted_execution_disabled(app)
+
+
+def test_load_secrets_suppresses_secret_managers_when_untrusted(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When untrusted, dotenv/GSM secret managers are not registered, but env still loads."""
+    from airbyte.mcp import _config
+
+    _set_trusted(monkeypatch, enabled=False)
+    env_file = tmp_path / "custom.env"
+    env_file.write_text("MY_SAFE_VAR=hello\n")
+    monkeypatch.setenv(_config.AIRBYTE_MCP_DOTENV_PATH_ENVVAR, str(env_file))
+    monkeypatch.delenv("MY_SAFE_VAR", raising=False)
+
+    registered: list[object] = []
+    monkeypatch.setattr(_config, "register_secret_manager", registered.append)
+
+    _config.load_secrets_to_env_vars()
+
+    assert registered == []
+    # The env var is still loaded so safe, non-secret-manager config keeps working.
+    import os
+
+    assert os.environ["MY_SAFE_VAR"] == "hello"
+
+
+def test_load_secrets_registers_dotenv_manager_when_trusted(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When trusted, a custom dotenv file is registered as a secret manager source."""
+    from airbyte.mcp import _config
+
+    _set_trusted(monkeypatch, enabled=True)
+    env_file = tmp_path / "custom.env"
+    env_file.write_text("MY_SAFE_VAR=hello\n")
+    monkeypatch.setenv(_config.AIRBYTE_MCP_DOTENV_PATH_ENVVAR, str(env_file))
+
+    registered: list[object] = []
+    monkeypatch.setattr(_config, "register_secret_manager", registered.append)
+
+    _config.load_secrets_to_env_vars()
+
+    assert any(isinstance(mgr, _config.DotenvSecretManager) for mgr in registered)
+
+
+def test_validate_airbyte_domains_rejects_include_and_exclude(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Setting both include and exclude domain lists hard-fails with remediation guidance."""
+    from airbyte.mcp._tool_utils import validate_airbyte_domains
+    from airbyte.mcp.server import app
+
+    monkeypatch.setenv(TRUSTED_DOMAINS_INCLUDE_ENV, "cloud")
+    monkeypatch.setenv(TRUSTED_DOMAINS_EXCLUDE_ENV, "local")
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        validate_airbyte_domains(app)
+    rendered = str(exc_info.value)
+    assert "mutually exclusive" in rendered
+    assert "restart" in rendered.lower()
+
+
+def test_validate_airbyte_domains_rejects_unknown_domain(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Requesting a domain with no registered tools hard-fails instead of silently dropping it."""
+    from airbyte.mcp._tool_utils import validate_airbyte_domains
+    from airbyte.mcp.server import app
+
+    monkeypatch.delenv(TRUSTED_DOMAINS_EXCLUDE_ENV, raising=False)
+    monkeypatch.setenv(TRUSTED_DOMAINS_INCLUDE_ENV, "not_a_real_domain")
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        validate_airbyte_domains(app)
+    assert "not_a_real_domain" in exc_info.value.context["unknown_domains"]
+
+
+def test_validate_airbyte_domains_allows_known_single_domain(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A single valid include domain passes validation."""
+    from airbyte.mcp._tool_utils import validate_airbyte_domains
+    from airbyte.mcp.server import app
+
+    monkeypatch.delenv(TRUSTED_DOMAINS_EXCLUDE_ENV, raising=False)
+    monkeypatch.setenv(TRUSTED_DOMAINS_INCLUDE_ENV, "cloud")
+    validate_airbyte_domains(app)

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.10.0"
+version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
@@ -1140,9 +1140,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/0d/609ea92685e25443c3b23fa1fa5ae8b5b90dc5a5af07ad1082a4f6b7d134/fastmcp_extensions-0.10.0.tar.gz", hash = "sha256:8a3350ae6728e1fbe04d57c355133641a529367bca0c7ed718c7b098062966b5", size = 196638, upload-time = "2026-07-14T06:07:11.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/90/8198eef9c4d8429fb76f00dbe9bb3b9a097bbfcb9adf7c41f4f26223e8a2/fastmcp_extensions-0.10.3.tar.gz", hash = "sha256:dc40edd91e52ca59d252f25c767f76654de34d2a1793aa3e756cbb76e0d9adba", size = 201916, upload-time = "2026-07-21T00:49:04.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/66/02a5c9e1a5614096392f07aa961945fbb789747885ca8755f911921bcc42/fastmcp_extensions-0.10.0-py3-none-any.whl", hash = "sha256:c856fc7992ff99ea42839fd32043b5ac400914e2e21b8e57b1b0cac08b145240", size = 63268, upload-time = "2026-07-14T06:07:09.408Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/62/4fd614321d5083e94375f07b3388f56f071fd16e25efe37451363c92a411/fastmcp_extensions-0.10.3-py3-none-any.whl", hash = "sha256:2932107823d3d11f73784bd5ab3cd4c7a07181335579017b14554c16e0023cd1", size = 66106, upload-time = "2026-07-21T00:49:02.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires the Airbyte MCP server into the generic secure-by-default trusted-execution gate landed in `fastmcp-extensions` v0.10.3 (airbytehq/fastmcp-extensions#71), and adds an **independent function-layer** of enforcement so trusted-machine capabilities can never be reached by an untrusted (e.g. hosted HTTP) caller — even if a future registration mistake left a tool visible.

This is PR2 of the MCP security hardening effort. It maps to remediations **R1** (trusted-execution gate), **R3** (server-side secret suppression / refusal), and the domain-config part of **R6** for the public `cloud-mcp` threat model. No infrastructure (Cloud Run / Pulumi), OAuth-client, or network-egress changes are in scope here.

### Two independent layers of defense

1. **Visibility layer (from PR1):** registering a `trusted_execution` config arg lets `fastmcp-extensions` hide `requires_client_filesystem` tools when the gate is off.
2. **Function layer (new here):** backend helpers call `require_trusted_execution(...)` themselves and hard-fail when the gate is off, independently of tool visibility.

Because the layers are independent, a mistake in either one alone cannot expose a trusted-machine capability.

### What changed

1. **Generic gate mapped to the Airbyte env var.** New `TRUSTED_EXECUTION_CONFIG_ARG` maps the generic `trusted_execution` config `name` to `AIRBYTE_MCP_TRUSTED_EXECUTION` (default `"0"`), keeping the generic library Airbyte-agnostic. Registered in `server.py`. It has **no** `http_header_key` — the gate *widens* the surface, so it must never be caller-controllable.

   ```python
   TRUSTED_EXECUTION_CONFIG_ARG = MCPServerConfigArg(
       name=CONFIG_TRUSTED_EXECUTION,      # generic name from fastmcp_extensions
       env_var=MCP_TRUSTED_EXECUTION_ENV_VAR,  # "AIRBYTE_MCP_TRUSTED_EXECUTION"
       default="0",
       required=False,
   )
   ```

2. **Permanent HTTP prohibition.** `http_main.main()` calls `assert_http_trusted_execution_disabled(app)` immediately before `app.run(...)`, hard-failing startup if trusted execution was explicitly enabled on the hosted entrypoint.

3. **Reusable function-layer guard** (`airbyte/mcp/_guards.py`):

   ```python
   def is_trusted_execution_enabled() -> bool: ...          # reads env only
   def require_trusted_execution(feature: str) -> None:     # raises when off
   ```

   Raises `PyAirbyteTrustedExecutionRequiredError` (new, under a new `PyAirbyteMCPError` base) with remediation in `guidance`, not in the deterministic message.

4. **Guarded backend helpers.** Guards were added so a *direct* call hard-fails when untrusted:
   - `_arg_resolvers.resolve_connector_config` — gates only the dangerous branches (`config_file`, `config_secret_name`, and inline `secret_reference::` values). An ordinary inline `config` dict is **still allowed** untrusted, because `cloud.py` legitimately resolves caller-provided config that way.
   - `local._get_mcp_source` (connector install/execution) and the local cache / secret-inventory / destructive tools: `list_cached_streams`, `describe_default_cache`, `run_sql_query`, `list_dotenv_secrets`, `list_connector_config_secrets`, `destination_smoke_test`.

5. **Secret-manager suppression when untrusted** (`_config.load_secrets_to_env_vars`). Dotenv and Google Secret Manager backends are no longer *registered as secret sources* when trusted execution is off, so `config_secret_name` / `secret_reference::` cannot resolve server-side secrets. Ordinary environment variables are still loaded from any referenced dotenv file so safe, non-secret-manager config keeps working.

6. **Domain-config hard-fail** (`_tool_utils.validate_airbyte_domains`, called after tool registration in `server.py`). Instead of silently dropping a requested domain, it hard-fails on (a) setting both `AIRBYTE_MCP_DOMAINS` and `AIRBYTE_MCP_DOMAINS_DISABLED`, and (b) naming a domain with no registered tools. Remediation names the setting to clear and says to restart.

## Test plan

New `tests/unit_tests/test_mcp_trusted_execution.py` (31 cases), covering:
1. env parsing / default-off for the gate;
2. `require_trusted_execution` raise-when-off / pass-when-on;
3. `resolve_connector_config`: inline config allowed untrusted; `config_file`, `config_secret_name`, and inline `secret_reference::` rejected untrusted; `config_file` + `secret_reference::` allowed when trusted;
4. parametrized function-layer rejection for all guarded `local` helpers when untrusted;
5. `assert_http_trusted_execution_disabled` raises when trusted is on, passes when off;
6. secret-manager suppression when untrusted (env var still loaded) vs. registration when trusted;
7. `validate_airbyte_domains` include+exclude conflict, unknown-domain, and valid-single-domain paths.

Local verification (uv):
```
uv run ruff format --check .   # 219 files already formatted
uv run ruff check .            # all checks passed
uv run pyrefly check           # 0 errors (2 preexisting warnings in cloud.py)
uv run pytest tests/unit_tests/test_mcp_trusted_execution.py   # 31 passed
uv run pytest tests/unit_tests/test_mcp_cloud.py test_mcp_tool_utils.py test_mcp_connector_registry.py  # 47 passed
```

## Limitations / out of scope

1. No Cloud Run / Pulumi, OAuth-client, or metadata-egress changes (separate follow-up PRs R2/R5 and infra wiring).
2. The generic `fastmcp-extensions` read API is used as-is; no new raising helper was added there (per maintainer direction).
3. The CI regression guard + `CONTRIBUTING.md` guidance (R8) is a separate follow-up PR.

https://app.devin.ai/sessions/1696a2c620134d61a5255f959ef4c4ef

Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a trusted-execution environment switch for MCP, covering connector config handling, secret hydration, dotenv secret processing, cache tools, and local SQL/destination checks.
  * Added startup validation for MCP domain include/exclude configuration.
* **Security**
  * Enforced hard failures for untrusted contexts across local privileged MCP capabilities.
  * Blocked enabling trusted execution via HTTP-exposed startup.
* **Bug Fixes**
  * Introduced MCP-specific error types for trusted-execution requirements and MCP server failures.
* **Tests**
  * Added unit tests covering trusted-execution gating, connector config restrictions, HTTP enforcement, secret/env loading behavior, and domain validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->