### PR TITLE
fix(mcp): honor client UI extension over stateless HTTP

### DIFF
--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -347,6 +347,9 @@ MCP_CONFIG_CONFIG_API_URL: str = "config_api_url"
 MCP_BEARER_TOKEN_HEADER: str = "Authorization"
 """HTTP header key for bearer token (standard Authorization header)."""
 
+MCP_EXTENSIONS_HEADER: str = "X-MCP-Extensions"
+"""HTTP header key for client-declared MCP extension IDs."""
+
 MCP_CLIENT_ID_HEADER: str = "X-Airbyte-Cloud-Client-Id"
 """HTTP header key for client ID."""
 

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -224,13 +224,18 @@ set; the interactive path activates once the OIDC client credentials are set.
   `AIRBYTE_MCP_AUTH_ALGORITHM` — expected `iss` / `aud` claims and signing
   algorithm.
 
-For stateless HTTP clients that need MCP Apps `interactive-ui` tools, the
-spec-aligned mechanism is per-request `_meta` under
-`io.modelcontextprotocol/clientCapabilities`, but FastMCP does not yet surface
-that metadata to tool filtering (as of `fastmcp` 3.4.5). Until it does, send the
+For stateless HTTP clients that need MCP Apps `interactive-ui` tools, clients
+that declare extensions at initialize receive a self-describing `Mcp-Session-Id`
+which spec-compliant clients echo on subsequent requests. Clients that do not
+echo session IDs can use the explicit fallback
 `X-MCP-Extensions: io.modelcontextprotocol/ui` header on each request instead.
-Multiple extension IDs may be comma-separated (recommended) or whitespace-
-separated.
+Multiple extension IDs may be comma-separated (recommended) or
+whitespace-separated.
+
+The eventual spec-aligned replacement is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
+`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
+using it requires a stack migration rather than a version-only change.
 
 With no auth variables set, the HTTP server falls back to unauthenticated local
 behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -234,8 +234,9 @@ whitespace-separated.
 
 The eventual spec-aligned replacement is per-request `_meta` under
 `io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
-`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
-using it requires a stack migration rather than a version-only change.
+`mcp` 2.x server architecture, while this project currently resolves the
+legacy `fastmcp` 3.x and `mcp` 1.x stack. Using it requires a stack migration
+rather than a version-only change.
 
 With no auth variables set, the HTTP server falls back to unauthenticated local
 behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -224,6 +224,12 @@ set; the interactive path activates once the OIDC client credentials are set.
   `AIRBYTE_MCP_AUTH_ALGORITHM` — expected `iss` / `aud` claims and signing
   algorithm.
 
+For stateless HTTP clients that need MCP Apps `interactive-ui` tools, the
+spec-aligned mechanism is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`, but FastMCP does not yet surface
+that metadata to tool filtering (as of `fastmcp` 3.4.5). Until it does, send the
+`X-MCP-Extensions: io.modelcontextprotocol/ui` header on each request instead.
+
 With no auth variables set, the HTTP server falls back to unauthenticated local
 behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config
 objects consumed by

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -229,6 +229,8 @@ spec-aligned mechanism is per-request `_meta` under
 `io.modelcontextprotocol/clientCapabilities`, but FastMCP does not yet surface
 that metadata to tool filtering (as of `fastmcp` 3.4.5). Until it does, send the
 `X-MCP-Extensions: io.modelcontextprotocol/ui` header on each request instead.
+Multiple extension IDs may be comma-separated (recommended) or whitespace-
+separated.
 
 With no auth variables set, the HTTP server falls back to unauthenticated local
 behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config

