### PR TITLE
feat(mcp): map branded AIRBYTE_MCP_* env into typed build_mcp_auth

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -151,15 +151,18 @@ server process locally, so there is no transport-layer auth and the only
 credentials that matter are your Airbyte Cloud creds in the dotenv file.
 
 When the server is instead exposed over **HTTP** (`airbyte-mcp-http` /
-`poe mcp-serve-http`), it verifies an `Authorization: Bearer <token>` on every
-request. Two client shapes are supported on the same deployment (combined
-automatically when both are configured):
+`poe mcp-serve-http`), transport auth is **always on** and verifies an
+`Authorization: Bearer <token>` on every request — defaulting to the Airbyte
+Cloud realm with zero auth config. Two client shapes are supported on the same
+deployment (combined automatically when both are configured):
 
 ### Humans → interactive OIDC
 
-Set `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET`. Interactive
-clients open a browser (Keycloak Authorization Code + PKCE) and the resulting
-token is verified by the server. No bearer token to manage by hand.
+Set `AIRBYTE_MCP_OIDC_CLIENT_ID` and `AIRBYTE_MCP_OIDC_CLIENT_SECRET` (the
+discovery URL defaults to Airbyte Cloud; override with
+`AIRBYTE_MCP_OIDC_CONFIG_URL`). Interactive clients open a browser (Keycloak
+Authorization Code + PKCE) and the resulting token is verified by the server.
+No bearer token to manage by hand.
 
 ### Machines / agents → headless bearer token
 
@@ -168,9 +171,10 @@ in a header. A headless agent **mints its own short-lived bearer token** and
 sends it as `Authorization: Bearer <token>`; the server verifies the signature
 (no browser, no stored/rotating refresh token).
 
-For Airbyte Cloud, set `MCP_AUTH_AIRBYTE_CLOUD=true` on the server so it verifies
-tokens against Airbyte Cloud's application-client realm without hand-configuring
-URLs. The agent mints an Airbyte Cloud access token from its
+By default the server verifies tokens against Airbyte Cloud's application-client
+realm with no configuration; a self-hosted deployment points at its own realm
+via the `AIRBYTE_MCP_AUTH_*` overrides below. The agent mints an Airbyte Cloud
+access token from its
 `AIRBYTE_CLOUD_CLIENT_ID` / `AIRBYTE_CLOUD_CLIENT_SECRET` (the
 `https://api.airbyte.com/v1/applications/token` endpoint) and sends it as the
 bearer. That single token both authenticates transport (verified by the server)
@@ -196,22 +200,30 @@ their MCP config:
 
 ### Server environment variables (HTTP mode)
 
