### PR TITLE
fix(cloud): accept list-shaped workspace notifications from Config API

### DIFF
--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from typing import Any, Protocol
@@ -91,7 +91,7 @@ class CloudWorkspaceInfo(BaseModel):
     organization_id: str | None = Field(default=None, alias="organizationId")
     """The organization ID for the workspace, if available."""
 
-    notifications: dict[str, object | None] = Field(default_factory=dict)
+    notifications: list[dict[str, object | None]] = Field(default_factory=list)
     """Workspace notification settings."""
 
     @classmethod
@@ -102,7 +102,7 @@ class CloudWorkspaceInfo(BaseModel):
             name=workspace.name,
             data_residency=workspace.data_residency,
             organization_id=getattr(workspace, "organization_id", None),
-            notifications=_notifications_to_dict(workspace.notifications),
+            notifications=_notifications_to_list(workspace.notifications),
         )
 
     @classmethod
@@ -249,15 +249,21 @@ class CloudCustomSourceDefinitionInfo(BaseModel):
         )
 
 
-def _notifications_to_dict(notifications: object) -> dict[str, object | None]:
-    """Convert workspace notification settings into a dictionary."""
+def _notifications_to_list(
+    notifications: object,
+) -> list[dict[str, object | None]]:
+    """Convert workspace notification settings into a list."""
     if notifications is None:
-        return {}
+        return []
     if is_dataclass(notifications) and not isinstance(notifications, type):
-        return {str(key): value for key, value in asdict(notifications).items()}
+        return [asdict(notifications)]
     if isinstance(notifications, Mapping):
-        return {str(key): value for key, value in notifications.items()}
-    return {}
+        return [dict(notifications)]
+    if isinstance(notifications, Sequence) and not isinstance(
+        notifications, (str, bytes, bytearray)
+    ):
+        return [dict(item) for item in notifications if isinstance(item, Mapping)]
+    return []
 
 
 def _enum_value(value: object) -> str:

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from typing import Any, Protocol
@@ -91,7 +91,9 @@ class CloudWorkspaceInfo(BaseModel):
     organization_id: str | None = Field(default=None, alias="organizationId")
     """The organization ID for the workspace, if available."""
 
-    notifications: list[dict[str, object | None]] = Field(default_factory=list)
+    notifications: dict[str, object | None] | list[dict[str, object | None]] = Field(
+        default_factory=dict
+    )
     """Workspace notification settings."""
 
     @classmethod
@@ -102,7 +104,7 @@ class CloudWorkspaceInfo(BaseModel):
             name=workspace.name,
             data_residency=workspace.data_residency,
             organization_id=getattr(workspace, "organization_id", None),
-            notifications=_notifications_to_list(workspace.notifications),
+            notifications=_notifications_to_dict(workspace.notifications),
         )
 
     @classmethod
@@ -249,21 +251,15 @@ class CloudCustomSourceDefinitionInfo(BaseModel):
         )
 
 
-def _notifications_to_list(
-    notifications: object,
-) -> list[dict[str, object | None]]:
-    """Convert workspace notification settings into a list."""
+def _notifications_to_dict(notifications: object) -> dict[str, object | None]:
+    """Convert workspace notification settings into a dictionary."""
     if notifications is None:
-        return []
+        return {}
     if is_dataclass(notifications) and not isinstance(notifications, type):
-        return [asdict(notifications)]
+        return {str(key): value for key, value in asdict(notifications).items()}
     if isinstance(notifications, Mapping):