--- a/airbyte/mcp/_capability_tokens.py
+++ b/airbyte/mcp/_capability_tokens.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Self-describing capability tokens for stateless MCP HTTP transport."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_TOKEN_SEPARATOR = "."
+_SESSION_HEADER = b"mcp-session-id"
+_BASE64URL_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_HTTP_REQUEST = "http"
+_HTTP_REQUEST_MESSAGE = "http.request"
+_HTTP_RESPONSE_START = "http.response.start"
+_HTTP_REQUEST_METHOD = "method"
+_HTTP_REQUEST_BODY = "body"
+_HTTP_REQUEST_MORE_BODY = "more_body"
+_HTTP_RESPONSE_HEADERS = "headers"
+_UUID4_VERSION = 4
+
+
+def encode_capability_token(extension_ids: AbstractSet[str]) -> str:
+    """Encode extension IDs as a visible-ASCII capability token.
+
+    The token contains a random UUID4 component and a base64url-encoded,
+    space-separated payload. An empty extension set returns an empty string.
+    """
+    normalized_ids = sorted(
+        extension_id
+        for extension_id in extension_ids
+        if extension_id and not any(char.isspace() for char in extension_id)
+    )
+    if not normalized_ids:
+        return ""
+    payload = " ".join(normalized_ids).encode("utf-8")
+    encoded_payload = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{uuid.uuid4().hex}{_TOKEN_SEPARATOR}{encoded_payload}"
+
+
+def decode_capability_token(token: str) -> set[str]:
+    """Decode extension IDs from a capability token, failing closed on errors."""
+    if not token or _TOKEN_SEPARATOR not in token:
+        return set()
+
+    nonce, encoded_payload = token.split(_TOKEN_SEPARATOR, maxsplit=1)
+    if not _is_uuid4_hex(nonce) or not encoded_payload:
+        return set()
+    if not _BASE64URL_PATTERN.fullmatch(encoded_payload):
+        return set()
+
+    try:
+        padding = "=" * (-len(encoded_payload) % 4)
+        payload = base64.urlsafe_b64decode(encoded_payload + padding).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return set()
+
+    extension_ids = payload.split()
+    if not extension_ids:
+        return set()
+    return set(extension_ids)
+
+
+def _is_uuid4_hex(value: str) -> bool:
+    try:
+        parsed = uuid.UUID(hex=value)
+    except ValueError:
+        return False
+    return parsed.hex == value.lower() and parsed.version == _UUID4_VERSION
+
+
+def _mapping(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _initialize_extension_ids(body: bytes) -> set[str]:
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return set()
+
+    payload_mapping = _mapping(payload)
+    if payload_mapping is None or payload_mapping.get("method") != "initialize":
+        return set()
+    params = _mapping(payload_mapping.get("params"))
+    capabilities = _mapping(params.get("capabilities")) if params is not None else None
+    extensions = _mapping(capabilities.get("extensions")) if capabilities is not None else None
+    if extensions is None:
+        return set()
+    return {
+        extension_id
+        for extension_id in extensions
+        if isinstance(extension_id, str) and extension_id
+    }
+
+
+class CapabilityTokenMiddleware:
+    """Carry initialize extension declarations through stateless HTTP requests."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != _HTTP_REQUEST or scope.get(_HTTP_REQUEST_METHOD) != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        body_parts: list[bytes] = []
+        while True:
+            message = await receive()
+            body_parts.append(message.get(_HTTP_REQUEST_BODY, b""))
+            if not message.get(_HTTP_REQUEST_MORE_BODY, False):
+                break
+        body = b"".join(body_parts)
+        extension_ids = _initialize_extension_ids(body)
+        token = encode_capability_token(extension_ids)
+        replayed = False
+
+        async def replay_receive() -> Message:
+            nonlocal replayed
+            if replayed:
+                return await receive()
+            replayed = True
+            return {
+                "type": _HTTP_REQUEST_MESSAGE,
+                "body": body,
+                "more_body": False,
+            }
+
+        async def send_response(message: Message) -> None:
+            if (
+                message.get("type") == _HTTP_RESPONSE_START
+                and token
+                and isinstance(message.get(_HTTP_RESPONSE_HEADERS), list)
+            ):
+                headers = [
+                    (name, value)
+                    for name, value in message[_HTTP_RESPONSE_HEADERS]
+                    if name.lower() != _SESSION_HEADER
+                ]
+                headers.append((_SESSION_HEADER, token.encode("ascii")))
+                message = {**message, _HTTP_RESPONSE_HEADERS: headers}
+            await send(message)
+
+        await self.app(scope, replay_receive, send_response)

--- a/airbyte/mcp/_capability_tokens.py
+++ b/airbyte/mcp/_capability_tokens.py
@@ -20,13 +20,14 @@ _TOKEN_SEPARATOR = "."
 _SESSION_HEADER = b"mcp-session-id"
 _BASE64URL_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 _HTTP_REQUEST = "http"
-_HTTP_REQUEST_MESSAGE = "http.request"
 _HTTP_RESPONSE_START = "http.response.start"
 _HTTP_REQUEST_METHOD = "method"
 _HTTP_REQUEST_BODY = "body"
 _HTTP_REQUEST_MORE_BODY = "more_body"
 _HTTP_RESPONSE_HEADERS = "headers"
+_HTTP_DISCONNECT = "http.disconnect"
 _UUID4_VERSION = 4
+_MAX_INITIALIZE_BODY_BYTES = 64 * 1024
 
 
 def encode_capability_token(extension_ids: AbstractSet[str]) -> str:
@@ -116,27 +117,46 @@ class CapabilityTokenMiddleware:
             await self.app(scope, receive, send)
             return
 
+        buffered_messages: list[Message] = []
         body_parts: list[bytes] = []
+        body_size = 0
+        oversized = False
+        disconnected = False
         while True:
             message = await receive()
-            body_parts.append(message.get(_HTTP_REQUEST_BODY, b""))
+            if message.get("type") == _HTTP_DISCONNECT:
+                buffered_messages.append(message)
+                disconnected = True
+                break
+            buffered_messages.append(message)
+            body_part = message.get(_HTTP_REQUEST_BODY, b"")
+            if not oversized:
+                body_size += len(body_part)
+                if body_size > _MAX_INITIALIZE_BODY_BYTES:
+                    oversized = True
+                    body_parts.clear()
+                else:
+                    body_parts.append(body_part)
+            if oversized:
+                break
             if not message.get(_HTTP_REQUEST_MORE_BODY, False):
                 break
         body = b"".join(body_parts)
-        extension_ids = _initialize_extension_ids(body)
+        extension_ids = set() if oversized or disconnected else _initialize_extension_ids(body)
         token = encode_capability_token(extension_ids)
-        replayed = False
+        replay_index = 0
 
         async def replay_receive() -> Message:
-            nonlocal replayed
-            if replayed:
+            nonlocal replay_index
+            if replay_index < len(buffered_messages):
+                message = buffered_messages[replay_index]
+                replay_index += 1
+                return message
+            if disconnected:
+                return {"type": _HTTP_DISCONNECT}
+            if oversized:
                 return await receive()
-            replayed = True
-            return {
-                "type": _HTTP_REQUEST_MESSAGE,
-                "body": body,
-                "more_body": False,
-            }
+            return await receive()
 
         async def send_response(message: Message) -> None:
             if (

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -62,6 +62,7 @@ from airbyte.constants import (
     MCP_WORKSPACE_ID_HEADER,
 )
 from airbyte.exceptions import PyAirbyteInputError
+from airbyte.mcp._capability_tokens import decode_capability_token
 
 
 if TYPE_CHECKING:
@@ -521,10 +522,9 @@ def airbyte_ui_support_filter(tool: Tool, _app: FastMCP) -> bool:
 def _client_supports_ui() -> bool:
     """Return whether the current client declared MCP Apps UI support.
 
-    Stateless streamable HTTP discards initialize-time `ClientCapabilities`, so
-    HTTP clients can declare extensions through the fallback request header.
-    There is no standardized MCP header for this today; the Airbyte server
-    accepts the non-standard `X-MCP-Extensions` header.
+    Stateless streamable HTTP carries initialize-time extensions in a
+    self-describing `Mcp-Session-Id` when the client supports session IDs.
+    `X-MCP-Extensions` remains an explicit fallback for clients that do not.
     """
     try:
         context = get_context()
@@ -540,7 +540,10 @@ def _fastmcp_context_supports_ui(context: Context) -> bool:
 
 
 def _client_declared_extensions_from_headers() -> set[str]:
-    """Return comma- or whitespace-separated extension IDs from HTTP headers."""
-    header_key = MCP_EXTENSIONS_HEADER.lower()
-    header_value = get_http_headers(include={header_key}).get(header_key, "")
+    """Return extension IDs from the session token or fallback HTTP header."""
+    headers = get_http_headers(include={MCP_EXTENSIONS_HEADER.lower(), "mcp-session-id"})
+    session_extensions = decode_capability_token(headers.get("mcp-session-id", ""))
+    if session_extensions:
+        return session_extensions
+    header_value = headers.get(MCP_EXTENSIONS_HEADER.lower(), "")
     return set(header_value.replace(",", " ").split())

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -56,6 +56,7 @@ from airbyte.constants import (
     MCP_CONFIG_WORKSPACE_ID,
     MCP_DOMAINS_DISABLED_ENV_VAR,
     MCP_DOMAINS_ENV_VAR,
+    MCP_EXTENSIONS_HEADER,
     MCP_READONLY_MODE_ENV_VAR,
     MCP_TRUSTED_EXECUTION_ENV_VAR,
     MCP_WORKSPACE_ID_HEADER,
@@ -518,12 +519,28 @@ def airbyte_ui_support_filter(tool: Tool, _app: FastMCP) -> bool:
 
 
 def _client_supports_ui() -> bool:
+    """Return whether the current client declared MCP Apps UI support.
+
+    Stateless streamable HTTP discards initialize-time `ClientCapabilities`, so
+    HTTP clients can declare extensions through the fallback request header.
+    There is no standardized MCP header for this today; the Airbyte server
+    accepts the non-standard `X-MCP-Extensions` header.
+    """
     try:
         context = get_context()
     except RuntimeError:
-        return False
-    return _fastmcp_context_supports_ui(context)
+        context_supports_ui = False
+    else:
+        context_supports_ui = _fastmcp_context_supports_ui(context)
+    return context_supports_ui or (UI_EXTENSION_ID in _client_declared_extensions_from_headers())
 
 
 def _fastmcp_context_supports_ui(context: Context) -> bool:
     return context.client_supports_extension(UI_EXTENSION_ID)
+
+
+def _client_declared_extensions_from_headers() -> set[str]:
+    """Return extension IDs declared in the current HTTP request headers."""
+    header_key = MCP_EXTENSIONS_HEADER.lower()
+    header_value = get_http_headers(include={header_key}).get(header_key, "")
+    return {extension.strip() for extension in header_value.split(",") if extension.strip()}

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -540,7 +540,7 @@ def _fastmcp_context_supports_ui(context: Context) -> bool:
 
 
 def _client_declared_extensions_from_headers() -> set[str]:
-    """Return extension IDs declared in the current HTTP request headers."""
+    """Return comma- or whitespace-separated extension IDs from HTTP headers."""
     header_key = MCP_EXTENSIONS_HEADER.lower()
     header_value = get_http_headers(include={header_key}).get(header_key, "")
-    return {extension.strip() for extension in header_value.split(",") if extension.strip()}
+    return set(header_value.replace(",", " ").split())

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -543,7 +543,6 @@ def _client_declared_extensions_from_headers() -> set[str]:
     """Return extension IDs from the session token or fallback HTTP header."""
     headers = get_http_headers(include={MCP_EXTENSIONS_HEADER.lower(), "mcp-session-id"})
     session_extensions = decode_capability_token(headers.get("mcp-session-id", ""))
-    if session_extensions:
-        return session_extensions
     header_value = headers.get(MCP_EXTENSIONS_HEADER.lower(), "")
-    return set(header_value.replace(",", " ").split())
+    fallback_extensions = set(header_value.replace(",", " ").split())
+    return session_extensions | fallback_extensions

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -23,8 +23,9 @@ or whitespace-separated.
 
 The eventual spec-aligned replacement is per-request `_meta` under
 `io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
-`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
-using it requires a stack migration rather than a version-only change.
+`mcp` 2.x server architecture, while this project currently resolves the
+legacy `fastmcp` 3.x and `mcp` 1.x stack. Using it requires a stack migration
+rather than a version-only change.
 
 Environment variables:
 
@@ -78,6 +79,7 @@ from fastmcp_extensions import (
     register_landing_page,
     run_mcp_http_server,
 )
+from starlette.responses import Response
 
 from airbyte.constants import set_hosted_mcp_mode
 from airbyte.mcp._capability_tokens import CapabilityTokenMiddleware
@@ -98,7 +100,7 @@ from airbyte.version import get_version
 
 if TYPE_CHECKING:
     from fastmcp.server.auth import AuthProvider
-    from starlette.types import ASGIApp
+    from starlette.types import ASGIApp, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +203,28 @@ def _log_auth_status() -> None:
 
 def _wrap_http_app(http_app: ASGIApp) -> ASGIApp:
     """Wrap the HTTP app with authentication and capability propagation."""
-    return CapabilityTokenMiddleware(wrap_if_enabled(http_app))
+    return _RejectEventStreamGetMiddleware(CapabilityTokenMiddleware(wrap_if_enabled(http_app)))
+
+
+class _RejectEventStreamGetMiddleware:
+    """Reject MCP SSE GETs without shadowing the browser landing page."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope.get("type") == "http"
+            and scope.get("method") == "GET"
+            and any(
+                name.lower() == b"accept" and b"text/event-stream" in value.lower()
+                for name, value in scope.get("headers", [])
+            )
+        ):
+            response = Response(status_code=405, headers={"allow": "POST, DELETE"})
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
 
 
 def main() -> None:

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -17,6 +17,8 @@ The spec-aligned mechanism is per-request `_meta` under
 does not expose that metadata to tool filtering yet. Until it does, clients
 that need MCP Apps `interactive-ui` tools must send the non-standard
 `X-MCP-Extensions: io.modelcontextprotocol/ui` header on each HTTP request.
