### PR TITLE
refactor(config): typed runtime settings via pydantic-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ By default, beginning with version `0.29.0`, PyAirbyte defaults to [`uv`](https:
 
 If you prefer to fall back to the prior `pip`-based installation methods, set the env var `AIRBYTE_NO_UV=true`.
 
+Non-secret runtime settings can also be configured in an optional `airbyte.yaml` or `airbyte.toml`
+file in the current working directory. Environment variables take precedence over file values, and
+file values take precedence over defaults. Credentials and other secrets continue to use PyAirbyte's
+secrets subsystem.
+
 #### Installing Connectors With a Custom Python Version
 
 In both `get_source()` and `get_destination()`, you can provide a `use_python` input arg that is equal to the desired version of Python that you with to use for the given connector. This can be helpful if an older connector doesn't support the version of Python that you are using for PyAirbyte itself.

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -72,7 +72,8 @@ DEFAULT_PROJECT_DIR: Path = _try_create_dir_if_missing(
 )
 """Default project directory.
 
-Can be overridden by setting the `AIRBYTE_PROJECT_DIR` environment variable.
+Values use `AIRBYTE_PROJECT_DIR`, then `project_dir` from `airbyte.yaml` or `airbyte.toml`, then
+the current working directory.
 
 If not set, defaults to the current working directory.
 
@@ -89,8 +90,8 @@ DEFAULT_INSTALL_DIR: Path = _try_create_dir_if_missing(
 )
 """Default install directory for connectors.
 
-If not set, defaults to `DEFAULT_PROJECT_DIR` (`AIRBYTE_PROJECT_DIR` env var) or the current
-working directory if neither is set.
+Values use `AIRBYTE_INSTALL_DIR`, then `install_dir` from `airbyte.yaml` or `airbyte.toml`, then
+`DEFAULT_PROJECT_DIR`.
 
 If a path is specified that does not yet exist, PyAirbyte will attempt to create it.
 """
@@ -101,7 +102,8 @@ DEFAULT_CACHE_ROOT: Path = (
 )
 """Default cache root is `.cache` in the current working directory.
 
-The default location can be overridden by setting the `AIRBYTE_CACHE_ROOT` environment variable.
+Values use `AIRBYTE_CACHE_ROOT`, then `cache_root` from `airbyte.yaml` or `airbyte.toml`, then the
+default `.cache` path.
 
 Overriding this can be useful if you always want to store cache files in a specific location.
 For example, in ephemeral environments like Google Colab, you might want to store cache files in
@@ -124,8 +126,8 @@ DEFAULT_ARROW_MAX_CHUNK_SIZE = 100_000
 TEMP_DIR_OVERRIDE: Path | None = _SETTINGS.temp_dir
 """The directory to use for temporary files.
 
-This value is read from the `AIRBYTE_TEMP_DIR` environment variable. If the variable is not set,
-Tempfile will use the system's default temporary directory.
+Values use `AIRBYTE_TEMP_DIR`, then `temp_dir` from `airbyte.yaml` or `airbyte.toml`, then the
+system's default temporary directory.
 
 This can be useful if you want to store temporary files in a specific location (or) when you
 need your temporary files to exist in user level directories, and not in system level
@@ -135,8 +137,8 @@ directories for permissions reasons.
 TEMP_FILE_CLEANUP = _SETTINGS.temp_file_cleanup
 """Whether to clean up temporary files after use.
 
-This value is read from the `AIRBYTE_TEMP_FILE_CLEANUP` environment variable. If the variable is
-not set, the default value is `True`.
+Values use `AIRBYTE_TEMP_FILE_CLEANUP`, then `temp_file_cleanup` from `airbyte.yaml` or
+`airbyte.toml`, then the default value `True`.
 """
 
 AIRBYTE_OFFLINE_MODE = _SETTINGS.offline_mode
@@ -147,11 +149,15 @@ Airbyte registry but will not raise an error if the registry is unavailable. Thi
 environments without internet access or with air-gapped networks.
 
 Offline mode also disables telemetry, similar to a `DO_NOT_TRACK` setting, ensuring no usage data
-is sent from your environment. You may also specify a custom registry URL via the`_REGISTRY_ENV_VAR`
-environment variable if you prefer to use a different registry source for metadata.
+is sent from your environment. You may also specify a custom registry URL via the
+`_REGISTRY_ENV_VAR` environment variable if you prefer to use a different registry source for
+metadata.
 
 This setting helps you make informed choices about data privacy and operation in restricted and
 air-gapped environments.
+
+Values use `AIRBYTE_OFFLINE_MODE`, then `offline_mode` from `airbyte.yaml` or `airbyte.toml`, then
+the default value `False`.
 """
 
 AIRBYTE_PRINT_FULL_ERROR_LOGS: bool = _SETTINGS.print_full_error_logs
@@ -162,6 +168,9 @@ the pipeline run.
 
 If not set, the default value is `False` for non-CI environments.
 If running in a CI environment ("CI" env var is set), then the default value is `True`.
+
+Values use `AIRBYTE_PRINT_FULL_ERROR_LOGS`, then `print_full_error_logs` from `airbyte.yaml` or
+`airbyte.toml`, then the `CI`-derived default.
 """
 
 NO_UV: bool = _SETTINGS.no_uv
@@ -173,6 +182,9 @@ is set to "1", "true", or "yes", uv will be disabled and pip will be used instea
 If the variable is not set or set to any other value, uv will be used by default.
 This provides a safe fallback mechanism for environments where uv is not available
 or causes issues.
+
+Values use `AIRBYTE_NO_UV`, then `no_uv` from `airbyte.yaml` or `airbyte.toml`, then the existing
+default.
 """
 
 SECRETS_HYDRATION_PREFIX = "secret_reference::"

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -1,14 +1,22 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
-"""Constants shared across the PyAirbyte codebase."""
+"""Constants shared across the PyAirbyte codebase.
+
+Non-secret runtime settings can be configured in optional ``airbyte.yaml`` or
+``airbyte.toml`` files in the current working directory. Environment variables
+override file values, and file values override defaults. Secret-shaped values
+remain resolved through :mod:`airbyte.secrets`.
+"""
 
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
+
+from airbyte.settings import Settings
 
 
 logger = logging.getLogger("airbyte")
+_SETTINGS = Settings()
 
 
 DEBUG_MODE = False  # Set to True to enable additional debug logging.
@@ -59,7 +67,7 @@ def _try_create_dir_if_missing(path: Path, desc: str = "specified") -> Path:
 
 
 DEFAULT_PROJECT_DIR: Path = _try_create_dir_if_missing(
-    Path(os.getenv("AIRBYTE_PROJECT_DIR", "") or Path.cwd()).expanduser().absolute(),
+    Path(_SETTINGS.project_dir or Path.cwd()).expanduser().absolute(),
     desc="project",
 )
 """Default project directory.
@@ -76,7 +84,7 @@ If a path is specified that does not yet exist, PyAirbyte will attempt to create
 
 
 DEFAULT_INSTALL_DIR: Path = _try_create_dir_if_missing(
-    Path(os.getenv("AIRBYTE_INSTALL_DIR", "") or DEFAULT_PROJECT_DIR).expanduser().absolute(),
+    Path(_SETTINGS.install_dir or DEFAULT_PROJECT_DIR).expanduser().absolute(),
     desc="install",
 )
 """Default install directory for connectors.
@@ -89,9 +97,7 @@ If a path is specified that does not yet exist, PyAirbyte will attempt to create
 
 
 DEFAULT_CACHE_ROOT: Path = (
-    (Path(os.getenv("AIRBYTE_CACHE_ROOT", "") or (DEFAULT_PROJECT_DIR / ".cache")))
-    .expanduser()
-    .absolute()
+    (Path(_SETTINGS.cache_root or (DEFAULT_PROJECT_DIR / ".cache"))).expanduser().absolute()
 )
 """Default cache root is `.cache` in the current working directory.
 
@@ -115,14 +121,7 @@ DEFAULT_ARROW_MAX_CHUNK_SIZE = 100_000
 """The default number of records to include in each batch of an Arrow dataset."""
 
 
-def _str_to_bool(value: str) -> bool:
-    """Convert a string value of an environment values to a boolean value."""
-    return bool(value) and value.lower() not in {"", "0", "false", "f", "no", "n", "off"}
-
-
-TEMP_DIR_OVERRIDE: Path | None = (
-    Path(os.environ["AIRBYTE_TEMP_DIR"]) if os.getenv("AIRBYTE_TEMP_DIR") else None
-)
+TEMP_DIR_OVERRIDE: Path | None = _SETTINGS.temp_dir
 """The directory to use for temporary files.
 
 This value is read from the `AIRBYTE_TEMP_DIR` environment variable. If the variable is not set,
@@ -133,24 +132,14 @@ need your temporary files to exist in user level directories, and not in system 
 directories for permissions reasons.
 """
 
-TEMP_FILE_CLEANUP = _str_to_bool(
-    os.getenv(
-        key="AIRBYTE_TEMP_FILE_CLEANUP",
-        default="true",
-    )
-)
+TEMP_FILE_CLEANUP = _SETTINGS.temp_file_cleanup
 """Whether to clean up temporary files after use.
 
 This value is read from the `AIRBYTE_TEMP_FILE_CLEANUP` environment variable. If the variable is
 not set, the default value is `True`.
 """
 
-AIRBYTE_OFFLINE_MODE = _str_to_bool(
-    os.getenv(
-        key="AIRBYTE_OFFLINE_MODE",
-        default="false",
-    )
-)
+AIRBYTE_OFFLINE_MODE = _SETTINGS.offline_mode
 """Enable or disable offline mode.
 
 When offline mode is enabled, PyAirbyte will attempt to fetch metadata for connectors from the
@@ -165,12 +154,7 @@ This setting helps you make informed choices about data privacy and operation in
 air-gapped environments.
 """
 
-AIRBYTE_PRINT_FULL_ERROR_LOGS: bool = _str_to_bool(
-    os.getenv(
-        key="AIRBYTE_PRINT_FULL_ERROR_LOGS",
-        default=os.getenv("CI", "false"),
-    )
-)
+AIRBYTE_PRINT_FULL_ERROR_LOGS: bool = _SETTINGS.print_full_error_logs
 """Whether to print full error logs when an error occurs.
 This setting helps in debugging by providing detailed logs when errors occur. This is especially
 helpful in ephemeral environments like CI/CD pipelines where log files may not be persisted after
@@ -180,7 +164,7 @@ If not set, the default value is `False` for non-CI environments.
 If running in a CI environment ("CI" env var is set), then the default value is `True`.
 """
 
-NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() not in {"1", "true", "yes"}
+NO_UV: bool = _SETTINGS.no_uv
 """Whether to use uv for Python package management.
 
 This value is determined by the `AIRBYTE_NO_UV` environment variable. When `AIRBYTE_NO_UV`

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 """Constants shared across the PyAirbyte codebase.
 
-Non-secret runtime settings can be configured in optional ``airbyte.yaml`` or
-``airbyte.toml`` files in the current working directory. Environment variables
+Non-secret runtime settings can be configured in optional `airbyte.yaml` or
+`airbyte.toml` files in the current working directory. Environment variables
 override file values, and file values override defaults. Secret-shaped values
-remain resolved through :mod:`airbyte.secrets`.
+remain resolved through `airbyte.secrets`.
 """
 
 from __future__ import annotations

--- a/airbyte/settings.py
+++ b/airbyte/settings.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 """Typed runtime settings for PyAirbyte.
 
-PyAirbyte reads these settings once when :mod:`airbyte.constants` is imported.
-Optional ``airbyte.yaml`` and ``airbyte.toml`` files in the current working
+PyAirbyte reads these settings once when `airbyte.constants` is imported.
+Optional `airbyte.yaml` and `airbyte.toml` files in the current working
 directory may provide values for the same settings. Environment variables take
 precedence over file values, and file values take precedence over defaults.
 
 This module intentionally contains only non-secret runtime settings. Cloud
 credentials, connector credentials, and other secret-shaped values continue to
-resolve through :mod:`airbyte.secrets`.
+resolve through `airbyte.secrets`.
 """
 
 from __future__ import annotations

--- a/airbyte/settings.py
+++ b/airbyte/settings.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Typed runtime settings for PyAirbyte.
+
+PyAirbyte reads these settings once when :mod:`airbyte.constants` is imported.
+Optional ``airbyte.yaml`` and ``airbyte.toml`` files in the current working
+directory may provide values for the same settings. Environment variables take
+precedence over file values, and file values take precedence over defaults.
+
+This module intentionally contains only non-secret runtime settings. Cloud
+credentials, connector credentials, and other secret-shaped values continue to
+resolve through :mod:`airbyte.secrets`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import AliasChoices, BeforeValidator, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+    YamlConfigSettingsSource,
+)
+
+
+def _str_to_bool(value: object) -> bool:
+    """Convert a value using PyAirbyte's legacy truthiness rules."""
+    if isinstance(value, bool):
+        return value
+    return bool(value) and str(value).lower() not in {"", "0", "false", "f", "no", "n", "off"}
+
+
+def _empty_path_to_none(value: object) -> object:
+    """Treat unset and empty path values as absent."""
+    if not value:
+        return None
+    return value
+
+
+def _parse_no_uv(value: object) -> bool:
+    """Preserve the inverted legacy AIRBYTE_NO_UV behavior."""
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() not in {"1", "true", "yes"}
+
+
+BoolSetting = Annotated[bool, BeforeValidator(_str_to_bool)]
+OptionalPathSetting = Annotated[Path | None, BeforeValidator(_empty_path_to_none)]
+NoUvSetting = Annotated[bool, BeforeValidator(_parse_no_uv)]
+
+
+class Settings(BaseSettings):
+    """Non-secret runtime settings loaded from environment or local config files."""
+
+    project_dir: OptionalPathSetting = None
+    install_dir: OptionalPathSetting = None
+    cache_root: OptionalPathSetting = None
+    temp_dir: OptionalPathSetting = None
+    temp_file_cleanup: BoolSetting = True
+    offline_mode: BoolSetting = False
+    print_full_error_logs: BoolSetting = Field(
+        default_factory=lambda: _str_to_bool(os.getenv("CI", "false")),
+        validation_alias=AliasChoices("AIRBYTE_PRINT_FULL_ERROR_LOGS", "print_full_error_logs"),
+    )
+    no_uv: NoUvSetting = True
+
+    model_config = SettingsConfigDict(
+        env_prefix="AIRBYTE_",
+        yaml_file=("airbyte.yaml",),
+        toml_file=("airbyte.toml",),
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Load local config files below environment and dotenv sources."""
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlConfigSettingsSource(settings_cls),
+            TomlConfigSettingsSource(settings_cls),
+            file_secret_settings,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyarrow>=16.1,<22.0",
     "pydantic>=2.0,<3.0",
     "pydantic-core",
+    "pydantic-settings[yaml]>=2.2,<3.0",
     "python-dotenv>=1.0.1,<2.0",
     "python-ulid>=3.0.0,<4.0",
     "pyyaml>=6.0.2,<7.0",

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -127,4 +127,4 @@ def test_empty_temp_dir_is_none_and_non_empty_value_is_a_path(
     assert Settings().temp_dir is None
 
     monkeypatch.setenv("AIRBYTE_TEMP_DIR", "/tmp/airbyte")
-    assert str(Settings().temp_dir) == "/tmp/airbyte"
+    assert Settings().temp_dir == Path("/tmp/airbyte")

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from airbyte.settings import Settings, _str_to_bool
+
+
+_SETTING_ENV_VARS = (
+    "AIRBYTE_PROJECT_DIR",
+    "AIRBYTE_INSTALL_DIR",
+    "AIRBYTE_CACHE_ROOT",
+    "AIRBYTE_TEMP_DIR",
+    "AIRBYTE_TEMP_FILE_CLEANUP",
+    "AIRBYTE_OFFLINE_MODE",
+    "AIRBYTE_PRINT_FULL_ERROR_LOGS",
+    "AIRBYTE_NO_UV",
+    "CI",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _SETTING_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("", False, id="empty"),
+        pytest.param("0", False, id="zero"),
+        pytest.param("false", False, id="false"),
+        pytest.param("FALSE", False, id="uppercase-false"),
+        pytest.param("f", False, id="f"),
+        pytest.param("no", False, id="no"),
+        pytest.param("n", False, id="n"),
+        pytest.param("off", False, id="off"),
+        pytest.param("yes", True, id="yes"),
+        pytest.param("random", True, id="random"),
+    ],
+)
+def test_str_to_bool_preserves_legacy_truthiness(value: str, expected: bool) -> None:
+    assert _str_to_bool(value) is expected
+
+
+def test_missing_config_files_use_defaults(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    settings = Settings()
+
+    assert settings.project_dir is None
+    assert settings.cache_root is None
+    assert settings.temp_file_cleanup is True
+    assert settings.offline_mode is False
+    assert settings.print_full_error_logs is False
+
+
+def test_config_file_values_are_loaded_and_environment_wins(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "airbyte.yaml").write_text(
+        "offline_mode: false\ncache_root: /from-file\nprint_full_error_logs: false\n"
+    )
+    monkeypatch.setenv("AIRBYTE_OFFLINE_MODE", "true")
+    monkeypatch.setenv("AIRBYTE_CACHE_ROOT", "/from-env")
+
+    settings = Settings()
+
+    assert settings.offline_mode is True
+    assert settings.cache_root == Path("/from-env")
+    assert settings.print_full_error_logs is False
+
+
+def test_toml_config_file_values_are_loaded(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "airbyte.toml").write_text(
+        'offline_mode = true\ncache_root = "/from-toml"\n'
+    )
+
+    settings = Settings()
+
+    assert settings.offline_mode is True
+    assert settings.cache_root == Path("/from-toml")
+
+
+def test_ci_controls_print_full_error_logs_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI", "yes")
+
+    assert Settings().print_full_error_logs is True
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("1", False, id="one"),
+        pytest.param("true", False, id="true"),
+        pytest.param("yes", False, id="yes"),
+        pytest.param("false", True, id="false"),
+        pytest.param("", True, id="empty"),
+    ],
+)
+def test_no_uv_preserves_inverted_environment_behavior(
+    value: str,
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_NO_UV", value)
+
+    assert Settings().no_uv is expected
+
+
+def test_empty_temp_dir_is_none_and_non_empty_value_is_a_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIRBYTE_TEMP_DIR", "")
+    assert Settings().temp_dir is None
+
+    monkeypatch.setenv("AIRBYTE_TEMP_DIR", "/tmp/airbyte")
+    assert str(Settings().temp_dir) == "/tmp/airbyte"

--- a/uv.lock
+++ b/uv.lock
@@ -149,6 +149,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-core" },
+    { name = "pydantic-settings", extra = ["yaml"] },
     { name = "python-dotenv" },
     { name = "python-ulid" },
     { name = "pyyaml" },
@@ -216,6 +217,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=16.1,<22.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pydantic-core" },
+    { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.2,<3.0" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0" },
     { name = "python-ulid", specifier = ">=3.0.0,<4.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0" },
@@ -3144,6 +3146,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[package.optional-dependencies]
+yaml = [
+    { name = "pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Requested by AJ (@aaronsteers) as the PyAirbyte counterpart to airbytehq/airbyte-ops-mcp#1213: replace hand-rolled `os.getenv` parsing with a typed `pydantic-settings` model, and get optional file-based config for free.

Scope is deliberately narrow — **only the eight non-secret runtime settings** that `airbyte/constants.py` reads at import time: `AIRBYTE_PROJECT_DIR`, `AIRBYTE_INSTALL_DIR`, `AIRBYTE_CACHE_ROOT`, `AIRBYTE_TEMP_DIR`, `AIRBYTE_TEMP_FILE_CLEANUP`, `AIRBYTE_OFFLINE_MODE`, `AIRBYTE_PRINT_FULL_ERROR_LOGS`, `AIRBYTE_NO_UV`. Nothing in `airbyte/secrets/`, `airbyte/cloud/`, `airbyte/mcp/`, or telemetry is touched: credential-shaped values keep resolving through `get_secret()` / the secrets subsystem, and a settings model must not shadow that.

New `airbyte/settings.py`:

```python
class Settings(BaseSettings):
    project_dir: OptionalPathSetting = None
    cache_root: OptionalPathSetting = None
    temp_file_cleanup: BoolSetting = True
    offline_mode: BoolSetting = False
    print_full_error_logs: BoolSetting = Field(
        default_factory=lambda: _str_to_bool(os.getenv("CI", "false")),
        validation_alias=AliasChoices("AIRBYTE_PRINT_FULL_ERROR_LOGS", "print_full_error_logs"),
    )
    no_uv: NoUvSetting = True
    ...
    model_config = SettingsConfigDict(
        env_prefix="AIRBYTE_",
        yaml_file=("airbyte.yaml",),
        toml_file=("airbyte.toml",),
    )
```

`constants.py` constructs one `Settings()` at import and each public constant derives from it, so the existing import-time-snapshot semantics are unchanged — several tests and `conftest.py` depend on those constants being frozen at import, so nothing here became lazy or dynamic.

**User-visible addition:** an optional `airbyte.yaml` / `airbyte.toml` in the working directory. Precedence is **env var > config file > default**, verified empirically; a missing file is tolerated (the native sources check `Path.is_file()`).

## Behavior preserved exactly

This is a refactor, so the quirks were kept rather than fixed:

1. `_str_to_bool` is not pydantic's bool parser — `""`/`0`/`false`/`f`/`no`/`n`/`off` are false and *anything else* is true, so `AIRBYTE_OFFLINE_MODE=yes` still works. It moves to `settings.py` as a `BeforeValidator`.
2. **`NO_UV` is inverted relative to its name**: it is `True` unless `AIRBYTE_NO_UV` is `1`/`true`/`yes`, i.e. it defaults to `True`, which contradicts its own docstring. Preserved as-is and pinned with a characterization test — worth a separate look, not a drive-by fix here.
3. `TEMP_DIR_OVERRIDE` is `None` when the var is unset *or* empty.
4. `AIRBYTE_PRINT_FULL_ERROR_LOGS` still defaults from the unprefixed `CI` var (`env_prefix` can't express that, hence the explicit `default_factory`).
5. `DEFAULT_INSTALL_DIR` still chains off the resolved `DEFAULT_PROJECT_DIR`, `DEFAULT_CACHE_ROOT` off `<project>/.cache`, and `_try_create_dir_if_missing` keeps its directory-creation and warning behavior in `constants.py`.

`airbyte/logs.py` keeps its own identical private `_str_to_bool` copy; de-duplicating it is out of scope here.

## Test plan

New `tests/unit_tests/test_settings.py` covers missing config files, YAML and TOML loading, env-over-file precedence, the `_str_to_bool` truthiness table, the `CI`-derived default, the `NO_UV` inversion, and empty/non-empty temp dir values.

`uv run pytest -q tests/unit_tests/` (456 passed, 1 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyrefly check` (0 errors), `uv run deptry . --config pyproject.toml`, `uv lock --check`.


Link to Devin session: https://app.devin.ai/sessions/9b54bbbb80a945d99ce92c8940d41503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `airbyte.yaml` and `airbyte.toml` runtime configuration support.
  * Added configurable project, installation, cache, temporary-directory, cleanup, offline-mode, logging, and UV settings.
  * Environment variables take precedence over configuration files, with defaults used as a fallback.
  * CI environments can automatically enable full error logs.

* **Documentation**
  * Documented runtime configuration options and precedence rules.
  * Clarified that secrets remain managed separately by PyAirbyte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->