+All names live in this server's branded `AIRBYTE_MCP_*` namespace; each headless
+var defaults to the Airbyte Cloud realm, so a self-hosted deployment overrides
+only the field(s) pointing at its own realm.
+
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.
-- `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` — enable interactive
-  OIDC (all three required).
-- `MCP_AUTH_AIRBYTE_CLOUD` — set truthy to verify headless tokens against Airbyte
-  Cloud's realm (fills JWKS URI / issuer / audience / algorithm with Airbyte
-  Cloud defaults; each stays overridable).
-- `MCP_AUTH_JWKS_URI` / `MCP_AUTH_JWT_PUBLIC_KEY` — JWKS URL or static public key
-  for verifying headless tokens.
-- `MCP_AUTH_ISSUER` / `MCP_AUTH_AUDIENCE` / `MCP_AUTH_ALGORITHM` — expected `iss`
-  / `aud` claims and signing algorithm (recommended for headless).
+- `AIRBYTE_MCP_OIDC_CLIENT_ID`, `AIRBYTE_MCP_OIDC_CLIENT_SECRET` — enable
+  interactive OIDC (both required).
+- `AIRBYTE_MCP_OIDC_CONFIG_URL` — OIDC discovery URL (defaults to Airbyte Cloud).
+- `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY` — optional `"package.module:callable"`
+  naming a durable OAuth-state store factory for the interactive proxy (defaults
+  to in-memory).
+- `AIRBYTE_MCP_AUTH_JWKS_URI` / `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY` — JWKS URL or
+  static public key for verifying headless tokens (defaults to Airbyte Cloud's
+  JWKS).
+- `AIRBYTE_MCP_AUTH_ISSUER` / `AIRBYTE_MCP_AUTH_AUDIENCE` /
+  `AIRBYTE_MCP_AUTH_ALGORITHM` — expected `iss` / `aud` claims and signing
+  algorithm (default to Airbyte Cloud's realm).
 
-If no transport auth variables are set, the HTTP server starts
-**unauthenticated** and logs a warning — acceptable only behind a trusted
-network boundary. The verifier assembly is provided by
-[`fastmcp-extensions`](https://github.com/airbytehq/fastmcp-extensions).
+Because the headless verifier defaults to Airbyte Cloud, the HTTP server is
+always authenticated even with no auth variables set. This server maps the
+`AIRBYTE_MCP_*` variables into the typed config objects consumed by
+[`fastmcp-extensions`](https://github.com/airbytehq/fastmcp-extensions), which
+assembles the verifier(s) and reads no environment variables itself.
 
 ## Troubleshooting
 

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -151,18 +151,19 @@ server process locally, so there is no transport-layer auth and the only
 credentials that matter are your Airbyte Cloud creds in the dotenv file.
 
 When the server is instead exposed over **HTTP** (`airbyte-mcp-http` /
-`poe mcp-serve-http`), transport auth is **always on** and verifies an
-`Authorization: Bearer <token>` on every request — defaulting to the Airbyte
-Cloud realm with zero auth config. Two client shapes are supported on the same
-deployment (combined automatically when both are configured):
+`poe mcp-serve-http`), transport auth verifies an `Authorization: Bearer
+<token>` on every request once it is configured. Auth is driven entirely by the
+`AIRBYTE_MCP_*` env values a deployment sets — the hosted Airbyte Cloud MCP
+deployment supplies its realm's values, and a self-hosted deployment supplies
+its own. Two client shapes are supported on the same deployment (combined
+automatically when both are configured):
 
 ### Humans → interactive OIDC
 
-Set `AIRBYTE_MCP_OIDC_CLIENT_ID` and `AIRBYTE_MCP_OIDC_CLIENT_SECRET` (the
-discovery URL defaults to Airbyte Cloud; override with
-`AIRBYTE_MCP_OIDC_CONFIG_URL`). Interactive clients open a browser (Keycloak
-Authorization Code + PKCE) and the resulting token is verified by the server.
-No bearer token to manage by hand.
+Set `AIRBYTE_MCP_OIDC_CLIENT_ID`, `AIRBYTE_MCP_OIDC_CLIENT_SECRET`, and
+`AIRBYTE_MCP_OIDC_CONFIG_URL` (the OIDC discovery URL). Interactive clients open
+a browser (Keycloak Authorization Code + PKCE) and the resulting token is
+verified by the server. No bearer token to manage by hand.
 
 ### Machines / agents → headless bearer token
 
@@ -171,10 +172,10 @@ in a header. A headless agent **mints its own short-lived bearer token** and
 sends it as `Authorization: Bearer <token>`; the server verifies the signature
 (no browser, no stored/rotating refresh token).
 
-By default the server verifies tokens against Airbyte Cloud's application-client
-realm with no configuration; a self-hosted deployment points at its own realm
-via the `AIRBYTE_MCP_AUTH_*` overrides below. The agent mints an Airbyte Cloud
-access token from its
+The server verifies tokens against whatever realm the deployment configures via
+the `AIRBYTE_MCP_AUTH_*` env values below. Against the hosted Airbyte Cloud MCP
+(configured for Airbyte Cloud's application-client realm), the agent mints an
+Airbyte Cloud access token from its
 `AIRBYTE_CLOUD_CLIENT_ID` / `AIRBYTE_CLOUD_CLIENT_SECRET` (the
 `https://api.airbyte.com/v1/applications/token` endpoint) and sends it as the
 bearer. That single token both authenticates transport (verified by the server)
@@ -200,31 +201,32 @@ their MCP config:
 
 ### Server environment variables (HTTP mode)
 
-The auth vars use this server's branded `AIRBYTE_MCP_*` namespace. The headless
-verifier defaults to Airbyte Cloud's realm — its JWKS URI, issuer, audience, and
-algorithm — so a self-hosted deployment overrides only the field(s) pointing at
-its own realm. The static public key has no default; the Cloud JWKS fallback
-applies only when neither the JWKS URI nor the public key is set. `MCP_SERVER_URL`
-is a deployment URL (not an auth var) and stays unbranded.
+The auth vars use this server's branded `AIRBYTE_MCP_*` namespace. This server
+declares only the env var *names* and reads them; the concrete *values* (a
+realm's JWKS URI, issuer, audience, discovery URL, etc.) are supplied at deploy
+time by the deployment's own repo — none are baked in here. The headless
+verifier activates once a signing-key source (JWKS URI or static public key) is
+set; the interactive path activates once the OIDC client credentials are set.
+`MCP_SERVER_URL` is a deployment URL (not an auth var) and stays unbranded.
 
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.
 - `AIRBYTE_MCP_OIDC_CLIENT_ID`, `AIRBYTE_MCP_OIDC_CLIENT_SECRET` — enable
   interactive OIDC (both required).
-- `AIRBYTE_MCP_OIDC_CONFIG_URL` — OIDC discovery URL (defaults to Airbyte Cloud).
+- `AIRBYTE_MCP_OIDC_CONFIG_URL` — OIDC discovery URL (required when the client
+  credentials are set).
 - `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY` — optional `"package.module:callable"`
   naming a durable OAuth-state store factory for the interactive proxy (defaults
   to in-memory).
 - `AIRBYTE_MCP_AUTH_JWKS_URI` / `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY` — JWKS URL or
-  static public key for verifying headless tokens (defaults to Airbyte Cloud's
-  JWKS).
+  static public key for verifying headless tokens (one activates the verifier).
 - `AIRBYTE_MCP_AUTH_ISSUER` / `AIRBYTE_MCP_AUTH_AUDIENCE` /
   `AIRBYTE_MCP_AUTH_ALGORITHM` — expected `iss` / `aud` claims and signing
-  algorithm (default to Airbyte Cloud's realm).
+  algorithm.
 
-Because the headless verifier defaults to Airbyte Cloud, the HTTP server is
-always authenticated even with no auth variables set. This server maps the
-`AIRBYTE_MCP_*` variables into the typed config objects consumed by
+With no auth variables set, the HTTP server falls back to unauthenticated local
+behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config
+objects consumed by
 [`fastmcp-extensions`](https://github.com/airbytehq/fastmcp-extensions), which
 assembles the verifier(s) and reads no environment variables itself.
 

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -200,9 +200,10 @@ their MCP config:
 
 ### Server environment variables (HTTP mode)
 
-All names live in this server's branded `AIRBYTE_MCP_*` namespace; each headless
-var defaults to the Airbyte Cloud realm, so a self-hosted deployment overrides
-only the field(s) pointing at its own realm.
+The auth vars use this server's branded `AIRBYTE_MCP_*` namespace, and each
+headless var defaults to the Airbyte Cloud realm, so a self-hosted deployment
+overrides only the field(s) pointing at its own realm. `MCP_SERVER_URL` is a
+deployment URL (not an auth var) and stays unbranded.
 
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -200,10 +200,12 @@ their MCP config:
 
 ### Server environment variables (HTTP mode)
 
-The auth vars use this server's branded `AIRBYTE_MCP_*` namespace, and each
-headless var defaults to the Airbyte Cloud realm, so a self-hosted deployment
-overrides only the field(s) pointing at its own realm. `MCP_SERVER_URL` is a
-deployment URL (not an auth var) and stays unbranded.
+The auth vars use this server's branded `AIRBYTE_MCP_*` namespace. The headless
+verifier defaults to Airbyte Cloud's realm — its JWKS URI, issuer, audience, and
+algorithm — so a self-hosted deployment overrides only the field(s) pointing at
+its own realm. The static public key has no default; the Cloud JWKS fallback
+applies only when neither the JWKS URI nor the public key is set. `MCP_SERVER_URL`
+is a deployment URL (not an auth var) and stays unbranded.
 
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -44,7 +44,6 @@ JWKS URI nor the public key is set:
 from __future__ import annotations
 
 import logging
-import os
 from urllib.parse import urlparse
 
 from fastmcp_extensions import (
@@ -55,7 +54,9 @@ from fastmcp_extensions import (
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
+    DEFAULT_MCP_SERVER_URL,
     MCP_SERVER_URL_ENV,
+    _env_or_default,
     app,
 )
 
@@ -68,11 +69,13 @@ MCP_LANDING_DOCS_URL = "https://docs.airbyte.com/ai-agents/"
 
 
 def _get_server_url() -> str:
-    """Return the public base URL from `MCP_SERVER_URL`, defaulting to localhost."""
-    return os.getenv(
-        MCP_SERVER_URL_ENV,
-        f"http://localhost:{DEFAULT_HTTP_PORT}",
-    )
+    """Return the public base URL from `MCP_SERVER_URL`, defaulting to localhost.
+
+    Uses the same blank-as-unset handling as `server._create_auth` so the HTTP
+    mount/landing URL and the auth redirect/base URL agree on the effective
+    server URL even when `MCP_SERVER_URL` is set but blank.
+    """
+    return _env_or_default(MCP_SERVER_URL_ENV, DEFAULT_MCP_SERVER_URL)
 
 
 def main() -> None:

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -25,12 +25,17 @@ credentials are set (the discovery URL defaults to Airbyte Cloud):
   naming a durable OAuth-state store factory (defaults to in-memory)
 
 Headless bearer-token verification (for agents/CI that mint their own
-short-lived token via the client credentials grant). Each var defaults to the
-Airbyte Cloud application-client realm, so a self-hosted deployment overrides
-only the field(s) pointing at its own realm:
+short-lived token via the client credentials grant). The verifier defaults to
+Airbyte Cloud's application-client realm — its JWKS URI, issuer, audience, and
+algorithm — so a self-hosted deployment overrides only the field(s) pointing at
+its own realm. The static public key has no default; it's an alternative
+signing-key source, and the Cloud JWKS fallback applies only when neither the
+JWKS URI nor the public key is set:
 
 - `AIRBYTE_MCP_AUTH_JWKS_URI`: JWKS endpoint used to verify token signatures
-- `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to the JWKS URI)
+  (defaults to Airbyte Cloud's JWKS unless a static public key is set)
+- `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to the JWKS
+  URI; no default)
 - `AIRBYTE_MCP_AUTH_ISSUER`: expected token issuer
 - `AIRBYTE_MCP_AUTH_AUDIENCE`: expected token audience
 - `AIRBYTE_MCP_AUTH_ALGORITHM`: signing algorithm override

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -5,9 +5,11 @@ Starts the MCP server with HTTP transport, suitable for hosted deployment
 behind a load balancer. Transport auth is assembled in `server.py`, which maps
 this server's branded `AIRBYTE_MCP_*` env vars into the typed configs consumed
 by `fastmcp_extensions.build_mcp_auth` (interactive OIDC and/or headless
-bearer-token verification, combined via `MultiAuth`). HTTP transport is
-**always authenticated**, defaulting to the Airbyte Cloud realm with zero auth
-config. See `server.py` for details.
+bearer-token verification, combined via `MultiAuth`). Auth activates only for
+the paths a deployment configures via env; with no auth env set the server
+falls back to unauthenticated local behavior. This module declares only the env
+var *names* — the concrete values are supplied at deploy time by the
+deployment's own repo. See `server.py` for details.
 
 Environment variables:
 
@@ -16,26 +18,23 @@ Environment variables:
   prefix, otherwise defaults to `/mcp`).
 
 Interactive OIDC (Keycloak Authorization Code + PKCE), enabled when the client
-credentials are set (the discovery URL defaults to Airbyte Cloud):
+credentials are set:
 
 - `AIRBYTE_MCP_OIDC_CLIENT_ID`: OIDC client identifier
 - `AIRBYTE_MCP_OIDC_CLIENT_SECRET`: OIDC client secret
-- `AIRBYTE_MCP_OIDC_CONFIG_URL`: OIDC discovery URL (defaults to Airbyte Cloud)
+- `AIRBYTE_MCP_OIDC_CONFIG_URL`: OIDC discovery URL (required when the client
+  credentials are set)
 - `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY`: optional `"package.module:callable"`
   naming a durable OAuth-state store factory (defaults to in-memory)
 
 Headless bearer-token verification (for agents/CI that mint their own
-short-lived token via the client credentials grant). The verifier defaults to
-Airbyte Cloud's application-client realm — its JWKS URI, issuer, audience, and
-algorithm — so a self-hosted deployment overrides only the field(s) pointing at
-its own realm. The static public key has no default; it's an alternative
-signing-key source, and the Cloud JWKS fallback applies only when neither the
-JWKS URI nor the public key is set:
+short-lived token via the client credentials grant). The verifier activates
+once a signing-key source — the JWKS URI or a static public key — is set;
+issuer, audience, and algorithm refine verification when provided:
 
 - `AIRBYTE_MCP_AUTH_JWKS_URI`: JWKS endpoint used to verify token signatures
-  (defaults to Airbyte Cloud's JWKS unless a static public key is set)
 - `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to the JWKS
-  URI; no default)
+  URI)
 - `AIRBYTE_MCP_AUTH_ISSUER`: expected token issuer
 - `AIRBYTE_MCP_AUTH_AUDIENCE`: expected token audience
 - `AIRBYTE_MCP_AUTH_ALGORITHM`: signing algorithm override

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -2,10 +2,12 @@
 """HTTP transport entry point for the Airbyte MCP server.
 
 Starts the MCP server with HTTP transport, suitable for hosted deployment
-behind a load balancer. Transport auth is assembled in `server.py` via
-`fastmcp_extensions.resolve_mcp_auth`, which supports interactive OIDC and
-headless bearer-token verification (combined via `MultiAuth` when both are
-configured). See `server.py` for details.
+behind a load balancer. Transport auth is assembled in `server.py`, which maps
+this server's branded `AIRBYTE_MCP_*` env vars into the typed configs consumed
+by `fastmcp_extensions.build_mcp_auth` (interactive OIDC and/or headless
+bearer-token verification, combined via `MultiAuth`). HTTP transport is
+**always authenticated**, defaulting to the Airbyte Cloud realm with zero auth
+config. See `server.py` for details.
 
 Environment variables:
 
@@ -13,22 +15,25 @@ Environment variables:
   derive the MCP endpoint mount path (serves at `/` when the URL has a path
   prefix, otherwise defaults to `/mcp`).
 
-Interactive OIDC (Keycloak Authorization Code + PKCE), enabled when all three
-are set:
+Interactive OIDC (Keycloak Authorization Code + PKCE), enabled when the client
+credentials are set (the discovery URL defaults to Airbyte Cloud):
 
-- `OIDC_CONFIG_URL`: Keycloak OIDC discovery URL
-- `OIDC_CLIENT_ID`: OIDC client identifier
-- `OIDC_CLIENT_SECRET`: OIDC client secret
+- `AIRBYTE_MCP_OIDC_CLIENT_ID`: OIDC client identifier
+- `AIRBYTE_MCP_OIDC_CLIENT_SECRET`: OIDC client secret
+- `AIRBYTE_MCP_OIDC_CONFIG_URL`: OIDC discovery URL (defaults to Airbyte Cloud)
+- `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY`: optional `"package.module:callable"`
+  naming a durable OAuth-state store factory (defaults to in-memory)
 
 Headless bearer-token verification (for agents/CI that mint their own
-short-lived token via the client credentials grant), enabled when
-`MCP_AUTH_JWKS_URI` or `MCP_AUTH_JWT_PUBLIC_KEY` is set:
+short-lived token via the client credentials grant). Each var defaults to the
+Airbyte Cloud application-client realm, so a self-hosted deployment overrides
+only the field(s) pointing at its own realm:
 
-- `MCP_AUTH_JWKS_URI`: JWKS endpoint used to verify token signatures
-- `MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to `MCP_AUTH_JWKS_URI`)
-- `MCP_AUTH_ISSUER`: expected token issuer
-- `MCP_AUTH_AUDIENCE`: expected token audience
-- `MCP_AUTH_ALGORITHM`: signing algorithm override
+- `AIRBYTE_MCP_AUTH_JWKS_URI`: JWKS endpoint used to verify token signatures
+- `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`: static public key (alternative to the JWKS URI)
+- `AIRBYTE_MCP_AUTH_ISSUER`: expected token issuer
+- `AIRBYTE_MCP_AUTH_AUDIENCE`: expected token audience
+- `AIRBYTE_MCP_AUTH_ALGORITHM`: signing algorithm override
 """
 
 from __future__ import annotations
@@ -89,15 +94,6 @@ def main() -> None:
         endpoint_url=endpoint_url,
         docs_url=MCP_LANDING_DOCS_URL,
     )
-
-    if getattr(app, "auth", None) is None:
-        logger.warning(
-            "HTTP transport starting without authentication: no interactive "
-            "OIDC or headless bearer-token auth is configured, so every "
-            "request is unauthenticated. Set `OIDC_CONFIG_URL`/`OIDC_CLIENT_ID`/"
-            "`OIDC_CLIENT_SECRET` (interactive) or `MCP_AUTH_JWKS_URI`/"
-            "`MCP_AUTH_JWT_PUBLIC_KEY` (headless) to require auth."
-        )
 
     logger.info(
         "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -111,6 +111,8 @@ def main() -> None:
             "(interactive) or `AIRBYTE_MCP_AUTH_JWKS_URI`/"
             "`AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY` (headless) to require auth."
         )
+    else:
+        logger.info("HTTP transport authentication is enabled (%s).", type(app.auth).__name__)
 
     logger.info(
         "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -102,6 +102,16 @@ def main() -> None:
         docs_url=MCP_LANDING_DOCS_URL,
     )
 
+    if app.auth is None:
+        logger.warning(
+            "HTTP transport starting without authentication: no interactive "
+            "OIDC or headless bearer-token auth is configured, so every request "
+            "is unauthenticated. Set `AIRBYTE_MCP_OIDC_CLIENT_ID`/"
+            "`AIRBYTE_MCP_OIDC_CLIENT_SECRET`/`AIRBYTE_MCP_OIDC_CONFIG_URL` "
+            "(interactive) or `AIRBYTE_MCP_AUTH_JWKS_URI`/"
+            "`AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY` (headless) to require auth."
+        )
+
     logger.info(
         "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",
         DEFAULT_HTTP_HOST,

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -3,24 +3,33 @@
 
 Supports two transport modes:
 
-- **stdio** (default): For local MCP clients (Claude Desktop, etc.)
+- **stdio** (default): For local MCP clients (Claude Desktop, etc.). Auth is not
+  enforced; the provider assembled below is ignored by the stdio transport.
 - **HTTP**: For hosted deployment. Start via `airbyte-mcp-http` entry point or
-  `poe mcp-serve-http`. Transport auth is assembled by
-  `fastmcp_extensions.resolve_mcp_auth`, which supports two client shapes on the
-  same deployment:
+  `poe mcp-serve-http`. HTTP transport is **always authenticated**, defaulting
+  to Airbyte Cloud with zero auth config. This server maps its own branded
+  `AIRBYTE_MCP_*` env vars into the typed configs that
+  `fastmcp_extensions.build_mcp_auth` consumes, which supports two client shapes
+  on the same deployment:
     - **Interactive** (humans in a browser): Keycloak Authorization Code + PKCE
-      via `OIDCProxy`, enabled when `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, and
-      `OIDC_CLIENT_SECRET` are all set.
+      via `OIDCProxy`, active once `AIRBYTE_MCP_OIDC_CLIENT_ID` and
+      `AIRBYTE_MCP_OIDC_CLIENT_SECRET` are supplied (the OIDC discovery URL
+      defaults to Airbyte Cloud).
     - **Headless** (agents, CI): the client mints its own short-lived bearer
       token via the OAuth 2.0 client credentials grant and sends it as
       `Authorization: Bearer <token>`. The server verifies it with a
-      `JWTVerifier` (no browser, no stored/rotating refresh token), enabled
-      when `MCP_AUTH_JWKS_URI` (or `MCP_AUTH_JWT_PUBLIC_KEY`) is set.
-  When both are configured they are combined via `MultiAuth`.
+      `JWTVerifier` against Airbyte Cloud's application-client realm by default
+      (no browser, no stored/rotating refresh token).
+  When both are active they are combined via `MultiAuth`.
 
-For Airbyte Cloud, set `MCP_AUTH_AIRBYTE_CLOUD=true` to verify against Airbyte
-Cloud's application-client realm without hand-configuring URLs. An agent then
-mints an Airbyte Cloud access token from its `AIRBYTE_CLOUD_CLIENT_ID` /
+This module owns the Airbyte Cloud realm defaults (non-secret, publicly
+discoverable) and maps its branded `AIRBYTE_MCP_OIDC_*` / `AIRBYTE_MCP_AUTH_*`
+env vars into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that
+`build_mcp_auth` consumes, so the extensions library stays provider-neutral and
+reads no env itself. A self-hosted deployment pointing at its own Airbyte
+instance overrides any default via the matching env var.
+
+An agent mints an Airbyte Cloud access token from its `AIRBYTE_CLOUD_CLIENT_ID` /
 `AIRBYTE_CLOUD_CLIENT_SECRET` (the `<api_root>/applications/token` endpoint) and
 sends it as `Authorization: Bearer`. That single token both authenticates
 transport (verified here) and authorizes downstream Cloud API calls (the same
@@ -33,19 +42,22 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import pkgutil
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from fastmcp_extensions import (
     JWTAuthConfig,
+    OIDCAuthConfig,
+    build_mcp_auth,
     mcp_server,
-    resolve_mcp_auth,
 )
 from starlette.responses import JSONResponse
 
 
 if TYPE_CHECKING:
     from fastmcp.server.auth import AuthProvider
+    from key_value.aio.protocols.key_value import AsyncKeyValue
     from starlette.requests import Request
 
 from airbyte._util.meta import set_mcp_mode
@@ -109,52 +121,151 @@ Safety features:
 
 logger = logging.getLogger(__name__)
 
-# Public base URL of this deployment; consumed by `http_main` to derive the
-# mounted MCP path. All other transport auth env vars (`OIDC_*` interactive,
-# `MCP_AUTH_*` headless) are read by `fastmcp_extensions.resolve_mcp_auth`.
+# This server's own (branded) transport-auth env vars. It owns these names and
+# maps them into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that
+# `build_mcp_auth` consumes; the extensions library reads no env itself. The
+# branded `AIRBYTE_MCP_*` namespace is an added layer over generic OAuth names.
+
+# Public base URL of this deployment (also used for OIDC redirect callbacks);
+# `http_main` reuses it to derive the mounted MCP path.
 MCP_SERVER_URL_ENV = "MCP_SERVER_URL"
 
-# Flag that opts headless verification into Airbyte Cloud's application-client
-# realm; this server owns only this provider literal.
-MCP_AUTH_AIRBYTE_CLOUD_ENV = "MCP_AUTH_AIRBYTE_CLOUD"
+# Interactive OIDC (`OIDCProxy`). Client id + secret gate the interactive path;
+# the discovery URL defaults to Airbyte Cloud when unset.
+OIDC_CLIENT_ID_ENV = "AIRBYTE_MCP_OIDC_CLIENT_ID"
+OIDC_CLIENT_SECRET_ENV = "AIRBYTE_MCP_OIDC_CLIENT_SECRET"
+OIDC_CONFIG_URL_ENV = "AIRBYTE_MCP_OIDC_CONFIG_URL"
 
-# Airbyte Cloud's application-client realm. Tokens minted from an Airbyte Cloud
-# `client_id`/`client_secret` via `<api_root>/applications/token` are RS256 JWTs
-# issued by this realm, and the same token is a valid Airbyte Cloud API bearer.
-# Verifying against this realm lets one token both authenticate transport and
-# authorize downstream Cloud calls. Enable with `MCP_AUTH_AIRBYTE_CLOUD=true`.
-AIRBYTE_CLOUD_REALM_ISSUER = "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
-AIRBYTE_CLOUD_JWKS_URI = f"{AIRBYTE_CLOUD_REALM_ISSUER}/protocol/openid-connect/certs"
-AIRBYTE_CLOUD_JWT_AUDIENCE = "account"
-AIRBYTE_CLOUD_JWT_ALGORITHM = "RS256"
+# Headless JWT verifier. Each defaults to the Airbyte Cloud realm below, so a
+# self-hosted deployment overrides only the field(s) pointing at its own realm.
+JWKS_URI_ENV = "AIRBYTE_MCP_AUTH_JWKS_URI"
+JWT_PUBLIC_KEY_ENV = "AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY"
+JWT_ISSUER_ENV = "AIRBYTE_MCP_AUTH_ISSUER"
+JWT_AUDIENCE_ENV = "AIRBYTE_MCP_AUTH_AUDIENCE"
+JWT_ALGORITHM_ENV = "AIRBYTE_MCP_AUTH_ALGORITHM"
+
+# Names a durable-storage factory (`"package.module:callable"`) for the
+# interactive `OIDCProxy`'s OAuth state. The concrete backend (and its infra
+# config) lives in the deployment's own package, keeping PyAirbyte generic.
+OIDC_CLIENT_STORAGE_FACTORY_ENV = "AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY"
+
+# Airbyte Cloud's application-client realm (non-secret, publicly discoverable).
+# Tokens minted from an Airbyte Cloud `client_id`/`client_secret` via
+# `<api_root>/applications/token` are RS256 JWTs issued by this realm, and the
+# same token is a valid Airbyte Cloud API bearer — so verifying against this
+# realm by default lets one token both authenticate transport and authorize
+# downstream Cloud calls.
+AIRBYTE_CLOUD_OIDC_CONFIG_URL = (
+    "https://cloud.airbyte.com/auth/realms/airbyte/.well-known/openid-configuration"
+)
+AIRBYTE_CLOUD_ISSUER = "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
+AIRBYTE_CLOUD_JWKS_URI = f"{AIRBYTE_CLOUD_ISSUER}/protocol/openid-connect/certs"
+AIRBYTE_CLOUD_AUDIENCE = "account"
+AIRBYTE_CLOUD_ALGORITHM = "RS256"
 
 DEFAULT_HTTP_HOST = "0.0.0.0"
 DEFAULT_HTTP_PORT = 8080
+DEFAULT_MCP_SERVER_URL = f"http://localhost:{DEFAULT_HTTP_PORT}"
+
+
+class _ClientStorageFactory(Protocol):
+    """Callable that builds a durable `OIDCProxy` OAuth-state backend.
+
+    A deployment names its factory via
+    `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY` (`"package.module:callable"`). The
+    callable receives the OIDC client secret as `encryption_source_material` so
+    it can derive an at-rest encryption key, and returns an `AsyncKeyValue`
+    store. Keeping the concrete backend (Firestore, Redis, ...) behind this hook
+    lets PyAirbyte stay generic — the infrastructure-specific factory ships in
+    the deployment's own package (e.g. the hosted Cloud MCP image), not here.
+    """
+
+    def __call__(self, *, encryption_source_material: str) -> AsyncKeyValue: ...
+
+
+def _env_or_default(name: str, default: str) -> str:
+    """Return the stripped value of env var `name`, or `default` when blank/unset.
+
+    Blank and whitespace-only values are treated as unset so an empty deployment
+    override falls back to the Airbyte Cloud realm default rather than an empty
+    string.
+    """
+    value = os.getenv(name, "").strip()
+    return value or default
+
+
+def _resolve_signing_key() -> tuple[str, str]:
+    """Resolve the headless JWT verifier's signing-key source.
+
+    Returns the `(jwks_uri, public_key)` pair. A deployment may set either env
+    var to point at its own realm; the Airbyte Cloud JWKS default applies only
+    when *neither* is set, so a self-hosted static public key isn't shadowed by
+    a leftover Cloud JWKS URI. Blank or whitespace-only values are treated as
+    unset, and an unset member is returned as the empty string.
+    """
+    jwks_uri = os.getenv(JWKS_URI_ENV, "").strip()
+    public_key = os.getenv(JWT_PUBLIC_KEY_ENV, "").strip()
+    if not jwks_uri and not public_key:
+        jwks_uri = AIRBYTE_CLOUD_JWKS_URI
+    return jwks_uri, public_key
+
+
+def _resolve_client_storage(*, encryption_source_material: str) -> AsyncKeyValue | None:
+    """Resolve the durable `OIDCProxy` OAuth-state store, if one is configured.
+
+    Reads `AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY` (`"package.module:callable"`),
+    imports the named factory, and calls it to build the store. Returns `None`
+    when the var is unset/blank, keeping `OIDCProxy`'s in-memory default (fine
+    for single-instance local dev). PyAirbyte stays backend-agnostic: it never
+    imports a concrete store, so the infrastructure-specific factory (e.g. the
+    Fernet-wrapped Firestore store for the hosted Cloud MCP image) ships in the
+    deployment's own package.
+    """
+    factory_spec = os.getenv(OIDC_CLIENT_STORAGE_FACTORY_ENV, "").strip()
+    if not factory_spec:
+        return None
+    factory: _ClientStorageFactory = pkgutil.resolve_name(factory_spec)
+    return factory(encryption_source_material=encryption_source_material)
 
 
 def _create_auth() -> AuthProvider | None:
-    """Assemble the transport auth provider from environment configuration.
+    """Assemble the transport auth provider, defaulting to Airbyte Cloud.
 
-    Delegates env parsing to `fastmcp_extensions.resolve_mcp_auth`, which wires
-    up interactive `OIDCProxy` (from `OIDC_*`) and/or headless `JWTVerifier`
-    (from `MCP_AUTH_*`), combining them via `MultiAuth` when both are set and
-    returning `None` when neither is — so the server falls back to standard
-    local (no-auth) behavior.
-
-    When `MCP_AUTH_AIRBYTE_CLOUD` is truthy, the headless verifier defaults to
-    Airbyte Cloud's application-client realm (JWKS / issuer / audience /
-    algorithm); individual `MCP_AUTH_*` vars still override those fields. This
-    is the only provider literal the server owns.
+    Reads this server's branded `AIRBYTE_MCP_*` env vars (falling back to
+    Airbyte Cloud's public realm defaults), maps them into the typed
+    `JWTAuthConfig` / `OIDCAuthConfig` objects that
+    `fastmcp_extensions.build_mcp_auth` consumes, and lets it wire up a headless
+    `JWTVerifier` and/or an interactive `OIDCProxy`, combined via `MultiAuth`.
+    Because a JWKS default is always present, HTTP transport always verifies
+    bearer tokens against Airbyte Cloud's application-client realm; the
+    interactive path additionally activates once the OIDC client credentials are
+    supplied. The `stdio` transport ignores the provider entirely.
     """
-    jwt_defaults: JWTAuthConfig | None = None
-    if os.getenv(MCP_AUTH_AIRBYTE_CLOUD_ENV, "").strip().lower() in {"1", "true", "yes"}:
-        jwt_defaults = JWTAuthConfig(
-            jwks_uri=AIRBYTE_CLOUD_JWKS_URI,
-            issuer=AIRBYTE_CLOUD_REALM_ISSUER,
-            audience=AIRBYTE_CLOUD_JWT_AUDIENCE,
-            algorithm=AIRBYTE_CLOUD_JWT_ALGORITHM,
+    base_url = _env_or_default(MCP_SERVER_URL_ENV, DEFAULT_MCP_SERVER_URL)
+
+    jwks_uri, public_key = _resolve_signing_key()
+    jwt = JWTAuthConfig(
+        jwks_uri=jwks_uri or None,
+        public_key=public_key or None,
+        issuer=_env_or_default(JWT_ISSUER_ENV, AIRBYTE_CLOUD_ISSUER),
+        audience=_env_or_default(JWT_AUDIENCE_ENV, AIRBYTE_CLOUD_AUDIENCE),
+        algorithm=_env_or_default(JWT_ALGORITHM_ENV, AIRBYTE_CLOUD_ALGORITHM),
+        base_url=base_url,
+    )
+
+    oidc: OIDCAuthConfig | None = None
+    oidc_client_id = os.getenv(OIDC_CLIENT_ID_ENV, "").strip()
+    oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "").strip()
+    if oidc_client_id and oidc_client_secret:
+        oidc = OIDCAuthConfig(
+            config_url=_env_or_default(OIDC_CONFIG_URL_ENV, AIRBYTE_CLOUD_OIDC_CONFIG_URL),
+            client_id=oidc_client_id,
+            client_secret=oidc_client_secret,
+            base_url=base_url,
+            client_storage=_resolve_client_storage(encryption_source_material=oidc_client_secret),
         )
-    return resolve_mcp_auth(jwt_defaults=jwt_defaults)
+
+    return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=base_url)
 
 
 set_mcp_mode()

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -121,10 +121,11 @@ Safety features:
 
 logger = logging.getLogger(__name__)
 