+Multiple extension IDs may be comma-separated (recommended) or whitespace-
+separated.
 
 Environment variables:
 

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -11,6 +11,13 @@ falls back to unauthenticated local behavior. This module declares only the env
 var *names* — the concrete values are supplied at deploy time by the
 deployment's own repo. See `server.py` for details.
 
+Stateless streamable HTTP does not retain initialize-time client capabilities.
+The spec-aligned mechanism is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`, but the installed FastMCP stack
+does not expose that metadata to tool filtering yet. Until it does, clients
+that need MCP Apps `interactive-ui` tools must send the non-standard
+`X-MCP-Extensions: io.modelcontextprotocol/ui` header on each HTTP request.
+
 Environment variables:
 
 - `MCP_SERVER_URL`: Public base URL. Used for OIDC redirect callbacks and to

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -11,14 +11,19 @@ falls back to unauthenticated local behavior. This module declares only the env
 var *names* — the concrete values are supplied at deploy time by the
 deployment's own repo. See `server.py` for details.
 
-Stateless streamable HTTP does not retain initialize-time client capabilities.
-The spec-aligned mechanism is per-request `_meta` under
-`io.modelcontextprotocol/clientCapabilities`, but the installed FastMCP stack
-does not expose that metadata to tool filtering yet. Until it does, clients
-that need MCP Apps `interactive-ui` tools must send the non-standard
-`X-MCP-Extensions: io.modelcontextprotocol/ui` header on each HTTP request.
-Multiple extension IDs may be comma-separated (recommended) or whitespace-
-separated.
+Stateless streamable HTTP does not retain initialize-time client capabilities
+internally. For clients that declare extensions at initialize, the server
+returns a self-describing `Mcp-Session-Id`, and spec-compliant clients echo it
+on subsequent requests. This makes MCP Apps `interactive-ui` tools available
+without a client-specific header. Clients that do not echo session IDs can use
+the explicit fallback `X-MCP-Extensions: io.modelcontextprotocol/ui` header on
+each HTTP request. Multiple extension IDs may be comma-separated (recommended)
+or whitespace-separated.
+
+The eventual spec-aligned replacement is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
+`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
+using it requires a stack migration rather than a version-only change.
 
 Environment variables:
 