-        return [dict(notifications)]
-    if isinstance(notifications, Sequence) and not isinstance(
-        notifications, (str, bytes, bytearray)
-    ):
-        return [dict(item) for item in notifications if isinstance(item, Mapping)]
-    return []
+        return {str(key): value for key, value in notifications.items()}
+    return {}
 
 
 def _enum_value(value: object) -> str:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -248,6 +248,35 @@ def test_cloud_client_create_workspace_uses_default_organization_id(
     assert captured_organization_id == "organization-id"
 
 
+def test_cloud_client_list_workspaces_accepts_api_notification_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_list_workspaces_in_organization(
+        **_: object,
+    ) -> list[dict[str, object]]:
+        return [
+            {
+                "workspaceId": "workspace-id",
+                "name": "Workspace",
+                "notifications": [],
+            }
+        ]
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    workspaces = CloudClient(
+        bearer_token="token",
+        organization_id="organization-id",
+    ).list_workspaces()
+
+    assert len(workspaces) == 1
+    assert workspaces[0].notifications == []
+
+
 def test_cloud_client_rename_workspace_forwards_inputs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -258,7 +258,7 @@ def test_cloud_client_list_workspaces_accepts_api_notification_list(
             {
                 "workspaceId": "workspace-id",
                 "name": "Workspace",
-                "notifications": [],
+                "notifications": [{"sendOnSuccess": True}],
             }
         ]
 
@@ -274,7 +274,7 @@ def test_cloud_client_list_workspaces_accepts_api_notification_list(
     ).list_workspaces()
 
     assert len(workspaces) == 1
-    assert workspaces[0].notifications == []
+    assert workspaces[0].notifications == [{"sendOnSuccess": True}]
 
 
 def test_cloud_workspace_info_accepts_api_notification_mapping() -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -277,6 +277,16 @@ def test_cloud_client_list_workspaces_accepts_api_notification_list(
     assert workspaces[0].notifications == []
 
 
+def test_cloud_workspace_info_accepts_api_notification_mapping() -> None:
+    workspace = CloudWorkspaceInfo.model_validate({
+        "workspaceId": "workspace-id",
+        "name": "Workspace",
+        "notifications": {"sendOnSuccess": True},
+    })
+
+    assert workspace.notifications == {"sendOnSuccess": True}
+
+
 def test_cloud_client_rename_workspace_forwards_inputs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

`list_cloud_workspaces` failed for every caller against Airbyte Cloud, even though the underlying API call succeeded:

```
1 validation error for CloudWorkspaceInfo
notifications
  Input should be a valid dictionary [type=dict_type, input_value=[], input_type=list]
```

The two constructors on `CloudWorkspaceInfo` are fed by two different upstreams with genuinely different shapes, and the field was only typed for one of them:

- `from_api_response()` receives the public-API SDK object, whose `WorkspaceResponse.notifications` is a single `NotificationsConfig` object → mapping.
- `from_mapping()` / `model_validate()` receives raw Config API dicts from `list_workspaces_in_organization()`, whose `notifications` is a **list** → this is the path that blew up.

So the field is widened to accept both shapes rather than coercing one into the other:

```diff
-    notifications: dict[str, object | None] = Field(default_factory=dict)
+    notifications: dict[str, object | None] | list[dict[str, object | None]] = Field(
+        default_factory=dict
+    )
```

Deliberately *not* done: wrapping the SDK's `NotificationsConfig` into a one-element list to unify the types. That would fabricate a shape the upstream never returned and make the two paths indistinguishable to a consumer. `_notifications_to_dict()` and the `from_api_response()` path are unchanged, so the SDK path keeps emitting a mapping exactly as before.

Found while validating OAuth token pass-through on the four hosted `mcp.internal.airbyte.ai` MCP servers — `list_cloud_workspaces` was broken on both cloud-mcp and cloud-mcp-preview.

## Test plan

Regression coverage added for both shapes in `tests/unit_tests/test_cloud_credentials.py`. `ruff`, `mypy`, and targeted tests pass locally (30 passed).


Link to Devin session: https://app.devin.ai/sessions/e994a619bc994892aeab139a9f1c1301
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloud workspace notification handling to support both list-based and mapping-based notification data.
  * Preserved empty/omitted notification values by defaulting to an empty structure when no payload is provided.
* **Tests**
  * Added unit coverage to verify Cloud workspace listing and workspace info model validation accept API-provided notification list and mapping formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->