-# This server's own (branded) transport-auth env vars. It owns these names and
-# maps them into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that
-# `build_mcp_auth` consumes; the extensions library reads no env itself. The
-# branded `AIRBYTE_MCP_*` namespace is an added layer over generic OAuth names.
+# This server's own transport-auth env vars. It owns these names and maps them
+# into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that `build_mcp_auth`
+# consumes; the extensions library reads no env itself. The auth vars below use
+# the branded `AIRBYTE_MCP_*` namespace as an added layer over generic OAuth
+# names; `MCP_SERVER_URL` (a deployment URL, not an auth var) stays unbranded.
 
 # Public base URL of this deployment (also used for OIDC redirect callbacks);
 # `http_main` reuses it to derive the mounted MCP path.

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -221,11 +221,24 @@ def _resolve_client_storage(*, encryption_source_material: str) -> AsyncKeyValue
     imports a concrete store, so the infrastructure-specific factory (e.g. the
     Fernet-wrapped Firestore store for the hosted Cloud MCP image) ships in the
     deployment's own package.
+
+    Raises `ValueError` (naming the env var and expected format) when the
+    factory reference is malformed or points at a missing symbol, so a
+    misconfigured deployment fails with a clear message instead of a bare
+    import traceback.
     """
     factory_spec = os.getenv(OIDC_CLIENT_STORAGE_FACTORY_ENV, "").strip()
     if not factory_spec:
         return None
-    factory: _ClientStorageFactory = pkgutil.resolve_name(factory_spec)
+    try:
+        factory: _ClientStorageFactory = pkgutil.resolve_name(factory_spec)
+    except (ImportError, AttributeError, ValueError) as exc:
+        msg = (
+            f"{OIDC_CLIENT_STORAGE_FACTORY_ENV}={factory_spec!r} could not be "
+            "resolved; expected a 'package.module:callable' reference to an "
+            "importable OAuth-state store factory."
+        )
+        raise ValueError(msg) from exc
     return factory(encryption_source_material=encryption_source_material)
 
 

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -121,24 +121,27 @@ Safety features:
 
 logger = logging.getLogger(__name__)
 
-# This server's own transport-auth env vars. It owns these names and maps them
-# into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that `build_mcp_auth`
-# consumes; the extensions library reads no env itself. The auth vars below use
-# the branded `AIRBYTE_MCP_*` namespace as an added layer over generic OAuth
-# names; `MCP_SERVER_URL` (a deployment URL, not an auth var) stays unbranded.
+# This server's own transport-auth env vars. It owns these *names* and maps the
+# *values* into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that
+# `build_mcp_auth` consumes; the extensions library reads no env itself. The
+# auth vars use the branded `AIRBYTE_MCP_*` namespace as an added layer over
+# generic OAuth names; `MCP_SERVER_URL` (a deployment URL, not an auth var)
+# stays unbranded. Only names live here — the concrete values (e.g. a specific
+# realm's endpoints) are supplied at deploy time by the deployment's own repo,
+# keeping infrastructure configuration out of this generic library.
 
 # Public base URL of this deployment (also used for OIDC redirect callbacks);
 # `http_main` reuses it to derive the mounted MCP path.
 MCP_SERVER_URL_ENV = "MCP_SERVER_URL"
 
 # Interactive OIDC (`OIDCProxy`). Client id + secret gate the interactive path;
-# the discovery URL defaults to Airbyte Cloud when unset.
+# the discovery URL comes from the deployment.
 OIDC_CLIENT_ID_ENV = "AIRBYTE_MCP_OIDC_CLIENT_ID"
 OIDC_CLIENT_SECRET_ENV = "AIRBYTE_MCP_OIDC_CLIENT_SECRET"
 OIDC_CONFIG_URL_ENV = "AIRBYTE_MCP_OIDC_CONFIG_URL"
 
-# Headless JWT verifier. Each defaults to the Airbyte Cloud realm below, so a
-# self-hosted deployment overrides only the field(s) pointing at its own realm.
+# Headless JWT verifier. A signing-key source (`JWKS_URI_ENV` or
+# `JWT_PUBLIC_KEY_ENV`) activates it; issuer/audience/algorithm refine it.
 JWKS_URI_ENV = "AIRBYTE_MCP_AUTH_JWKS_URI"
 JWT_PUBLIC_KEY_ENV = "AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY"
 JWT_ISSUER_ENV = "AIRBYTE_MCP_AUTH_ISSUER"
@@ -149,20 +152,6 @@ JWT_ALGORITHM_ENV = "AIRBYTE_MCP_AUTH_ALGORITHM"
 # interactive `OIDCProxy`'s OAuth state. The concrete backend (and its infra
 # config) lives in the deployment's own package, keeping PyAirbyte generic.
 OIDC_CLIENT_STORAGE_FACTORY_ENV = "AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY"
-
-# Airbyte Cloud's application-client realm (non-secret, publicly discoverable).
-# Tokens minted from an Airbyte Cloud `client_id`/`client_secret` via
-# `<api_root>/applications/token` are RS256 JWTs issued by this realm, and the
-# same token is a valid Airbyte Cloud API bearer — so verifying against this
-# realm by default lets one token both authenticate transport and authorize
-# downstream Cloud calls.
-AIRBYTE_CLOUD_OIDC_CONFIG_URL = (
-    "https://cloud.airbyte.com/auth/realms/airbyte/.well-known/openid-configuration"
-)
-AIRBYTE_CLOUD_ISSUER = "https://cloud.airbyte.com/auth/realms/_airbyte-application-clients"
-AIRBYTE_CLOUD_JWKS_URI = f"{AIRBYTE_CLOUD_ISSUER}/protocol/openid-connect/certs"
-AIRBYTE_CLOUD_AUDIENCE = "account"
-AIRBYTE_CLOUD_ALGORITHM = "RS256"
 
 DEFAULT_HTTP_HOST = "0.0.0.0"
 DEFAULT_HTTP_PORT = 8080
@@ -188,27 +177,10 @@ def _env_or_default(name: str, default: str) -> str:
     """Return the stripped value of env var `name`, or `default` when blank/unset.
 
     Blank and whitespace-only values are treated as unset so an empty deployment