@@ -58,8 +63,10 @@ from fastmcp_extensions import (
     assert_http_trusted_execution_disabled,
     register_landing_page,
 )
+from starlette.middleware import Middleware
 
 from airbyte.constants import set_hosted_mcp_mode
+from airbyte.mcp._capability_tokens import CapabilityTokenMiddleware
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
@@ -143,6 +150,7 @@ def main() -> None:
         host=DEFAULT_HTTP_HOST,
         port=DEFAULT_HTTP_PORT,
         path=mcp_path,
+        middleware=[Middleware(CapabilityTokenMiddleware)],
         stateless_http=True,
     )
 

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -171,7 +171,7 @@ def test_http_main_delegates_http_serving_to_fastmcp_extensions(
         "path": "/mcp",
         "transport": "streamable-http",
         "stateless_http": True,
-        "wrapper": http_main.wrap_if_enabled,
+        "wrapper": http_main._wrap_http_app,
         "host": http_main.DEFAULT_HTTP_HOST,
         "port": http_main.DEFAULT_HTTP_PORT,
     }

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -22,6 +23,7 @@ from starlette.middleware import Middleware
 from airbyte.mcp import _tool_utils
 from airbyte.mcp._capability_tokens import (
     CapabilityTokenMiddleware,
+    _MAX_INITIALIZE_BODY_BYTES,
     decode_capability_token,
     encode_capability_token,
 )
