### PR TITLE
ci: gate the cloud-mcp preview dispatch on the simple index, not the JSON API

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -115,15 +115,22 @@ jobs:
           PYPI_VERSION: ${{ steps.resolve-pyairbyte-requirement.outputs.version }}
         run: |
           set -euo pipefail
+          wheel="airbyte-${PYPI_VERSION}-py3-none-any.whl"
+          sdist="airbyte-${PYPI_VERSION}.tar.gz"
           attempt=1
-          while [ "$attempt" -le 30 ] && ! curl --fail --silent --show-error \
-            --output /dev/null "https://pypi.org/pypi/airbyte/$PYPI_VERSION/json"; do
-            echo "PyPI version $PYPI_VERSION is not available yet (attempt $attempt/30)."
+          while [ "$attempt" -le 30 ]; do
+            simple_index="$(curl --fail --silent --show-error \
+              "https://pypi.org/simple/airbyte/")"
+            if grep -Fq ">${wheel}<" <<<"$simple_index" \
+              && grep -Fq ">${sdist}<" <<<"$simple_index"; then
+              break
+            fi
+            echo "PyPI artifacts for version $PYPI_VERSION are not available in the simple index yet (attempt $attempt/30)."
             sleep 10
             attempt=$((attempt + 1))
           done
           [ "$attempt" -le 30 ] \
-            || { echo "::error::PyPI version $PYPI_VERSION did not become available after 30 attempts."; exit 1; }
+            || { echo "::error::PyPI artifacts for version $PYPI_VERSION did not become available in the simple index after 30 attempts."; exit 1; }
 
       - name: Build cloud-mcp dispatch payload
         id: build-client-payload

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -119,8 +119,10 @@ jobs:
           sdist="airbyte-${PYPI_VERSION}.tar.gz"
           attempt=1
           while [ "$attempt" -le 30 ]; do
-            simple_index="$(curl --fail --silent --show-error \
-              "https://pypi.org/simple/airbyte/")"
+            if ! simple_index="$(curl --fail --silent --show-error \
+              "https://pypi.org/simple/airbyte/")"; then
+              simple_index=""
+            fi
             if grep -Fq ">${wheel}<" <<<"$simple_index" \
               && grep -Fq ">${sdist}<" <<<"$simple_index"; then
               break


### PR DESCRIPTION
## Summary

The preview-deploy gate waited on the wrong PyPI surface, so it let a publish through before installers could see it. Observed on the `0.53.4.dev11003` prerelease: the wait step passed, and the ops-repo build ~60s later failed with

```text
Because there is no version of airbyte==0.53.4.dev11003 and you require
airbyte==0.53.4.dev11003, we can conclude that your requirements are unsatisfiable.
```

`https://pypi.org/pypi/<pkg>/<version>/json` becomes available before `https://pypi.org/simple/<pkg>/` does, and the simple index is what `uv`/`pip` resolve against. A retry ~2min later installed the identical pin cleanly, and the exact pin resolves locally with and without `--prerelease=allow`, ruling out prerelease exclusion as the cause.

So the gate now polls the surface the consumer actually reads, and requires both artifacts rather than a version entry:

```diff
-  curl --fail ... "https://pypi.org/pypi/airbyte/$PYPI_VERSION/json"
+  simple_index="$(curl --fail ... "https://pypi.org/simple/airbyte/")"
+  grep -Fq ">airbyte-${PYPI_VERSION}-py3-none-any.whl<" ... && grep -Fq ">airbyte-${PYPI_VERSION}.tar.gz<" ...
```

Matching on `>filename<` rather than a bare version substring, so `0.53.4` can't be satisfied by `0.53.40`. Retry bound and timeout behavior are unchanged.


Link to Devin session: https://app.devin.ai/sessions/76c65878862a4f7f9cfdb6de7f72e4ee
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publication verification by confirming both wheel and source distribution files are available.
  * Added polling to handle delays before newly published packages appear in the package index.
  * Retained retry limits and failure handling for unsuccessful publication checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._