-    override falls back to the Airbyte Cloud realm default rather than an empty
-    string.
+    override falls back to `default` rather than an empty string.
     """
     value = os.getenv(name, "").strip()
     return value or default
-
-
-def _resolve_signing_key() -> tuple[str, str]:
-    """Resolve the headless JWT verifier's signing-key source.
-
-    Returns the `(jwks_uri, public_key)` pair. A deployment may set either env
-    var to point at its own realm; the Airbyte Cloud JWKS default applies only
-    when *neither* is set, so a self-hosted static public key isn't shadowed by
-    a leftover Cloud JWKS URI. Blank or whitespace-only values are treated as
-    unset, and an unset member is returned as the empty string.
-    """
-    jwks_uri = os.getenv(JWKS_URI_ENV, "").strip()
-    public_key = os.getenv(JWT_PUBLIC_KEY_ENV, "").strip()
-    if not jwks_uri and not public_key:
-        jwks_uri = AIRBYTE_CLOUD_JWKS_URI
-    return jwks_uri, public_key
 
 
 def _resolve_client_storage(*, encryption_source_material: str) -> AsyncKeyValue | None:
@@ -243,36 +215,53 @@ def _resolve_client_storage(*, encryption_source_material: str) -> AsyncKeyValue
 
 
 def _create_auth() -> AuthProvider | None:
-    """Assemble the transport auth provider, defaulting to Airbyte Cloud.
+    """Assemble the transport auth provider from this server's env configuration.
 
-    Reads this server's branded `AIRBYTE_MCP_*` env vars (falling back to
-    Airbyte Cloud's public realm defaults), maps them into the typed
-    `JWTAuthConfig` / `OIDCAuthConfig` objects that
-    `fastmcp_extensions.build_mcp_auth` consumes, and lets it wire up a headless
+    Reads this server's branded `AIRBYTE_MCP_*` env vars and maps them into the
+    typed `JWTAuthConfig` / `OIDCAuthConfig` objects that
+    `fastmcp_extensions.build_mcp_auth` consumes, which wires up a headless
     `JWTVerifier` and/or an interactive `OIDCProxy`, combined via `MultiAuth`.
-    Because a JWKS default is always present, HTTP transport always verifies
-    bearer tokens against Airbyte Cloud's application-client realm; the
-    interactive path additionally activates once the OIDC client credentials are
-    supplied. The `stdio` transport ignores the provider entirely.
+    The headless verifier activates once a signing-key source
+    (`AIRBYTE_MCP_AUTH_JWKS_URI` or `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`) is
+    configured; the interactive path activates once the OIDC client credentials
+    are supplied. Returns `None` when neither is configured, so the server falls
+    back to unauthenticated local behavior. The `stdio` transport ignores the
+    provider entirely.
+
+    This server declares only the env var *names*; the concrete values (e.g. a
+    deployment's realm endpoints, issuer, audience, and discovery URL) are
+    supplied at deploy time by the deployment's own repo, keeping
+    infrastructure configuration out of this generic library.
     """
     base_url = _env_or_default(MCP_SERVER_URL_ENV, DEFAULT_MCP_SERVER_URL)
 
