### PR TITLE
fix(mcp): advertise slash-less protected-resource at root mount

### DIFF
--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -43,8 +43,10 @@ issuer, audience, and algorithm refine verification when provided:
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from fastmcp.server.auth import MultiAuth
 from fastmcp_extensions import (
     assert_http_trusted_execution_disabled,
     register_landing_page,
@@ -58,6 +60,10 @@ from airbyte.mcp.server import (
     _env_or_default,
     app,
 )
+
+
+if TYPE_CHECKING:
+    from fastmcp.server.auth import AuthProvider
 
 
 logger = logging.getLogger(__name__)
@@ -77,6 +83,37 @@ def _get_server_url() -> str:
     return _env_or_default(MCP_SERVER_URL_ENV, DEFAULT_MCP_SERVER_URL)
 
 
+def _advertise_root_mount_resource(auth: AuthProvider) -> None:
+    """Advertise the slash-less public URL as the RFC 8707 resource at a root mount.
+
+    Behind a path-stripping load balancer the MCP endpoint is mounted at root
+    (`mcp_path="/"`), and FastMCP derives the protected-resource identifier from
+    that mount path — appending a trailing slash (e.g. `.../cloud-mcp/`). Strict
+    RFC 9728 clients canonicalize the connection URL to the slash-less form
+    (`.../cloud-mcp`) and reject the mismatch, so they cannot attach. FastMCP
+    already returns the bare base URL for a *root* mount path (`None`/`""`), so
+    this maps the `"/"` mount path onto that root case, leaving non-root mounts
+    (e.g. the local `"/mcp"` default) untouched.
+
+    Applied to every provider in the tree because the protected-resource
+    metadata document and the `WWW-Authenticate` challenge are built from
+    different providers (the interactive server versus the top-level `MultiAuth`).
+    """
+    original = auth._get_resource_url  # noqa: SLF001  # FastMCP has no public seam for this.
+
+    def resolve_resource_url(path: str | None = None):  # noqa: ANN202
+        normalized = path if path and path != "/" else None
+        return original(normalized)
+
+    auth._get_resource_url = resolve_resource_url  # type: ignore[method-assign]  # noqa: SLF001
+
+    if isinstance(auth, MultiAuth):
+        if auth.server is not None:
+            _advertise_root_mount_resource(auth.server)
+        for verifier in auth.verifiers:
+            _advertise_root_mount_resource(verifier)
+
+
 def main() -> None:
     """Start the Airbyte MCP server with HTTP transport."""
     logging.basicConfig(level=logging.INFO)
@@ -90,6 +127,11 @@ def main() -> None:
     # The advertised endpoint must match where the MCP route is actually mounted:
     # the bare server URL when mounted at root, otherwise the server URL + mcp_path.
     endpoint_url = server_url if mcp_path == "/" else server_url.rstrip("/") + mcp_path
+
+    # At a root mount FastMCP would advertise a trailing-slash resource that
+    # strict RFC 9728 clients reject; pin it to the slash-less public URL.
+    if mcp_path == "/" and app.auth is not None:
+        _advertise_root_mount_resource(app.auth)
 
     # Serve a browser-friendly landing page on GET at the MCP path. In stateless
     # mode FastMCP only binds POST/DELETE there, so this GET route does not

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -84,7 +84,7 @@ def _get_server_url() -> str:
 
 
 def _advertise_root_mount_resource(auth: AuthProvider) -> None:
-    """Advertise the slash-less public URL as the RFC 8707 resource at a root mount.
+    """Advertise the slash-less public URL as the RFC 9728 resource at a root mount.
 
     Behind a path-stripping load balancer the MCP endpoint is mounted at root
     (`mcp_path="/"`), and FastMCP derives the protected-resource identifier from

--- a/tests/unit_tests/test_mcp_http_main.py
+++ b/tests/unit_tests/test_mcp_http_main.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for the HTTP transport entry point in `airbyte.mcp.http_main`.
+
+These cover `_advertise_root_mount_resource`, which normalizes the RFC 9728
+protected-resource identifier when the MCP endpoint is mounted at root behind a
+path-stripping load balancer. Without it FastMCP advertises a trailing-slash
+resource (e.g. `.../cloud-mcp/`) that strict clients reject because they
+canonicalize the connection URL to the slash-less form (`.../cloud-mcp`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.server.auth import MultiAuth
+from fastmcp.server.auth.auth import TokenVerifier
+
+from airbyte.mcp.http_main import _advertise_root_mount_resource
+
+
+_BASE_URL = "https://mcp.internal.airbyte.ai/cloud-mcp"
+
+
+class _FakeProvider(TokenVerifier):
+    """Minimal concrete provider that inherits FastMCP's resource-URL logic."""
+
+    async def verify_token(self, token: str) -> None:
+        """Never authenticates; the resource-URL logic is what is under test."""
+        return None
+
+
+@pytest.mark.parametrize(
+    ("mcp_path", "expected"),
+    [
+        pytest.param("/", _BASE_URL, id="root_mount_drops_trailing_slash"),
+        pytest.param("", _BASE_URL, id="empty_path_is_root"),
+        pytest.param(None, _BASE_URL, id="none_path_is_root"),
+        pytest.param("/mcp", f"{_BASE_URL}/mcp", id="non_root_path_unchanged"),
+    ],
+)
+def test_advertise_root_mount_resource(mcp_path: str | None, expected: str) -> None:
+    """The helper maps a root mount to the slash-less resource, leaving others intact."""
+    provider = _FakeProvider(base_url=_BASE_URL)
+
+    _advertise_root_mount_resource(provider)
+
+    assert str(provider._get_resource_url(mcp_path)) == expected
+
+
+def test_advertise_root_mount_resource_recurses_into_multiauth() -> None:
+    """The fix reaches the interactive server and every headless verifier in the tree."""
+    server = _FakeProvider(base_url=_BASE_URL)
+    verifier = _FakeProvider(base_url=_BASE_URL)
+    multi = MultiAuth(server=server, verifiers=[verifier])
+
+    _advertise_root_mount_resource(multi)
+
+    for provider in (multi, server, verifier):
+        assert str(provider._get_resource_url("/")) == _BASE_URL
+        assert str(provider._get_resource_url("/mcp")) == f"{_BASE_URL}/mcp"

--- a/tests/unit_tests/test_mcp_http_main.py
+++ b/tests/unit_tests/test_mcp_http_main.py
@@ -17,7 +17,7 @@ from fastmcp.server.auth.auth import TokenVerifier
 from airbyte.mcp.http_main import _advertise_root_mount_resource
 
 
-_BASE_URL = "https://mcp.internal.airbyte.ai/cloud-mcp"
+_BASE_URL = "https://mcp.example.com/cloud-mcp"
 
 
 class _FakeProvider(TokenVerifier):


### PR DESCRIPTION
## Summary

Strict RFC 9728 MCP clients can't connect to the hosted MCP servers: they reject the advertised protected-resource because it carries a trailing slash the client doesn't expect.

```
Protected resource https://mcp.internal.airbyte.ai/cloud-mcp/
does not match expected https://mcp.internal.airbyte.ai/cloud-mcp (or origin)
```

Root cause: behind the path-stripping load balancer we mount the MCP endpoint at root (`mcp_path="/"`, see `main()`), and FastMCP derives the RFC 8707 resource id from that mount path — `_get_resource_url("/")` computes `base_url.rstrip("/") + "/" + ""`, i.e. it appends a trailing slash (`.../cloud-mcp/`). The client canonicalizes the connection URL to the slash-less form and rejects the mismatch. (Lenient clients like Goose tolerated it, which is why this only surfaced on strict clients.)

Fix: at a root mount only, normalize the resource computation so `"/"` is treated as the root case (`None`), which FastMCP already resolves to the bare `base_url` (no slash). Non-root mounts (e.g. the local `/mcp` default) are untouched.

```python
# new helper, invoked from main() only when mcp_path == "/"
def _advertise_root_mount_resource(auth):
    original = auth._get_resource_url
    def resolve_resource_url(path=None):
        normalized = path if path and path != "/" else None   # "/" -> None
        return original(normalized)
    auth._get_resource_url = resolve_resource_url
    # recurse: the PRM document and the WWW-Authenticate challenge are built
    # from different providers (interactive server vs. top-level MultiAuth)
    if isinstance(auth, MultiAuth):
        ...recurse into auth.server and auth.verifiers...
```

Net effect (verified locally against the real OIDC provider tree, `MCP_SERVER_URL=https://mcp.internal.airbyte.ai/cloud-mcp`):

```
              route path                                   document `resource` / WWW-Authenticate
before  /.well-known/oauth-protected-resource/cloud-mcp/   https://mcp.internal.airbyte.ai/cloud-mcp/   (rejected)
after   /.well-known/oauth-protected-resource/cloud-mcp    https://mcp.internal.airbyte.ai/cloud-mcp    (accepted)
```

The recursion is required because `MultiAuth` (interactive OIDC + headless JWT) builds the PRM document from `server` while the `WWW-Authenticate` challenge resolves through the top-level provider — both must agree, or the client sees an inconsistent challenge.

FastMCP exposes no public seam for this, so the helper wraps the private `_get_resource_url` (annotated `# noqa: SLF001`, matching the repo's existing non-public-API-access convention). Applies to the hosted cloud-mcp deployment; the equivalent fix for ops-mcp lives in its own repo.

Tests: `tests/unit_tests/test_mcp_http_main.py` — parametrized over root (`/`, `""`, `None`) → slash-less and non-root (`/mcp`) → unchanged, plus `MultiAuth` recursion into the interactive server and headless verifiers.


Link to Devin session: https://app.devin.ai/sessions/a5b9501ef92c412aad0408b7c74ef9c8
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed protected-resource URL formatting when the MCP endpoint is mounted at the server root by removing the trailing slash.
  * Improved compatibility with strict RFC 9728 clients through consistent root resource URL normalization.
  * Ensured consistent URL handling across authentication providers, including nested authentication configurations.
* **Tests**
  * Added coverage for root and non-root mount paths, including multi-provider authentication scenarios and empty or unspecified mount paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**