### PR TITLE
docs: fence docstring examples so pdoc output renders as code

### DIFF
--- a/airbyte/caches/snowflake.py
+++ b/airbyte/caches/snowflake.py
@@ -3,7 +3,7 @@
 
 ## Usage Example
 
-# Password connection:
+### Password connection:
 
 ```python
 from airbyte as ab
@@ -20,7 +20,7 @@ cache = SnowflakeCache(
 )
 ```
 
-# Private key connection:
+### Private key connection:
 
 ```python
 from airbyte as ab
@@ -38,7 +38,7 @@ cache = SnowflakeCache(
 )
 ```
 
-# Private key path connection:
+### Private key path connection:
 
 ```python
 from airbyte as ab

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -880,9 +880,12 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             cron_expression: A cron expression defining when syncs should run.
 
         Examples:
-                - "0 0 * * *" - Daily at midnight UTC
-                - "0 */6 * * *" - Every 6 hours
-                - "0 0 * * 0" - Weekly on Sunday at midnight UTC
+            ```python
+            "0 0 * * *"  # Daily at midnight UTC
+
+            "0 */6 * * *"  # Every 6 hours
+            "0 0 * * 0"  # Weekly on Sunday at midnight UTC
+            ```
         """
         updated_response = api_util.patch_connection(
             connection_id=self.connection_id,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -880,12 +880,9 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
             cron_expression: A cron expression defining when syncs should run.
 
         Examples:
-            ```python
-            "0 0 * * *"  # Daily at midnight UTC
-
-            "0 */6 * * *"  # Every 6 hours
-            "0 0 * * 0"  # Weekly on Sunday at midnight UTC
-            ```
+            - "0 0 * * *"  # Daily at midnight UTC
+            - "0 */6 * * *"  # Every 6 hours
+            - "0 0 * * 0"  # Weekly on Sunday at midnight UTC
         """
         updated_response = api_util.patch_connection(
             connection_id=self.connection_id,

--- a/airbyte/registry.py
+++ b/airbyte/registry.py
@@ -568,9 +568,11 @@ def get_connector_version_history(
         AirbyteConnectorNotRegisteredError: If the connector is not found in the registry.
 
     Example:
-        >>> versions = get_connector_version_history("source-faker", num_versions_to_validate=3)
-        >>> for v in versions[:5]:
-        ...     print(f"{v.version}: {v.release_date}")
+        ```python
+        versions = get_connector_version_history("source-faker", num_versions_to_validate=3)
+        for v in versions[:5]:
+            print(f"{v.version}: {v.release_date}")
+        ```
     """
     if connector_name not in get_available_connectors(InstallType.ANY):
         raise exc.AirbyteConnectorNotRegisteredError(

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -150,10 +150,12 @@ class Source(ConnectorBase):  # noqa: PLR0904
         """Override the cursor key for one or more streams.
 
         Usage:
+            ```python
             source.set_cursor_keys(
                 stream1="cursor1",
                 stream2="cursor2",
             )
+            ```
 
         Note:
         - This does not unset previously set cursors.
@@ -195,10 +197,12 @@ class Source(ConnectorBase):  # noqa: PLR0904
         This does not unset previously set primary keys.
 
         Usage:
+            ```python
             source.set_primary_keys(
                 stream1="pk1",
                 stream2=["pk1", "pk2"],
             )
+            ```
 
         Note:
         - This does not unset previously set primary keys.


### PR DESCRIPTION
## Summary

An SEO audit of docs.airbyte.com (DOCS-64) found pages under `/developers/pyairbyte/reference/` serving multiple `<h1>` tags. The cause is upstream of the docs site, in this repo's docstrings.

`airbytehq/airbyte` generates that reference tree with pdoc3 and renders it through Docusaurus 3, which uses MDX v3. **MDX v3 dropped support for indented code blocks.** So a docstring example written as an indented block is no longer code once rendered — it's parsed as ordinary Markdown, which means a line like `>>> # Download and save a file` becomes an `<h1>`, and `# Password connection:` in a module docstring becomes another one.

This converts the affected examples to fenced blocks and demotes the module-level example subsection headings, so the intent survives the MDX round trip:

```diff
      Example:
-         >>> versions = get_connector_version_history("source-faker", num_versions_to_validate=3)
-         >>> for v in versions[:5]:
-         ...     print(f"{v.version}: {v.release_date}")
+         ```python
+         versions = get_connector_version_history("source-faker", num_versions_to_validate=3)
+         for v in versions[:5]:
+             print(f"{v.version}: {v.release_date}")
+         ```
```

```diff
-# Password connection:
+### Password connection:
```

Four files: `registry.py`, `sources/base.py`, `caches/snowflake.py` (the page the audit flagged), and `connections.py`, where an over-indented cron bullet list was being read as a code block — that one stays a list, just re-indented to the normal 4-space continuation.

Docstring formatting only: no signatures, behaviour, or logic touched. `poe check` passes (ruff check, ruff format, pyrefly 0 errors).

A companion PR in `airbytehq/airbyte` adds a defensive pass to the generation workflow that fences stray indented examples and demotes duplicate H1s, so future docstrings can't silently reintroduce this. That guard is a safety net; this is the durable fix, and it also makes the examples render correctly in pdoc's own HTML output rather than only fixing the symptom downstream.


Link to Devin session: https://app.devin.ai/sessions/5914ab297c1e4847bd2fac547209f730
Requested by: @ian-at-airbyte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code examples and heading formatting for Snowflake connection options.
  * Clarified cron schedule examples with Python comment syntax.
  * Updated connector version history examples to use fenced Python code blocks.
  * Standardized cursor and primary key examples with Markdown code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->