-    jwks_uri, public_key = _resolve_signing_key()
-    jwt = JWTAuthConfig(
-        jwks_uri=jwks_uri or None,
-        public_key=public_key or None,
-        issuer=_env_or_default(JWT_ISSUER_ENV, AIRBYTE_CLOUD_ISSUER),
-        audience=_env_or_default(JWT_AUDIENCE_ENV, AIRBYTE_CLOUD_AUDIENCE),
-        algorithm=_env_or_default(JWT_ALGORITHM_ENV, AIRBYTE_CLOUD_ALGORITHM),
-        base_url=base_url,
-    )
+    jwt: JWTAuthConfig | None = None
+    jwks_uri = os.getenv(JWKS_URI_ENV, "").strip()
+    public_key = os.getenv(JWT_PUBLIC_KEY_ENV, "").strip()
+    if jwks_uri or public_key:
+        jwt = JWTAuthConfig(
+            jwks_uri=jwks_uri or None,
+            public_key=public_key or None,
+            issuer=os.getenv(JWT_ISSUER_ENV, "").strip() or None,
+            audience=os.getenv(JWT_AUDIENCE_ENV, "").strip() or None,
+            algorithm=os.getenv(JWT_ALGORITHM_ENV, "").strip() or None,
+            base_url=base_url,
+        )
 
     oidc: OIDCAuthConfig | None = None
     oidc_client_id = os.getenv(OIDC_CLIENT_ID_ENV, "").strip()
     oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "").strip()
     if oidc_client_id and oidc_client_secret:
+        config_url = os.getenv(OIDC_CONFIG_URL_ENV, "").strip()
+        if not config_url:
+            msg = (
+                f"{OIDC_CLIENT_ID_ENV} and {OIDC_CLIENT_SECRET_ENV} are set but "
+                f"{OIDC_CONFIG_URL_ENV} is not; the interactive OIDC path needs "
+                "an OpenID Connect discovery URL."
+            )
+            raise ValueError(msg)
         oidc = OIDCAuthConfig(
-            config_url=_env_or_default(OIDC_CONFIG_URL_ENV, AIRBYTE_CLOUD_OIDC_CONFIG_URL),
+            config_url=config_url,
             client_id=oidc_client_id,
             client_secret=oidc_client_secret,
             base_url=base_url,

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -253,6 +253,17 @@ def _create_auth() -> AuthProvider | None:
     oidc: OIDCAuthConfig | None = None
     oidc_client_id = os.getenv(OIDC_CLIENT_ID_ENV, "").strip()
     oidc_client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV, "").strip()
+    if bool(oidc_client_id) != bool(oidc_client_secret):
+        present, missing = (
+            (OIDC_CLIENT_ID_ENV, OIDC_CLIENT_SECRET_ENV)
+            if oidc_client_id
+            else (OIDC_CLIENT_SECRET_ENV, OIDC_CLIENT_ID_ENV)
+        )
+        msg = (
+            f"{present} is set but {missing} is not; the interactive OIDC path "
+            "needs both client credentials. Set both, or neither."
+        )
+        raise ValueError(msg)
     if oidc_client_id and oidc_client_secret:
         config_url = os.getenv(OIDC_CONFIG_URL_ENV, "").strip()
         if not config_url:

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -6,35 +6,37 @@ Supports two transport modes:
 - **stdio** (default): For local MCP clients (Claude Desktop, etc.). Auth is not
   enforced; the provider assembled below is ignored by the stdio transport.
 - **HTTP**: For hosted deployment. Start via `airbyte-mcp-http` entry point or
-  `poe mcp-serve-http`. HTTP transport is **always authenticated**, defaulting
-  to Airbyte Cloud with zero auth config. This server maps its own branded
-  `AIRBYTE_MCP_*` env vars into the typed configs that
-  `fastmcp_extensions.build_mcp_auth` consumes, which supports two client shapes
-  on the same deployment:
+  `poe mcp-serve-http`. This server maps its own branded `AIRBYTE_MCP_*` env vars
+  into the typed configs that `fastmcp_extensions.build_mcp_auth` consumes, which
+  supports two client shapes on the same deployment:
     - **Interactive** (humans in a browser): Keycloak Authorization Code + PKCE