@@ -187,8 +189,12 @@ def test_capability_token_round_trip(
     [
         pytest.param("garbage", id="garbage"),
         pytest.param(
-            "00000000000000000000000000000000.not-base64!",
+            f"{uuid.uuid4().hex}.not-base64!",
             id="non-base64",
+        ),
+        pytest.param(
+            f"00000000000000000000000000000000.{'aW8ubW9kZWxjb250ZXh0cHJvdG9jb2wvdWk'}",
+            id="non-uuid4-with-valid-payload",
         ),
         pytest.param("00000000-0000-0000-0000-000000000000", id="uuid-only"),
         pytest.param("", id="empty"),
@@ -278,6 +284,95 @@ def test_client_declared_extensions_from_headers(
     monkeypatch.setattr(_tool_utils, "get_http_headers", lambda **_: headers)
     extensions = _tool_utils._client_declared_extensions_from_headers()
     assert ("io.modelcontextprotocol/ui" in extensions) is expected
+
+
+def test_client_declared_extensions_union_session_token_and_fallback_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session-token and fallback-header extensions are combined."""
+    token = encode_capability_token({"io.modelcontextprotocol/roots"})
+    monkeypatch.setattr(
+        _tool_utils,
+        "get_http_headers",
+        lambda **_: {
+            "mcp-session-id": token,
+            "x-mcp-extensions": "io.modelcontextprotocol/ui",
+        },
+    )
+
+    assert _tool_utils._client_declared_extensions_from_headers() == {
+        "io.modelcontextprotocol/roots",
+        "io.modelcontextprotocol/ui",
+    }
+
+
+async def _capture_middleware_request(
+    messages: list[dict[str, object]],
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    received: list[dict[str, object]] = []
+    responses: list[dict[str, object]] = []
+    message_index = 0
+
+    async def receive() -> Any:
+        nonlocal message_index
+        message = messages[message_index]
+        message_index += 1
+        return message
+
+    async def send(message: dict[str, object]) -> None:
+        responses.append(message)
+
+    async def app(scope: Any, receive: Any, send: Any) -> None:
+        del scope
+        while True:
+            message = await receive()
+            received.append(message)
+            if message["type"] == "http.disconnect" or not message.get("more_body"):
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    middleware = CapabilityTokenMiddleware(app)
+    await middleware(
+        {"type": "http", "method": "POST"},
+        receive,
+        send,
+    )
+    return received, responses
+
+
+def test_capability_token_middleware_forwards_large_body_without_token() -> None:
+    """Bodies larger than the sniffing cap reach the app intact."""
+    body = b"x" * (_MAX_INITIALIZE_BODY_BYTES + 1)
+    received, responses = asyncio.run(
+        _capture_middleware_request([
+            {"type": "http.request", "body": body[:1024], "more_body": True},
+            {"type": "http.request", "body": body[1024:], "more_body": False},
+        ])
+    )
+
+    assert b"".join(message.get("body", b"") for message in received) == body
+    assert all(
+        header_name != b"mcp-session-id"
+        for response in responses
+        for header_name, _ in response.get("headers", [])
+    )
+
+
+def test_capability_token_middleware_forwards_disconnect_without_token() -> None:
+    """A disconnected request is forwarded without attempting token parsing."""
+    received, responses = asyncio.run(
+        _capture_middleware_request([
+            {"type": "http.request", "body": b'{"jsonrpc":', "more_body": True},
+            {"type": "http.disconnect"},
+        ])
+    )
+
+    assert received[-1]["type"] == "http.disconnect"
+    assert all(
+        header_name != b"mcp-session-id"
+        for response in responses
+        for header_name, _ in response.get("headers", [])
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -153,6 +153,11 @@ def test_stdio_ui_tool_visibility(
             id="comma-separated",
         ),
         pytest.param(
+            {"x-mcp-extensions": "other io.modelcontextprotocol/ui another"},
+            True,
+            id="whitespace-separated",
+        ),
+        pytest.param(
             {"x-mcp-extensions": "other"},
             False,
             id="unknown-extension",
@@ -169,7 +174,8 @@ def test_client_declared_extensions_from_headers(
     """Header extension parsing tolerates common HTTP formatting.
 
     `get_http_headers()` lowercases header names, so the parser looks up the
-    lowercased key; end-to-end casing is covered by the HTTP visibility test.
+    lowercased key; comma- and whitespace-separated values are accepted.
+    End-to-end casing is covered by the HTTP visibility test.
     """
     monkeypatch.setattr(_tool_utils, "get_http_headers", lambda **_: headers)
     extensions = _tool_utils._client_declared_extensions_from_headers()
@@ -207,7 +213,7 @@ def test_stateless_http_ui_tool_visibility(
     assert (UI_TOOL_NAMES <= names) is expected
     if expected:
         assert any(
-            header_name == b"x-McP-ExTeNsIoNs"
+            header_name.lower() == b"x-mcp-extensions"
             for request_headers in wire_headers
             for header_name, _ in request_headers
         )

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -210,10 +210,12 @@ def test_stateless_http_ui_tool_visibility(
             )
         )
     )
-    assert (UI_TOOL_NAMES <= names) is expected
     if expected:
+        assert UI_TOOL_NAMES <= names
         assert any(
             header_name.lower() == b"x-mcp-extensions"
             for request_headers in wire_headers
             for header_name, _ in request_headers
         )
+    else:
+        assert UI_TOOL_NAMES.isdisjoint(names)

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Tests for stateless HTTP extension declarations and UI tool visibility."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
+
+from airbyte.mcp import _tool_utils
+from airbyte.mcp.server import app
+
+
+UI_EXTENSION = {"io.modelcontextprotocol/ui": {}}
+UI_TOOL_NAMES = {
+    "show_connectors_list",
+    "show_workspace_sync_status",
+    "show_connection_sync_history",
+}
+REPO_ROOT = Path(__file__).parents[2]
+
+
+@pytest.fixture
+def configure_client_capabilities(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Configure initialize capabilities for a test client."""
+    original = types.ClientCapabilities
+
+    def client_capabilities(**kwargs: Any) -> types.ClientCapabilities:
+        kwargs["extensions"] = UI_EXTENSION
+        return original(**kwargs)
+
+    def configure(ui: bool) -> None:
+        # ClientSession has no hook for declaring initialize extensions.
+        monkeypatch.setattr(
+            types,
+            "ClientCapabilities",
+            client_capabilities if ui else original,
+        )
+
+    return configure
+
+
+def _http_app() -> Any:
+    """Build the in-process HTTP app, mirroring `http_main`'s stateless config."""
+    return app.http_app(
+        path="/mcp",
+        transport="streamable-http",
+        stateless_http=True,
+    )
+
+
+@asynccontextmanager
+async def _stdio_session(
+    *,
+    ui: bool,
+    configure_client_capabilities: Any,
+) -> AsyncIterator[ClientSession]:
+    configure_client_capabilities(ui)
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("AIRBYTE_MCP_")
+    }
+    parameters = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "airbyte.mcp.server"],
+        cwd=REPO_ROOT,
+        env=environment,
+    )
+    async with stdio_client(parameters) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            yield session
+
+
+@asynccontextmanager
+async def _http_session(
+    *,
+    headers: dict[str, str] | None,
+    configure_client_capabilities: Any,
+    wire_headers: list[list[tuple[bytes, bytes]]] | None = None,
+) -> AsyncIterator[ClientSession]:
+    configure_client_capabilities(False)
+    http_app = _http_app()
+
+    async def capture_request(request: httpx.Request) -> None:
+        if wire_headers is not None:
+            wire_headers.append(request.headers.raw)
+
+    async with http_app.router.lifespan_context(http_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=http_app),
+            base_url="http://testserver",
+            headers=headers,
+            event_hooks={"request": [capture_request]},
+        ) as http_client:
+            async with streamable_http_client(
+                "http://testserver/mcp",
+                http_client=http_client,
+            ) as (read_stream, write_stream, _):
+                async with ClientSession(read_stream, write_stream) as session:
+                    yield session
+
+
+async def _tool_names(session_factory: Any) -> set[str]:
+    async with session_factory as session:
+        await session.initialize()
+        result = await session.list_tools()
+        return {tool.name for tool in result.tools}
+
+
+@pytest.mark.parametrize("ui", [True, False], ids=["ui-client", "non-ui-client"])
+def test_stdio_ui_tool_visibility(
+    ui: bool,
+    configure_client_capabilities: Any,
+) -> None:
+    """Stdio uses initialize capabilities for UI tool visibility."""
+    names = asyncio.run(
+        _tool_names(
+            _stdio_session(
+                ui=ui,
+                configure_client_capabilities=configure_client_capabilities,
+            )
+        )
+    )
+    if ui:
+        assert UI_TOOL_NAMES <= names
+    else:
+        assert UI_TOOL_NAMES.isdisjoint(names)
+
+
+@pytest.mark.parametrize(
+    "headers, expected",
+    [
+        pytest.param(
+            {"x-mcp-extensions": "io.modelcontextprotocol/ui"},
+            True,
+            id="single-value",
+        ),
+        pytest.param(
+            {"x-mcp-extensions": "other, io.modelcontextprotocol/ui, another"},
+            True,
+            id="comma-separated",
+        ),
+        pytest.param(
+            {"x-mcp-extensions": "other"},
+            False,
+            id="unknown-extension",
+        ),
+        pytest.param({"x-mcp-extensions": " , "}, False, id="blank"),
+        pytest.param({}, False, id="missing-header"),
+    ],
+)
+def test_client_declared_extensions_from_headers(
+    headers: dict[str, str],
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Header extension parsing tolerates common HTTP formatting.
+
+    `get_http_headers()` lowercases header names, so the parser looks up the
+    lowercased key; end-to-end casing is covered by the HTTP visibility test.
+    """
+    monkeypatch.setattr(_tool_utils, "get_http_headers", lambda **_: headers)
+    extensions = _tool_utils._client_declared_extensions_from_headers()
+    assert ("io.modelcontextprotocol/ui" in extensions) is expected
+
+
+@pytest.mark.parametrize(
+    "headers, expected",
+    [
+        pytest.param(
+            {"x-McP-ExTeNsIoNs": "io.modelcontextprotocol/ui"},
+            True,
+            id="ui-header",
+        ),
+        pytest.param({}, False, id="no-header"),
+        pytest.param({"X-MCP-Extensions": " "}, False, id="blank-header"),
+    ],
+)
+def test_stateless_http_ui_tool_visibility(
+    headers: dict[str, str],
+    expected: bool,
+    configure_client_capabilities: Any,
+) -> None:
+    """Stateless HTTP uses the extension header without failing open."""
+    wire_headers: list[list[tuple[bytes, bytes]]] = []
+    names = asyncio.run(
+        _tool_names(
+            _http_session(
+                headers=headers,
+                configure_client_capabilities=configure_client_capabilities,
+                wire_headers=wire_headers,
+            )
+        )
+    )
+    assert (UI_TOOL_NAMES <= names) is expected
+    if expected:
+        assert any(
+            header_name == b"x-McP-ExTeNsIoNs"
+            for request_headers in wire_headers
+            for header_name, _ in request_headers
+        )

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -17,8 +17,14 @@ from mcp import types
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamable_http_client
+from starlette.middleware import Middleware
 
 from airbyte.mcp import _tool_utils
+from airbyte.mcp._capability_tokens import (
+    CapabilityTokenMiddleware,
+    decode_capability_token,
+    encode_capability_token,
+)
 from airbyte.mcp.server import app
 
 
@@ -55,6 +61,7 @@ def _http_app() -> Any:
     """Build the in-process HTTP app, mirroring `http_main`'s stateless config."""
     return app.http_app(
         path="/mcp",
+        middleware=[Middleware(CapabilityTokenMiddleware)],
         transport="streamable-http",
         stateless_http=True,
     )
@@ -88,21 +95,30 @@ async def _http_session(
     *,
     headers: dict[str, str] | None,
     configure_client_capabilities: Any,
+    ui: bool = False,
     wire_headers: list[list[tuple[bytes, bytes]]] | None = None,
+    response_headers: list[list[tuple[bytes, bytes]]] | None = None,
 ) -> AsyncIterator[ClientSession]:
-    configure_client_capabilities(False)
+    configure_client_capabilities(ui)
     http_app = _http_app()
 
     async def capture_request(request: httpx.Request) -> None:
         if wire_headers is not None:
             wire_headers.append(request.headers.raw)
 
+    async def capture_response(response: httpx.Response) -> None:
+        if response_headers is not None:
+            response_headers.append(response.headers.raw)
+
     async with http_app.router.lifespan_context(http_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=http_app),
             base_url="http://testserver",
             headers=headers,
-            event_hooks={"request": [capture_request]},
+            event_hooks={
+                "request": [capture_request],
+                "response": [capture_response],
+            },
         ) as http_client:
             async with streamable_http_client(
                 "http://testserver/mcp",
@@ -137,6 +153,88 @@ def test_stdio_ui_tool_visibility(
         assert UI_TOOL_NAMES <= names
     else:
         assert UI_TOOL_NAMES.isdisjoint(names)
+
+
+@pytest.mark.parametrize(
+    "extension_ids, expected",
+    [
+        pytest.param(
+            {"io.modelcontextprotocol/ui"},
+            {"io.modelcontextprotocol/ui"},
+            id="single-extension",
+        ),
+        pytest.param(
+            {"io.modelcontextprotocol/ui", "io.modelcontextprotocol/roots"},
+            {"io.modelcontextprotocol/ui", "io.modelcontextprotocol/roots"},
+            id="multiple-extensions",
+        ),
+        pytest.param(set(), set(), id="empty"),
+        pytest.param({"foo bar"}, set(), id="whitespace-containing-id"),
+        pytest.param({" \t\n"}, set(), id="all-whitespace-ids"),
+    ],
+)
+def test_capability_token_round_trip(
+    extension_ids: set[str],
+    expected: set[str],
+) -> None:
+    """Capability tokens round-trip extension IDs."""
+    token = encode_capability_token(extension_ids)
+    assert decode_capability_token(token) == expected
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        pytest.param("garbage", id="garbage"),
+        pytest.param(
+            "00000000000000000000000000000000.not-base64!",
+            id="non-base64",
+        ),
+        pytest.param("00000000-0000-0000-0000-000000000000", id="uuid-only"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_capability_token_decode_fails_closed(token: str) -> None:
+    """Malformed capability tokens do not expose extensions."""
+    assert decode_capability_token(token) == set()
+
+
+def test_stateless_http_initialize_capabilities_survive_via_session_token(
+    configure_client_capabilities: Any,
+) -> None:
+    """Stateless HTTP carries initialize extensions through the session token."""
+    names = asyncio.run(
+        _tool_names(
+            _http_session(
+                headers={},
+                ui=True,
+                configure_client_capabilities=configure_client_capabilities,
+            )
+        )
+    )
+    assert UI_TOOL_NAMES <= names
+
+
+def test_stateless_http_without_extensions_mints_no_session_token(
+    configure_client_capabilities: Any,
+) -> None:
+    """Clients without extensions receive no session token or UI tools."""
+    response_headers: list[list[tuple[bytes, bytes]]] = []
+    names = asyncio.run(
+        _tool_names(
+            _http_session(
+                headers={},
+                configure_client_capabilities=configure_client_capabilities,
+                response_headers=response_headers,
+            )
+        )
+    )
+    assert UI_TOOL_NAMES.isdisjoint(names)
+    assert all(
+        header_name.lower() != b"mcp-session-id"
+        for headers in response_headers
+        for header_name, _ in headers
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_http_main.py
+++ b/tests/unit_tests/test_mcp_http_main.py
@@ -10,12 +10,17 @@ canonicalize the connection URL to the slash-less form (`.../cloud-mcp`).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastmcp.server.auth import MultiAuth
 from fastmcp.server.auth.auth import TokenVerifier
 
 from airbyte.mcp import http_main
-from airbyte.mcp.http_main import _advertise_root_mount_resource
+from airbyte.mcp.http_main import (
+    _RejectEventStreamGetMiddleware,
+    _advertise_root_mount_resource,
+)
 
 
 _BASE_URL = "https://mcp.example.com/cloud-mcp"
@@ -105,3 +110,63 @@ def test_landing_version_url(
 
     assert http_main._landing_version_url() == expected
     assert http_main._landing_version_str() == f"v{installed}"
+
+
+@pytest.mark.parametrize(
+    ("accept", "expected_status", "expected_body"),
+    [
+        pytest.param(
+            b"text/event-stream",
+            405,
+            b"",
+            id="sse-get-is-rejected",
+        ),
+        pytest.param(
+            b"text/html,application/xhtml+xml",
+            200,
+            b"<title>Airbyte MCP Server</title>",
+            id="browser-get-reaches-landing-page",
+        ),
+    ],
+)
+def test_event_stream_get_content_negotiation(
+    accept: bytes,
+    expected_status: int,
+    expected_body: bytes,
+) -> None:
+    """SSE GETs are rejected while browser GETs reach the landing page."""
+    messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    async def landing_page(scope: object, receive: object, send: object) -> None:
+        del scope, receive
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/html")],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": b"<title>Airbyte MCP Server</title>",
+        })
+
+    middleware = _RejectEventStreamGetMiddleware(landing_page)
+    asyncio.run(
+        middleware(
+            {
+                "type": "http",
+                "method": "GET",
+                "headers": [(b"accept", accept)],
+            },
+            receive,
+            send,
+        )
+    )
+
+    assert messages[0]["status"] == expected_status
+    assert messages[1]["body"] == expected_body


### PR DESCRIPTION
Closes #1096.

Requested by AJ Steers.

## Summary

MCP Apps `interactive-ui` tools (`show_connectors_list`, `show_workspace_sync_status`, `show_connection_sync_history`) were visible to a UI-capable client over stdio but never over streamable HTTP. Reproduced: stdio 44 tools, HTTP 39.

Root cause: the hosted HTTP entrypoint runs `stateless_http=True`, and mcp's `StreamableHTTPSessionManager` builds a fresh `ServerSession` per request. By the time `tools/list` is served, `ServerSession._client_params is None`, so FastMCP's `client_supports_extension()` — which only reads `ClientCapabilities.extensions` captured at `initialize` — returns `False` and `airbyte_ui_support_filter` hides the tools. Nothing about the client is wrong; the capability simply doesn't survive to the request that needs it.

The server stays stateless (no session map, no `ContextVar`, no LB affinity requirement). Instead the declaration is carried *by the client*, through two additive signals:

```python
def _client_supports_ui() -> bool:
    # 1. session-declared capabilities: stdio (and stateful HTTP)
    context_supports_ui = _fastmcp_context_supports_ui(get_context())  # False if no context
    # 2. per-request declaration: stateless HTTP
    return context_supports_ui or UI_EXTENSION_ID in _client_declared_extensions_from_headers()


def _client_declared_extensions_from_headers() -> set[str]:
    headers = get_http_headers(include={MCP_EXTENSIONS_HEADER.lower(), "mcp-session-id"})
    return (
        decode_capability_token(headers.get("mcp-session-id", ""))          # self-describing token
        | set(headers.get(MCP_EXTENSIONS_HEADER.lower(), "").replace(",", " ").split())  # fallback header
    )
```

### The self-describing session token (works with off-the-shelf clients)

`CapabilityTokenMiddleware` sniffs the `initialize` POST body, reads `params.capabilities.extensions`, and — only if there is at least one usable extension ID — sets a response header:

```
Mcp-Session-Id: <uuid4hex>.<base64url("io.modelcontextprotocol/ui io.modelcontextprotocol/roots")>
```

The token *is* the data, not a lookup key: the spec says compliant clients MUST echo `Mcp-Session-Id` on subsequent requests, so each later request re-declares the capabilities with zero server-side state. Decoding fails closed (bad nonce, bad base64, foreign value → empty set, never raises), and a client that declares nothing gets no session ID at all.

This is what makes a standard MCP Apps host work with no client change. Verified end-to-end with Goose Desktop 1.36.0 over streamable HTTP and **no** custom header: 44 tools including all three `show_*`, widget rendered inline, filtering and row-click working. The same Goose build against `origin/main` sees 39 tools and no `show_*` (evidence in #1104).

### `X-MCP-Extensions` (fallback for clients that don't echo session IDs)

`X-MCP-Extensions: io.modelcontextprotocol/ui` on each request, comma-separated (whitespace tolerated). This is what the AG-UI client in airbytehq/airbyte-ops-mcp#1203 uses. It is unioned with the token, so a client whose token carries only unrelated extensions can still add `ui` per request.

### Why not `_meta`, and why an `X-` prefix

The spec-aligned stateless mechanism is per-request `_meta` under `io.modelcontextprotocol/clientCapabilities` (MCP 2026-07-28 / SEP-2575). It isn't reachable on this stack: `mcp` 1.x builds the server `RequestContext` from transport `message.request_meta`, not `params._meta`, so `get_context().request_context.meta` is `None` during a stateless `tools/list` even when the client sends it — and that key only exists in the `mcp` 2.x server architecture, which the `fastmcp` 3.x line pins away from. Shipping dead parsing would be worse than documenting the migration. There is also no standardized capability *header*, hence the `X-` prefix on ours. Both signals retire when `_meta` becomes reachable — `_client_supports_ui()` just gains a branch.

Upstream framing, if we file it: `client_supports_extension()` should fall back to the current request's `_meta[io.modelcontextprotocol/clientCapabilities]` when `_client_params` is `None`.

## Changes

- `airbyte/mcp/_capability_tokens.py` (new): `encode_capability_token()` / `decode_capability_token()` and `CapabilityTokenMiddleware`. Airbyte-agnostic by design — it lifts into `fastmcp-extensions` as a file move.
- `airbyte/mcp/_tool_utils.py`: `_client_supports_ui()` consults session capabilities, then the union of token and fallback-header declarations. Never fails open.
- `airbyte/constants.py`: `MCP_EXTENSIONS_HEADER = "X-MCP-Extensions"`.
- `airbyte/mcp/http_main.py`: installs the middleware, and `_RejectEventStreamGetMiddleware` answers `GET` requests asking for `text/event-stream` with `405` + `Allow: POST, DELETE`. Handing back a session ID makes spec-compliant clients open the standalone GET SSE stream, which would otherwise be served the browser landing page as `200 text/html`; browser GETs are unaffected.
- Docs in `airbyte/mcp/__init__.py` and `airbyte/mcp/http_main.py`.

Bounding notes worth knowing: the middleware sniffs at most 64 KiB (an `initialize` body is a few hundred bytes) — past that the request is streamed through untouched and mints nothing — and `http.disconnect` is handled by type rather than inferred from a missing `more_body`.

## Test plan

`tests/unit_tests/test_mcp_http.py` runs against a real in-process ASGI streamable-HTTP server plus a real stdio subprocess server:

- stdio, client declaring `extensions: {"io.modelcontextprotocol/ui": {}}` at initialize → all three `show_` tools; non-declaring client → none of them (`UI_TOOL_NAMES.isdisjoint(names)`).
- stateless HTTP declaring the UI extension at initialize with **no** custom header → all three visible (the token path).
- stateless HTTP with `X-MCP-Extensions` (sent mixed-case, asserted case-insensitively via an httpx event hook) → all three; no header → none.
- token codec: round-trip, whitespace-bearing and all-whitespace IDs dropped, malformed tokens (bad nonce, non-base64 payload, non-UUID4 nonce with valid payload) decode to the empty set.
- resolver: token carrying only `roots` plus `X-MCP-Extensions: io.modelcontextprotocol/ui` → both.
- middleware: over-cap body reaches the app byte-identical with no session ID minted; mid-body `http.disconnect` forwarded without minting.
- `tests/unit_tests/test_mcp_http_main.py`: `Accept: text/event-stream` GET → 405; browser GET → landing page HTML.

Real-process check on the merged branch (`airbyte-mcp-http`, UI extension declared at initialize, no custom header): `tool_count=44`, all three `show_*` present; browser `GET /mcp` → 200 with `<title>Airbyte MCP Server</title>` and the version footer; `GET /mcp` with `Accept: text/event-stream` → 405.

Local: `ruff format`, `ruff check`, `pyrefly check` clean; MCP unit suites 69 passed.


Link to Devin session: https://app.devin.ai/sessions/26b42c83920e467ea4a8242915c17dc7
Requested by: @aaronsteers