### PR TITLE
ci: bump semantic-pr-release-drafter to v2.3.1 to unblock release draft finalize

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create draft release (not ready)
-        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.3.1
         id: not-ready-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         run: UV_DYNAMIC_VERSIONING_BYPASS="${VERSION#v}" uv build
 
       - name: Attach assets and finalize draft
-        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

The **Release Drafter** workflow on `main` has been failing, leaving the `v0.53.0` draft stuck (unpublishable). The `Draft Release` job fails at *Attach assets and finalize draft* with a hard error:

```
prepared-release-id targets an already-prepared release as the source of truth, so the
following input(s) are incompatible and must not be set alongside it: allow-major-bumps.
Remove them; their values are taken from the prepared release.
```

Root cause: the workflow pins `aaronsteers/semantic-pr-release-drafter@v2.2.0`. In `v2.2.0` the finalize step (`prepared-release-id`) *rejects* `allow-major-bumps`, but that input has a non-empty default in the action, so it is always "set" — making the two-step (`not-ready` → finalize) path fail on every run.

Fixed upstream by [semantic-pr-release-drafter#59](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/59) — *"ignore-with-warning `prepared-release-id` inputs instead of failing"* — released in `v2.3.1` (`v2.2.0...v2.3.1` = banner-URL change #58 + the #59 fix). The updated `action.yml` documents these inputs as ignored no-ops (with a warning) on the finalize path.

## Change

Bump both `uses:` pins in `.github/workflows/release_drafter.yml`:

```diff
-        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.3.1
```

No workflow logic change — this only unblocks the finalize step so the drafter can prepare/publish releases again.

Flagged by AJ (stuck release-drafter workflow).

Link to Devin session: https://app.devin.ai/sessions/a5b9501ef92c412aad0408b7c74ef9c8
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to use a newer version of the release-drafting action.
  * Release drafting and artifact publishing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->