-      via `OIDCProxy`, active once `AIRBYTE_MCP_OIDC_CLIENT_ID` and
-      `AIRBYTE_MCP_OIDC_CLIENT_SECRET` are supplied (the OIDC discovery URL
-      defaults to Airbyte Cloud).
+      via `OIDCProxy`, active once `AIRBYTE_MCP_OIDC_CLIENT_ID`,
+      `AIRBYTE_MCP_OIDC_CLIENT_SECRET`, and `AIRBYTE_MCP_OIDC_CONFIG_URL` (the
+      OIDC discovery URL) are supplied.
     - **Headless** (agents, CI): the client mints its own short-lived bearer
       token via the OAuth 2.0 client credentials grant and sends it as
       `Authorization: Bearer <token>`. The server verifies it with a
-      `JWTVerifier` against Airbyte Cloud's application-client realm by default
-      (no browser, no stored/rotating refresh token).
-  When both are active they are combined via `MultiAuth`.
+      `JWTVerifier`, active once a signing-key source (`AIRBYTE_MCP_AUTH_JWKS_URI`
+      or `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`) is configured (no browser, no
+      stored/rotating refresh token).
+  When both are active they are combined via `MultiAuth`; when neither is
+  configured `_create_auth` returns `None` and HTTP transport runs
+  unauthenticated (a startup warning is logged in `http_main`).
 
-This module owns the Airbyte Cloud realm defaults (non-secret, publicly
-discoverable) and maps its branded `AIRBYTE_MCP_OIDC_*` / `AIRBYTE_MCP_AUTH_*`
-env vars into the typed `OIDCAuthConfig` / `JWTAuthConfig` objects that
-`build_mcp_auth` consumes, so the extensions library stays provider-neutral and
-reads no env itself. A self-hosted deployment pointing at its own Airbyte
-instance overrides any default via the matching env var.
+This module declares only the env var *names* and maps their values into the
+typed `OIDCAuthConfig` / `JWTAuthConfig` objects that `build_mcp_auth` consumes,
+so the extensions library stays provider-neutral and reads no env itself. It
+embeds no provider-specific configuration *values* (a realm's discovery URL,
+issuer, JWKS URI, audience, algorithm, etc.); those are supplied at deploy time
+by the deployment's own repo — e.g. the hosted Cloud MCP image in
+`airbyte-ops-mcp` sets the `AIRBYTE_MCP_*` env for the Airbyte Cloud realm.
 
