### PR TITLE
ci: fix cloud-mcp preview auto-deploy (GitHub App auth + released version)

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -81,7 +81,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
 
   # Prod cloud-mcp is bumped via Dependabot on airbytehq/airbyte-ops-mcp, not here.
-  # A PyPI publish only refreshes the cloud-mcp preview against the new version.
+  # A PyPI publish dispatches the just-released version to airbyte-ops-mcp, which
+  # opens/refreshes a deterministic `airbyte==<version>` bump PR and deploys the
+  # cloud-mcp preview off it (see `deploy-mcp-command.yml`).
   deploy_cloud_mcp_preview:
     name: Deploy Cloud MCP (Preview)
     needs: publish_to_pypi
@@ -89,13 +91,35 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: Resolve released version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            raw="${{ github.event.release.tag_name }}"
+          else
+            raw="${{ github.event.inputs.version_override }}"
+          fi
+          echo "value=${raw#v}" >> "$GITHUB_OUTPUT"
+
       - name: Wait for PyPI availability
         run: sleep 120
+
+      # Cross-repo dispatch is authenticated with an Octavia GitHub App token
+      # scoped to airbyte-ops-mcp (the app must be installed there with
+      # contents: write), matching the pattern used by prerelease-command.yml.
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: airbytehq
+          repositories: airbyte-ops-mcp
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Trigger cloud-mcp preview deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.GITHUB_CI_WORKFLOW_TRIGGER_PAT }}
+          token: ${{ steps.get-app-token.outputs.token }}
           repository: airbytehq/airbyte-ops-mcp
           event-type: deploy-cloud-mcp
-          client-payload: '{"mcp-server": "cloud-mcp", "preview": "true"}'
+          client-payload: '{"mcp-server": "cloud-mcp", "preview": "true", "airbyte-version": "${{ steps.version.outputs.value }}"}'

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -81,9 +81,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
 
   # Prod cloud-mcp is bumped via Dependabot on airbytehq/airbyte-ops-mcp, not here.
-  # A PyPI publish dispatches the just-released version to airbyte-ops-mcp, which
-  # opens/refreshes a deterministic `airbyte==<version>` bump PR and deploys the
-  # cloud-mcp preview off it (see `deploy-mcp-command.yml`).
+  # A PyPI publish dispatches the just-released version to airbyte-ops-mcp, whose
+  # deploy-mcp-command.yml opens/refreshes a deterministic `airbyte==<version>`
+  # bump PR and deploys the cloud-mcp preview off it.
   deploy_cloud_mcp_preview:
     name: Deploy Cloud MCP (Preview)
     needs: publish_to_pypi
@@ -91,28 +91,58 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      # Read the raw ref/input via env (not inline `${{ }}` in the script) to
+      # avoid shell injection, then validate it is a plain PEP 440-ish version
+      # before it reaches the dispatch payload -- this both fails fast on a
+      # malformed tag/override and guarantees the value is safe to interpolate
+      # into the client-payload JSON string below (no quotes/backslashes).
       - name: Resolve released version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          VERSION_OVERRIDE: ${{ github.event.inputs.version_override }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            raw="${{ github.event.release.tag_name }}"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            raw="$RELEASE_TAG"
           else
-            raw="${{ github.event.inputs.version_override }}"
+            raw="$VERSION_OVERRIDE"
           fi
-          echo "value=${raw#v}" >> "$GITHUB_OUTPUT"
+          version="${raw#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.a-zA-Z0-9-]*)?$ ]] \
+            || { echo "::error::Refusing to dispatch an unexpected version string: '$version'"; exit 1; }
+          echo "value=$version" >> "$GITHUB_OUTPUT"
 
+      # Poll the version-specific PyPI endpoint instead of a fixed sleep so the
+      # dispatch never races ahead of replication (and fails fast if the just-
+      # published version never shows up).
       - name: Wait for PyPI availability
-        run: sleep 120
+        env:
+          AIRBYTE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error \
+              "https://pypi.org/pypi/airbyte/${AIRBYTE_VERSION}/json" >/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::airbyte==${AIRBYTE_VERSION} was not available on PyPI in time"
+          exit 1
 
-      # Cross-repo dispatch is authenticated with an Octavia GitHub App token
-      # scoped to airbyte-ops-mcp (the app must be installed there with
-      # contents: write), matching the pattern used by prerelease-command.yml.
+      # Cross-repo dispatch is authenticated with an Octavia GitHub App token,
+      # scoped to airbyte-ops-mcp and to contents:write only (least privilege;
+      # repository scoping limits where the token works, not its permission
+      # set), matching the pattern used by prerelease-command.yml.
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-app-token
         with:
           owner: airbytehq
           repositories: airbyte-ops-mcp
+          permission-contents: write
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Summary

The PyAirbyte release-triggered cloud-mcp preview auto-deploy has never worked: `deploy_cloud_mcp_preview` authenticated the cross-repo `repository_dispatch` with `secrets.GITHUB_CI_WORKFLOW_TRIGGER_PAT`, a secret that doesn't exist in this repo (it lives in `airbyte-ops-mcp`). At runtime it resolved empty and `peter-evans/repository-dispatch` failed with `Parameter token or opts.auth is required`, so no dispatch ever reached `airbyte-ops-mcp` (confirmed on the `v0.53.1` release run).

Two fixes here:

1. **Auth via the Octavia GitHub App** (the pattern already used by `prerelease-command.yml`) instead of the phantom PAT — an installation token scoped to the target repo:

```yaml
- uses: actions/create-github-app-token@v2.1.4    # scoped to airbyte-ops-mcp
  id: get-app-token
  with:
    owner: airbytehq
    repositories: airbyte-ops-mcp
    app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
    private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
- uses: peter-evans/repository-dispatch@v4.0.1
  with:
    token: ${{ steps.get-app-token.outputs.token }}   # was: secrets.GITHUB_CI_WORKFLOW_TRIGGER_PAT
    ...
```

2. **Carry the released version in the dispatch payload** so the preview actually reflects the new library. Previously the payload had no version, so even a successful dispatch would have rebuilt cloud-mcp off whatever `requirements.txt` was already pinned to:

```
client-payload: {"mcp-server":"cloud-mcp","preview":"true","airbyte-version":"<version>"}
```

`<version>` is resolved from `release.tag_name` (minus a leading `v`) for release events, or `inputs.version_override` for `workflow_dispatch` prereleases.

The consuming side lives in airbytehq/airbyte-ops-mcp#1175: on a `deploy-cloud-mcp` dispatch carrying `airbyte-version`, that workflow opens/refreshes a deterministic `airbyte==<version>` bump PR and deploys the cloud-mcp preview off it.

**Prerequisite (ops/admin):** the Octavia GitHub App must be installed on `airbyte-ops-mcp` with `contents: write` (required for the `/dispatches` endpoint and for the bump-branch push on the consuming side). AJ confirmed it's scoped for this.


Link to Devin session: https://app.devin.ai/sessions/a5b9501ef92c412aad0408b7c74ef9c8
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved post-release automation for Cloud MCP preview deployments.
  * Preview deployments now use the exact published package version.
  * Added availability checks to ensure the published package is ready before deployment.
  * Improved release handling for both tagged releases and manually triggered publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->