### PR TITLE
ci: use prepared-release-id to finalize release draft

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create draft release (not ready)
-        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
         id: not-ready-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,11 +45,13 @@ jobs:
         run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
 
       - name: Attach assets and finalize draft
-        uses: aaronsteers/semantic-pr-release-drafter@v2.1.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ steps.not-ready-draft.outputs.tag-name }}
+          # Finalize the exact draft prepared above via a strongly consistent
+          # point-read; version/tag/prerelease/SHA are reused from that release.
+          prepared-release-id: ${{ steps.not-ready-draft.outputs.id }}
           attach-files: |
             dist/*.whl
             dist/*.tar.gz


### PR DESCRIPTION
## Summary

Migrates the two-step release-drafter workflow to `aaronsteers/semantic-pr-release-drafter@v2.2.0` and finalizes the draft via `prepared-release-id` instead of re-pinning `version`.

Before, the finalize step re-discovered its draft by re-passing the version:

```yaml
version: ${{ steps.not-ready-draft.outputs.tag-name }}
```

That relied on the eventually-consistent `GET /releases` list, which can miss a draft created seconds earlier → a **duplicate** draft. Now the finalize targets the exact release created by the first step via a strongly consistent point-read:

```yaml
prepared-release-id: ${{ steps.not-ready-draft.outputs.id }}
```

The prepared release is the source of truth: its version, tag, prerelease state, and pinned commit SHA are reused as-is, so nothing can drift between the two steps. (The build step still consumes `tag-name` for `UV_DYNAMIC_VERSIONING_BYPASS` — unchanged.)

Requested by @aaronsteers, following up on aaronsteers/semantic-pr-release-drafter#57 (the `prepared-release-id` feature, released in v2.2.0).

Link to Devin session: https://app.devin.ai/sessions/c5aa9e420587440b9e2e5f4e92f65383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to use the latest release-drafting action.
  * Improved draft release finalization to reliably attach assets to the correct prepared release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._