-An agent mints an Airbyte Cloud access token from its `AIRBYTE_CLOUD_CLIENT_ID` /
-`AIRBYTE_CLOUD_CLIENT_SECRET` (the `<api_root>/applications/token` endpoint) and
-sends it as `Authorization: Bearer`. That single token both authenticates
-transport (verified here) and authorizes downstream Cloud API calls (the same
-header feeds the Cloud bearer token), because an Airbyte-Cloud-issued JWT is
-itself a valid Cloud API bearer.
+For the headless path, an agent mints an access token from its client id/secret
+(via the deployment's `<api_root>/applications/token` endpoint) and sends it as
+`Authorization: Bearer`. When the deployment's realm is Airbyte Cloud, that
+single token both authenticates transport (verified here) and authorizes
+downstream Cloud API calls, because an Airbyte-Cloud-issued JWT is itself a valid
+Cloud API bearer.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.10.0,<1.0.0",
+    # 0.14.0 stripped the library's env-var mapping (`resolve_mcp_auth`), so this
+    # package now owns its `AIRBYTE_MCP_*` env names and maps them into the typed
+    # `build_mcp_auth` API (with `OIDCAuthConfig.client_storage` injection).
+    "fastmcp-extensions>=0.14.0,<1.0.0",
     "starlette",
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -198,13 +198,20 @@ def test_create_auth_oidc_without_config_url_raises(monkeypatch: MonkeyPatch) ->
         server._create_auth()
 
 
-def test_create_auth_no_oidc_without_secret(monkeypatch: MonkeyPatch) -> None:
-    """A client id alone (no secret) does not activate the interactive path."""
+def test_create_auth_partial_oidc_id_only_raises(monkeypatch: MonkeyPatch) -> None:
+    """A client id alone (no secret) fails closed rather than starting unauthenticated."""
     _clear_all_auth_env(monkeypatch)
     monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
-    captured = _capture_build_mcp_auth(monkeypatch)
-    server._create_auth()
-    assert captured["oidc"] is None
+    with pytest.raises(ValueError, match=server.OIDC_CLIENT_SECRET_ENV):
+        server._create_auth()
+
+
+def test_create_auth_partial_oidc_secret_only_raises(monkeypatch: MonkeyPatch) -> None:
+    """A client secret alone (no id) fails closed rather than starting unauthenticated."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    with pytest.raises(ValueError, match=server.OIDC_CLIENT_ID_ENV):
+        server._create_auth()
 
 
 def test_resolve_client_storage_returns_none_when_unset(

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -220,6 +220,23 @@ def test_resolve_client_storage_imports_and_calls_factory(
     assert _STORAGE_FACTORY_CALLS == ["the-secret"]
 
 
+@pytest.mark.parametrize(
+    "factory_spec",
+    [
+        pytest.param("not-a-valid-reference", id="malformed_reference"),
+        pytest.param(f"{__name__}:_does_not_exist", id="missing_symbol"),
+    ],
+)
+def test_resolve_client_storage_raises_clear_error_on_bad_factory(
+    monkeypatch: MonkeyPatch,
+    factory_spec: str,
+) -> None:
+    """A malformed/unresolvable factory reference fails with the env var named."""
+    monkeypatch.setenv(server.OIDC_CLIENT_STORAGE_FACTORY_ENV, factory_spec)
+    with pytest.raises(ValueError, match=server.OIDC_CLIENT_STORAGE_FACTORY_ENV):
+        server._resolve_client_storage(encryption_source_material="s")
+
+
 def test_create_auth_injects_resolved_storage_on_oidc(monkeypatch: MonkeyPatch) -> None:
     """The resolved storage object is passed through to `OIDCAuthConfig.client_storage`."""
     _STORAGE_FACTORY_CALLS.clear()

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for branded transport-auth resolution in `airbyte.mcp.server`.
+
+These cover what this server owns: mapping its branded `AIRBYTE_MCP_*` env vars
+into the typed `JWTAuthConfig` / `OIDCAuthConfig` objects it hands to
+`fastmcp_extensions.build_mcp_auth`, the Airbyte Cloud realm defaults,
+blank-as-unset handling, the signing-key precedence, and the durable-storage
+factory injection on the interactive path. The generic verifier assembly lives
+in `fastmcp-extensions` and is tested there.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp_extensions import JWTAuthConfig, OIDCAuthConfig
+
+from airbyte.mcp import server
+
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+_ALL_AUTH_ENV = (
+    server.MCP_SERVER_URL_ENV,
+    server.OIDC_CLIENT_ID_ENV,
+    server.OIDC_CLIENT_SECRET_ENV,
+    server.OIDC_CONFIG_URL_ENV,
+    server.OIDC_CLIENT_STORAGE_FACTORY_ENV,
+    server.JWKS_URI_ENV,
+    server.JWT_PUBLIC_KEY_ENV,
+    server.JWT_ISSUER_ENV,
+    server.JWT_AUDIENCE_ENV,
+    server.JWT_ALGORITHM_ENV,
+)
+
+
+def _clear_all_auth_env(monkeypatch: MonkeyPatch) -> None:
+    for name in _ALL_AUTH_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _capture_build_mcp_auth(monkeypatch: MonkeyPatch) -> dict[str, Any]:
+    """Patch `build_mcp_auth` with a spy and return the dict it records into."""
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> None:
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(server, "build_mcp_auth", _capture)
+    return captured
+
+
+def test_auth_env_names_are_branded() -> None:
+    """The transport-auth env vars all use this server's `AIRBYTE_MCP_*` namespace."""
+    assert server.OIDC_CLIENT_ID_ENV == "AIRBYTE_MCP_OIDC_CLIENT_ID"
+    assert server.OIDC_CLIENT_SECRET_ENV == "AIRBYTE_MCP_OIDC_CLIENT_SECRET"
+    assert server.OIDC_CONFIG_URL_ENV == "AIRBYTE_MCP_OIDC_CONFIG_URL"
+    assert (
+        server.OIDC_CLIENT_STORAGE_FACTORY_ENV
+        == "AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY"
+    )
+    assert server.JWKS_URI_ENV == "AIRBYTE_MCP_AUTH_JWKS_URI"
+    assert server.JWT_PUBLIC_KEY_ENV == "AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY"
+    assert server.JWT_ISSUER_ENV == "AIRBYTE_MCP_AUTH_ISSUER"
+    assert server.JWT_AUDIENCE_ENV == "AIRBYTE_MCP_AUTH_AUDIENCE"
+    assert server.JWT_ALGORITHM_ENV == "AIRBYTE_MCP_AUTH_ALGORITHM"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param(None, "fallback", id="unset"),
+        pytest.param("", "fallback", id="empty"),
+        pytest.param("   ", "fallback", id="spaces"),
+        pytest.param("\t", "fallback", id="tab"),
+        pytest.param("  actual  ", "actual", id="strips-and-returns"),
+    ],
+)
+def test_env_or_default(
+    value: str | None,
+    expected: str,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Blank/unset values fall back to the default; real values are stripped.
+
+    The default (`"fallback"`) is deliberately distinct from the stripped value
+    (`"actual"`), so the `strips-and-returns` case fails if the env value is
+    ignored and the default is returned instead.
+    """
+    if value is None:
+        monkeypatch.delenv("SOME_VAR", raising=False)
+    else:
+        monkeypatch.setenv("SOME_VAR", value)
+    assert server._env_or_default("SOME_VAR", "fallback") == expected
+
+
+def test_resolve_signing_key_defaults_to_cloud_jwks(monkeypatch: MonkeyPatch) -> None:
+    """With neither var set, the headless verifier defaults to Airbyte Cloud's JWKS."""
+    monkeypatch.delenv(server.JWKS_URI_ENV, raising=False)
+    monkeypatch.delenv(server.JWT_PUBLIC_KEY_ENV, raising=False)
+    jwks_uri, public_key = server._resolve_signing_key()
+    assert jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
+    assert public_key == ""
+
+
+def test_resolve_signing_key_blank_values_fall_back_to_cloud(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Blank/whitespace overrides are treated as unset and fall back to Cloud."""
+    monkeypatch.setenv(server.JWKS_URI_ENV, "   ")
+    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "  ")
+    jwks_uri, public_key = server._resolve_signing_key()
+    assert jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
+    assert public_key == ""
+
+
+def test_resolve_signing_key_honors_explicit_jwks(monkeypatch: MonkeyPatch) -> None:
+    """An explicit self-hosted JWKS URI is used instead of the Cloud default."""
+    monkeypatch.setenv(server.JWKS_URI_ENV, "https://self-hosted/jwks")
+    monkeypatch.delenv(server.JWT_PUBLIC_KEY_ENV, raising=False)
+    jwks_uri, _public_key = server._resolve_signing_key()
+    assert jwks_uri == "https://self-hosted/jwks"
+
+
+def test_resolve_signing_key_static_key_not_shadowed_by_cloud_jwks(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A static public key must not be shadowed by the injected Cloud JWKS default."""
+    monkeypatch.delenv(server.JWKS_URI_ENV, raising=False)
+    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "-----BEGIN PUBLIC KEY-----")
+    jwks_uri, public_key = server._resolve_signing_key()
+    assert jwks_uri == ""
+    assert public_key == "-----BEGIN PUBLIC KEY-----"
+
+
+def test_create_auth_defaults_to_bearer_verification(monkeypatch: MonkeyPatch) -> None:
+    """With zero auth env, HTTP transport still verifies bearer tokens (no OIDC)."""
+    _clear_all_auth_env(monkeypatch)
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+
+    assert captured["oidc"] is None
+    jwt = captured["jwt"]
+    assert isinstance(jwt, JWTAuthConfig)
+    assert jwt.jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
+    assert jwt.issuer == server.AIRBYTE_CLOUD_ISSUER
+    assert jwt.audience == server.AIRBYTE_CLOUD_AUDIENCE
+    assert jwt.algorithm == server.AIRBYTE_CLOUD_ALGORITHM
+
+
+def test_create_auth_returns_a_verifier_by_default(monkeypatch: MonkeyPatch) -> None:
+    """The real `build_mcp_auth` yields a bearer-token verifier from the defaults."""
+    _clear_all_auth_env(monkeypatch)
+    auth = server._create_auth()
+    assert isinstance(auth, JWTVerifier)
+
+
+def test_create_auth_activates_oidc_when_credentials_present(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """OIDC client id + secret activate the interactive path with Cloud defaults."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
+    monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+
+    oidc = captured["oidc"]
+    assert isinstance(oidc, OIDCAuthConfig)
+    assert oidc.client_id == "cid"
+    assert oidc.client_secret == "csecret"
+    assert oidc.config_url == server.AIRBYTE_CLOUD_OIDC_CONFIG_URL
+    # No storage factory configured -> in-memory default.
+    assert oidc.client_storage is None
+
+
+def test_create_auth_no_oidc_without_secret(monkeypatch: MonkeyPatch) -> None:
+    """A client id alone (no secret) does not activate the interactive path."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+    assert captured["oidc"] is None
+
+
+def test_resolve_client_storage_returns_none_when_unset(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No factory env var means the interactive proxy keeps its in-memory default."""
+    monkeypatch.delenv(server.OIDC_CLIENT_STORAGE_FACTORY_ENV, raising=False)
+    assert server._resolve_client_storage(encryption_source_material="s") is None
+
+
+_STORAGE_FACTORY_CALLS: list[str] = []
+_SENTINEL_STORE = object()
+
+
+def _fake_store_factory(*, encryption_source_material: str) -> object:
+    """Test factory recording its `encryption_source_material` and returning a sentinel."""
+    _STORAGE_FACTORY_CALLS.append(encryption_source_material)
+    return _SENTINEL_STORE
+
+
+def test_resolve_client_storage_imports_and_calls_factory(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The factory env var is resolved to a callable and invoked with the secret."""
+    _STORAGE_FACTORY_CALLS.clear()
+    monkeypatch.setenv(
+        server.OIDC_CLIENT_STORAGE_FACTORY_ENV,
+        f"{__name__}:_fake_store_factory",
+    )
+    store = server._resolve_client_storage(encryption_source_material="the-secret")
+    assert store is _SENTINEL_STORE
+    assert _STORAGE_FACTORY_CALLS == ["the-secret"]
+
+
+def test_create_auth_injects_resolved_storage_on_oidc(monkeypatch: MonkeyPatch) -> None:
+    """The resolved storage object is passed through to `OIDCAuthConfig.client_storage`."""
+    _STORAGE_FACTORY_CALLS.clear()
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
+    monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    monkeypatch.setenv(
+        server.OIDC_CLIENT_STORAGE_FACTORY_ENV,
+        f"{__name__}:_fake_store_factory",
+    )
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+
+    oidc = captured["oidc"]
+    assert isinstance(oidc, OIDCAuthConfig)
+    assert oidc.client_storage is _SENTINEL_STORE
+    # The OIDC client secret is the encryption source material.
+    assert _STORAGE_FACTORY_CALLS == ["csecret"]

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -3,10 +3,12 @@
 
 These cover what this server owns: mapping its branded `AIRBYTE_MCP_*` env vars
 into the typed `JWTAuthConfig` / `OIDCAuthConfig` objects it hands to
-`fastmcp_extensions.build_mcp_auth`, the Airbyte Cloud realm defaults,
-blank-as-unset handling, the signing-key precedence, and the durable-storage
-factory injection on the interactive path. The generic verifier assembly lives
-in `fastmcp-extensions` and is tested there.
+`fastmcp_extensions.build_mcp_auth`, activation of the headless and interactive
+paths from env, blank-as-unset handling, and the durable-storage factory
+injection on the interactive path. This server declares only env var names and
+maps their values — it embeds no provider-specific configuration values; those
+are supplied at deploy time by the deployment's own repo. The generic verifier
+assembly lives in `fastmcp-extensions` and is tested there.
 """
 
 from __future__ import annotations
@@ -99,74 +101,82 @@ def test_env_or_default(
     assert server._env_or_default("SOME_VAR", "fallback") == expected
 
 
-def test_resolve_signing_key_defaults_to_cloud_jwks(monkeypatch: MonkeyPatch) -> None:
-    """With neither var set, the headless verifier defaults to Airbyte Cloud's JWKS."""
-    monkeypatch.delenv(server.JWKS_URI_ENV, raising=False)
-    monkeypatch.delenv(server.JWT_PUBLIC_KEY_ENV, raising=False)
-    jwks_uri, public_key = server._resolve_signing_key()
-    assert jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
-    assert public_key == ""
-
-
-def test_resolve_signing_key_blank_values_fall_back_to_cloud(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """Blank/whitespace overrides are treated as unset and fall back to Cloud."""
-    monkeypatch.setenv(server.JWKS_URI_ENV, "   ")
-    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "  ")
-    jwks_uri, public_key = server._resolve_signing_key()
-    assert jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
-    assert public_key == ""
-
-
-def test_resolve_signing_key_honors_explicit_jwks(monkeypatch: MonkeyPatch) -> None:
-    """An explicit self-hosted JWKS URI is used instead of the Cloud default."""
-    monkeypatch.setenv(server.JWKS_URI_ENV, "https://self-hosted/jwks")
-    monkeypatch.delenv(server.JWT_PUBLIC_KEY_ENV, raising=False)
-    jwks_uri, _public_key = server._resolve_signing_key()
-    assert jwks_uri == "https://self-hosted/jwks"
-
-
-def test_resolve_signing_key_static_key_not_shadowed_by_cloud_jwks(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """A static public key must not be shadowed by the injected Cloud JWKS default."""
-    monkeypatch.delenv(server.JWKS_URI_ENV, raising=False)
-    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "-----BEGIN PUBLIC KEY-----")
-    jwks_uri, public_key = server._resolve_signing_key()
-    assert jwks_uri == ""
-    assert public_key == "-----BEGIN PUBLIC KEY-----"
-
-
-def test_create_auth_defaults_to_bearer_verification(monkeypatch: MonkeyPatch) -> None:
-    """With zero auth env, HTTP transport still verifies bearer tokens (no OIDC)."""
+def test_create_auth_no_env_yields_no_provider(monkeypatch: MonkeyPatch) -> None:
+    """With zero auth env, neither path is configured (no embedded defaults)."""
     _clear_all_auth_env(monkeypatch)
     captured = _capture_build_mcp_auth(monkeypatch)
     server._create_auth()
 
     assert captured["oidc"] is None
+    assert captured["jwt"] is None
+
+
+def test_create_auth_no_env_returns_none(monkeypatch: MonkeyPatch) -> None:
+    """The real `build_mcp_auth` yields no provider when nothing is configured."""
+    _clear_all_auth_env(monkeypatch)
+    assert server._create_auth() is None
+
+
+def test_create_auth_maps_jwt_env_when_jwks_set(monkeypatch: MonkeyPatch) -> None:
+    """A JWKS URI activates the headless verifier; issuer/audience/algorithm map through."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.JWKS_URI_ENV, "https://idp.example/jwks")
+    monkeypatch.setenv(server.JWT_ISSUER_ENV, "https://idp.example/")
+    monkeypatch.setenv(server.JWT_AUDIENCE_ENV, "mcp-api")
+    monkeypatch.setenv(server.JWT_ALGORITHM_ENV, "RS256")
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+
     jwt = captured["jwt"]
     assert isinstance(jwt, JWTAuthConfig)
-    assert jwt.jwks_uri == server.AIRBYTE_CLOUD_JWKS_URI
-    assert jwt.issuer == server.AIRBYTE_CLOUD_ISSUER
-    assert jwt.audience == server.AIRBYTE_CLOUD_AUDIENCE
-    assert jwt.algorithm == server.AIRBYTE_CLOUD_ALGORITHM
+    assert jwt.jwks_uri == "https://idp.example/jwks"
+    assert jwt.public_key is None
+    assert jwt.issuer == "https://idp.example/"
+    assert jwt.audience == "mcp-api"
+    assert jwt.algorithm == "RS256"
 
 
-def test_create_auth_returns_a_verifier_by_default(monkeypatch: MonkeyPatch) -> None:
-    """The real `build_mcp_auth` yields a bearer-token verifier from the defaults."""
+def test_create_auth_activates_jwt_with_static_public_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A static public key activates the verifier without a JWKS URI."""
     _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "-----BEGIN PUBLIC KEY-----")
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+
+    jwt = captured["jwt"]
+    assert isinstance(jwt, JWTAuthConfig)
+    assert jwt.jwks_uri is None
+    assert jwt.public_key == "-----BEGIN PUBLIC KEY-----"
+
+
+def test_create_auth_returns_verifier_when_jwks_set(monkeypatch: MonkeyPatch) -> None:
+    """The real `build_mcp_auth` yields a bearer-token verifier when a JWKS URI is set."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.JWKS_URI_ENV, "https://idp.example/jwks")
     auth = server._create_auth()
     assert isinstance(auth, JWTVerifier)
+
+
+def test_create_auth_blank_jwt_env_yields_no_verifier(monkeypatch: MonkeyPatch) -> None:
+    """Blank/whitespace signing-key vars are treated as unset (no verifier)."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.JWKS_URI_ENV, "   ")
+    monkeypatch.setenv(server.JWT_PUBLIC_KEY_ENV, "  ")
+    captured = _capture_build_mcp_auth(monkeypatch)
+    server._create_auth()
+    assert captured["jwt"] is None
 
 
 def test_create_auth_activates_oidc_when_credentials_present(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """OIDC client id + secret activate the interactive path with Cloud defaults."""
+    """OIDC client id + secret + discovery URL activate the interactive path."""
     _clear_all_auth_env(monkeypatch)
     monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
     monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    monkeypatch.setenv(server.OIDC_CONFIG_URL_ENV, "https://idp.example/.well-known")
     captured = _capture_build_mcp_auth(monkeypatch)
     server._create_auth()
 
@@ -174,9 +184,18 @@ def test_create_auth_activates_oidc_when_credentials_present(
     assert isinstance(oidc, OIDCAuthConfig)
     assert oidc.client_id == "cid"
     assert oidc.client_secret == "csecret"
-    assert oidc.config_url == server.AIRBYTE_CLOUD_OIDC_CONFIG_URL
+    assert oidc.config_url == "https://idp.example/.well-known"
     # No storage factory configured -> in-memory default.
     assert oidc.client_storage is None
+
+
+def test_create_auth_oidc_without_config_url_raises(monkeypatch: MonkeyPatch) -> None:
+    """OIDC credentials without a discovery URL fail clearly, naming the env var."""
+    _clear_all_auth_env(monkeypatch)
+    monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
+    monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    with pytest.raises(ValueError, match=server.OIDC_CONFIG_URL_ENV):
+        server._create_auth()
 
 
 def test_create_auth_no_oidc_without_secret(monkeypatch: MonkeyPatch) -> None:
@@ -243,6 +262,7 @@ def test_create_auth_injects_resolved_storage_on_oidc(monkeypatch: MonkeyPatch) 
     _clear_all_auth_env(monkeypatch)
     monkeypatch.setenv(server.OIDC_CLIENT_ID_ENV, "cid")
     monkeypatch.setenv(server.OIDC_CLIENT_SECRET_ENV, "csecret")
+    monkeypatch.setenv(server.OIDC_CONFIG_URL_ENV, "https://idp.example/.well-known")
     monkeypatch.setenv(
         server.OIDC_CLIENT_STORAGE_FACTORY_ENV,
         f"{__name__}:_fake_store_factory",

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
     { name = "fastmcp", specifier = ">=3.0,<4.0" },
-    { name = "fastmcp-extensions", specifier = ">=0.10.0,<1.0.0" },
+    { name = "fastmcp-extensions", specifier = ">=0.14.0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.27.0,<3.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.12.0,<4.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0,<3.0" },
@@ -1129,20 +1129,21 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.10.3"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "py-key-value-aio" },
     { name = "segment-analytics-python" },
     { name = "sentry-sdk" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/90/8198eef9c4d8429fb76f00dbe9bb3b9a097bbfcb9adf7c41f4f26223e8a2/fastmcp_extensions-0.10.3.tar.gz", hash = "sha256:dc40edd91e52ca59d252f25c767f76654de34d2a1793aa3e756cbb76e0d9adba", size = 201916, upload-time = "2026-07-21T00:49:04.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/de/f148a60bae3f7f0f31ff57f821d253e690a0e53fc4caad9f52aa01c8699c/fastmcp_extensions-0.14.0.tar.gz", hash = "sha256:4773b0d92168d6f64604dd66977010e17aef09e8b8440cf2a18df576d0a02a60", size = 215412, upload-time = "2026-07-24T00:50:16.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/62/4fd614321d5083e94375f07b3388f56f071fd16e25efe37451363c92a411/fastmcp_extensions-0.10.3-py3-none-any.whl", hash = "sha256:2932107823d3d11f73784bd5ab3cd4c7a07181335579017b14554c16e0023cd1", size = 66106, upload-time = "2026-07-21T00:49:02.714Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/35/b2bdc80cc2e3ae26549dfd8ab404440ce287d08b5b157d1da96e66cf06da/fastmcp_extensions-0.14.0-py3-none-any.whl", hash = "sha256:b709062b3eb764b20a40b803c1eccd55d386367933390f196fb6541b0ec6f57d", size = 76398, upload-time = "2026-07-24T00:50:15.212Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`fastmcp-extensions` 0.14.0 removed the library's env-var mapping (`resolve_mcp_auth`), so each MCP server now owns its own env names and hands the library typed config objects. This migrates PyAirbyte's HTTP-transport auth (`airbyte/mcp/server.py`) to the typed `build_mcp_auth` API and rebrands its auth env vars into the `AIRBYTE_MCP_*` namespace (AJ: "read branded env var names — unique domain of env vars is added security layer").

**Names here, values in the deployment.** PyAirbyte declares only the env var *names* and maps their values into typed configs. It embeds **no** provider-specific configuration values — no `cloud.airbyte.com` realm URLs, issuer, JWKS URI, audience, or algorithm. Those concrete values are supplied at deploy time by the deployment's own repo (the hosted Cloud MCP image in `airbyte-ops-mcp`), keeping infra config out of this generic library.

Behavior:
- **Auth activates from env, per path.** The headless `JWTVerifier` activates once a signing-key source (`AIRBYTE_MCP_AUTH_JWKS_URI` or `AIRBYTE_MCP_AUTH_JWT_PUBLIC_KEY`) is set; the interactive `OIDCProxy` activates once `AIRBYTE_MCP_OIDC_CLIENT_ID` + `AIRBYTE_MCP_OIDC_CLIENT_SECRET` are set. With no auth env, `_create_auth()` returns `None` (unauthenticated local behavior).
- **OIDC discovery URL is required, not defaulted.** When the OIDC credentials are set but `AIRBYTE_MCP_OIDC_CONFIG_URL` is not, `_create_auth()` raises a clear `ValueError` naming the missing var rather than falling back to a baked-in realm.
- **Env vars are rebranded** (generic → `AIRBYTE_MCP_*`), and the `MCP_AUTH_AIRBYTE_CLOUD` opt-in toggle is removed. `MCP_SERVER_URL` stays unbranded (it's a deployment URL, not an auth var).

New `_create_auth()` shape:

```python
base_url = _env_or_default(MCP_SERVER_URL_ENV, DEFAULT_MCP_SERVER_URL)

jwt = None
jwks_uri = env(JWKS_URI_ENV); public_key = env(JWT_PUBLIC_KEY_ENV)
if jwks_uri or public_key:                       # verifier activates only when configured
    jwt = JWTAuthConfig(jwks_uri=..., public_key=..., issuer=env(...), audience=env(...), algorithm=env(...), base_url=...)

oidc = None
if oidc_client_id and oidc_client_secret:
    config_url = env(OIDC_CONFIG_URL_ENV)
    if not config_url:
        raise ValueError(f"{OIDC_CLIENT_ID_ENV} and {OIDC_CLIENT_SECRET_ENV} are set but {OIDC_CONFIG_URL_ENV} is not; ...")
    oidc = OIDCAuthConfig(config_url=config_url, ..., client_storage=_resolve_client_storage(...))

return build_mcp_auth(oidc=oidc, jwt=jwt, base_url=base_url)   # -> None when both are None
```

**PyAirbyte stays backend-agnostic.** Durable OAuth-state storage for the interactive `OIDCProxy` is injected via a PyAirbyte-owned factory hook rather than any concrete store:

```python
# AIRBYTE_MCP_OIDC_CLIENT_STORAGE_FACTORY="package.module:callable"
factory = pkgutil.resolve_name(spec)                              # imported only if the var is set
store = factory(encryption_source_material=oidc_client_secret)    # -> AsyncKeyValue | None
OIDCAuthConfig(..., client_storage=store)
```

The concrete Firestore/Fernet factory (and its infra config) ships in the deployment's own package — the hosted Cloud MCP image in `airbyte-ops-mcp` — keeping PyAirbyte free of infra-specific params.

Docs in `airbyte/mcp/__init__.py` and `airbyte/mcp/http_main.py` updated to the branded names and the "names here, values at deploy time" model. Bumps `fastmcp-extensions` to `>=0.14.0`. Adds `tests/unit_tests/test_mcp_auth.py` covering the branded names, blank-as-unset handling, per-path activation, JWT/OIDC env mapping, the missing-discovery-URL error, and storage-factory resolution/injection.

Requested by AJ Steers.


Link to Devin session: https://app.devin.ai/sessions/a5b9501ef92c412aad0408b7c74ef9c8
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added branded `AIRBYTE_MCP_*` settings for interactive OIDC and headless bearer-token (JWT) verification, including optional durable OIDC client-state storage.
  - Enabled HTTP transport authentication based on configured `AIRBYTE_MCP_*` values, while stdio remains unauthenticated.

- **Documentation**
  - Updated MCP auth documentation to use the new `AIRBYTE_MCP_*` namespace and clarified blank-as-unset fallback to unauthenticated local behavior when unset.
  - Clarified HTTP server URL and auth redirect behavior consistency.

- **Tests**
  - Added/updated unit tests for env-var handling, JWT/OIDC activation rules, and durable storage resolution/error cases.

- **Chores**
  - Updated the `fastmcp-extensions` dependency constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->