### PR TITLE
fix(config): use uv by default and honor AIRBYTE_NO_UV

### DIFF
--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -181,7 +181,7 @@ If running in a CI environment ("CI" env var is set), then the default value is 
 """
 
 NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() in {"1", "true", "yes"}
-"""Whether to use uv for Python package management.
+"""Whether to disable uv and use pip for Python package management.
 
 This value is determined by the `AIRBYTE_NO_UV` environment variable. When `AIRBYTE_NO_UV`
 is set to "1", "true", or "yes", pip will be used instead of uv.

--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -180,15 +180,14 @@ If not set, the default value is `False` for non-CI environments.
 If running in a CI environment ("CI" env var is set), then the default value is `True`.
 """
 
-NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() not in {"1", "true", "yes"}
+NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() in {"1", "true", "yes"}
 """Whether to use uv for Python package management.
 
 This value is determined by the `AIRBYTE_NO_UV` environment variable. When `AIRBYTE_NO_UV`
-is set to "1", "true", or "yes", uv will be disabled and pip will be used instead.
+is set to "1", "true", or "yes", pip will be used instead of uv.
 
-If the variable is not set or set to any other value, uv will be used by default.
-This provides a safe fallback mechanism for environments where uv is not available
-or causes issues.
+If the variable is not set or set to any other value, uv will be used by default. Set this
+variable to opt out of uv and use pip instead.
 """
 
 SECRETS_HYDRATION_PREFIX = "secret_reference::"

--- a/tests/unit_tests/test_constants.py
+++ b/tests/unit_tests/test_constants.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -40,6 +41,7 @@ def test_no_uv_environment_mapping(env_value: str | None, expected_no_uv: bool) 
         capture_output=True,
         text=True,
         env=environment,
+        cwd=Path(__file__).parents[2],
     )
 
     assert result.stdout.strip() == str(expected_no_uv)

--- a/tests/unit_tests/test_constants.py
+++ b/tests/unit_tests/test_constants.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_no_uv"),
+    [
+        pytest.param(None, False, id="unset"),
+        pytest.param("1", True, id="one"),
+        pytest.param("true", True, id="true"),
+        pytest.param("TRUE", True, id="mixed-case-true"),
+        pytest.param("YeS", True, id="mixed-case-yes"),
+        pytest.param("0", False, id="zero"),
+        pytest.param("false", False, id="false"),
+        pytest.param("no", False, id="no"),
+        pytest.param("other", False, id="other"),
+    ],
+)
+def test_no_uv_environment_mapping(env_value: str | None, expected_no_uv: bool) -> None:
+    """Verify `AIRBYTE_NO_UV` opts out of uv only for explicit truthy values."""
+    environment = os.environ.copy()
+    if env_value is None:
+        environment.pop("AIRBYTE_NO_UV", None)
+    else:
+        environment["AIRBYTE_NO_UV"] = env_value
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from airbyte.constants import NO_UV; print(NO_UV)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.stdout.strip() == str(expected_no_uv)


### PR DESCRIPTION
## Summary

`AIRBYTE_NO_UV` has been wired backwards since a2b051e ("feat: replace pip with uv"), with the practical result that **PyAirbyte has been installing connectors with pip, not uv, in the default configuration** — the opposite of that PR's stated goal and of the constant's own docstring.

The mapping is off by one `not`:

```python
# before — unset env var yields NO_UV = True
NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() not in {"1", "true", "yes"}

# after — unset env var yields NO_UV = False
NO_UV: bool = os.getenv("AIRBYTE_NO_UV", "").lower() in {"1", "true", "yes"}
```

Every consumer already reads the constant the natural way (`airbyte/_executors/python.py`, `airbyte/validate.py`):

```python
uv_cmd_prefix = ["uv"] if not NO_UV else []
```

so `NO_UV = True` by default meant the `uv` prefix was never applied and the venv/install fell back to `sys.executable -m venv` and `pip`. No consumer logic changes here; only the environment-variable mapping does.

Behavior table:

| `AIRBYTE_NO_UV` | before | after |
| --- | --- | --- |
| unset (default) | pip | **uv** |
| `1` / `true` / `yes` | uv | pip |
| `0` / `false` / anything else | pip | uv |

`uv>=0.5.0,<0.9.0` is a direct runtime dependency, so uv is always present and the new default cannot fail for lack of the binary.

Note for reviewers: `tests/conftest.py` sets `AIRBYTE_NO_UV=1` for its `use_uv=False` parametrization. Under the old mapping that case was silently exercising uv, and its `use_uv=True` counterpart was exercising pip — the two connector-install paths were swapped. This fix makes both match their names, so it also restores the intended test coverage rather than just flipping a default.

## Test plan

`tests/unit_tests/test_constants.py` pins the corrected mapping across unset, `1`, `true`, `TRUE`, `YeS`, `0`, `false`, `no`, and an arbitrary value. Each case runs in a subprocess because `NO_UV` is evaluated at import time and cannot be re-read by monkeypatching the environment in-process.

Local: `uv run pytest -q tests/unit_tests/` (445 passed, 1 skipped), `ruff check`, `ruff format --check`, `pyrefly check` all clean.

## Related

Conflicts textually with https://github.com/airbytehq/PyAirbyte/pull/1098, which rewrites the same line to load from `pydantic-settings` and pins the *old* inverted behavior in a characterization test. Whichever lands second needs a rebase; if this one lands first, that characterization test should be updated to assert the corrected mapping.


Link to Devin session: https://app.devin.ai/sessions/9b54bbbb80a945d99ce92c8940d41503
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of the `AIRBYTE_NO_UV` setting so recognized truthy values consistently disable uv and use pip.
  * Improved behavior for unset, falsy, and unrecognized setting values.

* **Tests**
  * Added coverage for environment-variable parsing across supported and miscellaneous values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._