### PR TITLE
ci: gate cloud-mcp dispatch on uv resolution, not the HTML simple index

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -132,7 +132,9 @@ jobs:
               break
             fi
             echo "$PYPI_REQUIREMENT is not resolvable from PyPI yet (attempt $attempt/30)."
-            sleep 10
+            if [ "$attempt" -lt 30 ]; then
+              sleep 10
+            fi
             attempt=$((attempt + 1))
           done
           [ "$attempt" -le 30 ] \

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -126,7 +126,7 @@ jobs:
           set -euo pipefail
           attempt=1
           while [ "$attempt" -le 30 ]; do
-            if uv pip compile --quiet --no-cache --no-deps \
+            if uv pip compile --quiet --no-cache --no-deps --python-version 3.12 \
               --output-file "$RUNNER_TEMP/pyairbyte-requirement.txt" - \
               <<<"$PYPI_REQUIREMENT"; then
               break

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -110,29 +110,33 @@ jobs:
           echo "version=$version" | tee -a "$GITHUB_OUTPUT"
           echo "requirement=airbyte==$version" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Wait for PyAirbyte version on PyPI
+      - name: Install uv
+        uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
+        with:
+          enable-cache: false
+
+      # Gate on `uv` itself: it reads the PEP 691 JSON variant of the simple
+      # index, which PyPI caches separately (`vary: Accept`) from the HTML one
+      # and which can stay stale for far longer. Polling anything else can go
+      # green while the cloud-mcp image build still cannot resolve the version.
+      - name: Wait for PyAirbyte version to be resolvable
         env:
-          PYPI_VERSION: ${{ steps.resolve-pyairbyte-requirement.outputs.version }}
+          PYPI_REQUIREMENT: ${{ steps.resolve-pyairbyte-requirement.outputs.requirement }}
         run: |
           set -euo pipefail
-          wheel="airbyte-${PYPI_VERSION}-py3-none-any.whl"
-          sdist="airbyte-${PYPI_VERSION}.tar.gz"
           attempt=1
           while [ "$attempt" -le 30 ]; do
-            if ! simple_index="$(curl --fail --silent --show-error \
-              "https://pypi.org/simple/airbyte/")"; then
-              simple_index=""
-            fi
-            if grep -Fq ">${wheel}<" <<<"$simple_index" \
-              && grep -Fq ">${sdist}<" <<<"$simple_index"; then
+            if uv pip compile --quiet --no-cache --no-deps \
+              --output-file "$RUNNER_TEMP/pyairbyte-requirement.txt" - \
+              <<<"$PYPI_REQUIREMENT"; then
               break
             fi
-            echo "PyPI artifacts for version $PYPI_VERSION are not available in the simple index yet (attempt $attempt/30)."
+            echo "$PYPI_REQUIREMENT is not resolvable from PyPI yet (attempt $attempt/30)."
             sleep 10
             attempt=$((attempt + 1))
           done
           [ "$attempt" -le 30 ] \
-            || { echo "::error::PyPI artifacts for version $PYPI_VERSION did not become available in the simple index after 30 attempts."; exit 1; }
+            || { echo "::error::$PYPI_REQUIREMENT did not become resolvable from PyPI after 30 attempts."; exit 1; }
 
       - name: Build cloud-mcp dispatch payload
         id: build-client-payload


### PR DESCRIPTION
## Summary

The cloud-mcp preview deploy is still failing after airbytehq/PyAirbyte#1101 — twice since it merged, on v0.54.0 and v0.54.1 — with `Because there is no version of airbyte==0.54.1 ...` in the image build. The gate passes in about four seconds and dispatches anyway.

Cause: it polls a different cache object than the thing that has to resolve the version. `#1101` gates on the **HTML** simple index via `curl`; `uv` requests the PEP 691 **JSON** variant, and PyPI responds `vary: Accept` with `cache-control: max-age=600`, so those are two independently cached objects. Measured roughly 40 minutes after v0.54.1 published:

```console
$ curl -s https://pypi.org/simple/airbyte/ | grep -c 0.54.1
2                                    # HTML: present within seconds
$ curl -sH 'Accept: application/vnd.pypi.simple.v1+json' https://pypi.org/simple/airbyte/ \
    | jq '.versions | index("0.54.1")'
null                                 # JSON: still absent
$ # same request with a cache-busting query param -> present
```

So the diagnosis in `#1101` was right that `pypi.org/pypi/airbyte/json` is untrustworthy (it still reported `0.54.0` at that point too); the mistake was assuming the HTML index is what the resolver reads.

Fix: ask the resolver itself, which is the only honest oracle here.

```diff
-wheel="airbyte-${PYPI_VERSION}-py3-none-any.whl"
-...
-curl --fail --silent "https://pypi.org/simple/airbyte/" | grep -Fq ">${wheel}<"
+uv pip compile --quiet --no-cache --no-deps \
+  --output-file "$RUNNER_TEMP/pyairbyte-requirement.txt" - <<<"$PYPI_REQUIREMENT"
```

Same bounded 30-attempt / 10-second loop and the same hard failure if it never lands. `--no-deps` keeps it a pure "can this exact version be resolved" question, so an unrelated dependency-resolution hiccup can't wedge a release; `--no-cache` keeps a local `uv` cache from answering for PyPI.

The other half of this — the image build resolving a stale index on its own runner — is https://github.com/airbytehq/airbyte-ops-mcp/pull/1256.

Verified locally against the real index: `airbyte==0.54.0` exits 0, `airbyte==99.99.99` exits 1.


Link to Devin session: https://app.devin.ai/sessions/a5b9501ef92c412aad0408b7c74ef9c8
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment reliability by verifying required package availability before installation.
  * Deployments now wait for dependency resolution for up to five minutes and provide a clear failure when requirements remain unavailable.
  * This reduces transient deployment failures caused by newly published packages not yet being ready for installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**