### PR TITLE
feat(mcp): carry client UI extension through stateless HTTP sessions

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -224,13 +224,18 @@ set; the interactive path activates once the OIDC client credentials are set.
   `AIRBYTE_MCP_AUTH_ALGORITHM` — expected `iss` / `aud` claims and signing
   algorithm.
 
-For stateless HTTP clients that need MCP Apps `interactive-ui` tools, the
-spec-aligned mechanism is per-request `_meta` under
-`io.modelcontextprotocol/clientCapabilities`, but FastMCP does not yet surface
-that metadata to tool filtering (as of `fastmcp` 3.4.5). Until it does, send the
+For stateless HTTP clients that need MCP Apps `interactive-ui` tools, clients
+that declare extensions at initialize receive a self-describing `Mcp-Session-Id`
+which spec-compliant clients echo on subsequent requests. Clients that do not
+echo session IDs can use the explicit fallback
 `X-MCP-Extensions: io.modelcontextprotocol/ui` header on each request instead.
-Multiple extension IDs may be comma-separated (recommended) or whitespace-
-separated.
+Multiple extension IDs may be comma-separated (recommended) or
+whitespace-separated.
+
+The eventual spec-aligned replacement is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
+`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
+using it requires a stack migration rather than a version-only change.
 
 With no auth variables set, the HTTP server falls back to unauthenticated local
 behavior. This server maps the `AIRBYTE_MCP_*` variables into the typed config

--- a/airbyte/mcp/_capability_tokens.py
+++ b/airbyte/mcp/_capability_tokens.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Self-describing capability tokens for stateless MCP HTTP transport."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_TOKEN_SEPARATOR = "."
+_SESSION_HEADER = b"mcp-session-id"
+_BASE64URL_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_HTTP_REQUEST = "http"
+_HTTP_REQUEST_MESSAGE = "http.request"
+_HTTP_RESPONSE_START = "http.response.start"
+_HTTP_REQUEST_METHOD = "method"
+_HTTP_REQUEST_BODY = "body"
+_HTTP_REQUEST_MORE_BODY = "more_body"
+_HTTP_RESPONSE_HEADERS = "headers"
+_UUID4_VERSION = 4
+
+
+def encode_capability_token(extension_ids: AbstractSet[str]) -> str:
+    """Encode extension IDs as a visible-ASCII capability token.
+
+    The token contains a random UUID4 component and a base64url-encoded,
+    space-separated payload. An empty extension set returns an empty string.
+    """
+    normalized_ids = sorted(extension_id for extension_id in extension_ids if extension_id)
+    if not normalized_ids:
+        return ""
+    payload = " ".join(normalized_ids).encode("utf-8")
+    encoded_payload = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{uuid.uuid4().hex}{_TOKEN_SEPARATOR}{encoded_payload}"
+
+
+def decode_capability_token(token: str) -> set[str]:
+    """Decode extension IDs from a capability token, failing closed on errors."""
+    if not token or _TOKEN_SEPARATOR not in token:
+        return set()
+
+    nonce, encoded_payload = token.split(_TOKEN_SEPARATOR, maxsplit=1)
+    if not _is_uuid4_hex(nonce) or not encoded_payload:
+        return set()
+    if not _BASE64URL_PATTERN.fullmatch(encoded_payload):
+        return set()
+
+    try:
+        padding = "=" * (-len(encoded_payload) % 4)
+        payload = base64.urlsafe_b64decode(encoded_payload + padding).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return set()
+
+    extension_ids = payload.split()
+    if not extension_ids or any(
+        not extension_id or any(char.isspace() for char in extension_id)
+        for extension_id in extension_ids
+    ):
+        return set()
+    return set(extension_ids)
+
+
+def _is_uuid4_hex(value: str) -> bool:
+    try:
+        parsed = uuid.UUID(hex=value)
+    except ValueError:
+        return False
+    return parsed.hex == value.lower() and parsed.version == _UUID4_VERSION
+
+
+def _mapping(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _initialize_extension_ids(body: bytes) -> set[str]:
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return set()
+
+    payload_mapping = _mapping(payload)
+    if payload_mapping is None or payload_mapping.get("method") != "initialize":
+        return set()
+    params = _mapping(payload_mapping.get("params"))
+    capabilities = _mapping(params.get("capabilities")) if params is not None else None
+    extensions = _mapping(capabilities.get("extensions")) if capabilities is not None else None
+    if extensions is None:
+        return set()
+    return {
+        extension_id
+        for extension_id in extensions
+        if isinstance(extension_id, str) and extension_id
+    }
+
+
+class CapabilityTokenMiddleware:
+    """Carry initialize extension declarations through stateless HTTP requests."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != _HTTP_REQUEST or scope.get(_HTTP_REQUEST_METHOD) != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        body_parts: list[bytes] = []
+        while True:
+            message = await receive()
+            body_parts.append(message.get(_HTTP_REQUEST_BODY, b""))
+            if not message.get(_HTTP_REQUEST_MORE_BODY, False):
+                break
+        body = b"".join(body_parts)
+        extension_ids = _initialize_extension_ids(body)
+        token = encode_capability_token(extension_ids)
+        replayed = False
+
+        async def replay_receive() -> Message:
+            nonlocal replayed
+            if replayed:
+                return await receive()
+            replayed = True
+            return {
+                "type": _HTTP_REQUEST_MESSAGE,
+                "body": body,
+                "more_body": False,
+            }
+
+        async def send_response(message: Message) -> None:
+            if (
+                message.get("type") == _HTTP_RESPONSE_START
+                and token
+                and isinstance(message.get(_HTTP_RESPONSE_HEADERS), list)
+            ):
+                headers = [
+                    (name, value)
+                    for name, value in message[_HTTP_RESPONSE_HEADERS]
+                    if name.lower() != _SESSION_HEADER
+                ]
+                headers.append((_SESSION_HEADER, token.encode("ascii")))
+                message = {**message, _HTTP_RESPONSE_HEADERS: headers}
+            await send(message)
+
+        await self.app(scope, replay_receive, send_response)

--- a/airbyte/mcp/_capability_tokens.py
+++ b/airbyte/mcp/_capability_tokens.py
@@ -35,7 +35,11 @@ def encode_capability_token(extension_ids: AbstractSet[str]) -> str:
     The token contains a random UUID4 component and a base64url-encoded,
     space-separated payload. An empty extension set returns an empty string.
     """
-    normalized_ids = sorted(extension_id for extension_id in extension_ids if extension_id)
+    normalized_ids = sorted(
+        extension_id
+        for extension_id in extension_ids
+        if extension_id and not any(char.isspace() for char in extension_id)
+    )
     if not normalized_ids:
         return ""
     payload = " ".join(normalized_ids).encode("utf-8")
@@ -61,10 +65,7 @@ def decode_capability_token(token: str) -> set[str]:
         return set()
 
     extension_ids = payload.split()
-    if not extension_ids or any(
-        not extension_id or any(char.isspace() for char in extension_id)
-        for extension_id in extension_ids
-    ):
+    if not extension_ids:
         return set()
     return set(extension_ids)
 

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -62,6 +62,7 @@ from airbyte.constants import (
     MCP_WORKSPACE_ID_HEADER,
 )
 from airbyte.exceptions import PyAirbyteInputError
+from airbyte.mcp._capability_tokens import decode_capability_token
 
 
 if TYPE_CHECKING:
@@ -521,10 +522,9 @@ def airbyte_ui_support_filter(tool: Tool, _app: FastMCP) -> bool:
 def _client_supports_ui() -> bool:
     """Return whether the current client declared MCP Apps UI support.
 
-    Stateless streamable HTTP discards initialize-time `ClientCapabilities`, so
-    HTTP clients can declare extensions through the fallback request header.
-    There is no standardized MCP header for this today; the Airbyte server
-    accepts the non-standard `X-MCP-Extensions` header.
+    Stateless streamable HTTP carries initialize-time extensions in a
+    self-describing `Mcp-Session-Id` when the client supports session IDs.
+    `X-MCP-Extensions` remains an explicit fallback for clients that do not.
     """
     try:
         context = get_context()
@@ -540,7 +540,10 @@ def _fastmcp_context_supports_ui(context: Context) -> bool:
 
 
 def _client_declared_extensions_from_headers() -> set[str]:
-    """Return comma- or whitespace-separated extension IDs from HTTP headers."""
-    header_key = MCP_EXTENSIONS_HEADER.lower()
-    header_value = get_http_headers(include={header_key}).get(header_key, "")
+    """Return extension IDs from the session token or fallback HTTP header."""
+    headers = get_http_headers(include={MCP_EXTENSIONS_HEADER.lower(), "mcp-session-id"})
+    session_extensions = decode_capability_token(headers.get("mcp-session-id", ""))
+    if session_extensions:
+        return session_extensions
+    header_value = headers.get(MCP_EXTENSIONS_HEADER.lower(), "")
     return set(header_value.replace(",", " ").split())

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -11,14 +11,19 @@ falls back to unauthenticated local behavior. This module declares only the env
 var *names* — the concrete values are supplied at deploy time by the
 deployment's own repo. See `server.py` for details.
 
-Stateless streamable HTTP does not retain initialize-time client capabilities.
-The spec-aligned mechanism is per-request `_meta` under
-`io.modelcontextprotocol/clientCapabilities`, but the installed FastMCP stack
-does not expose that metadata to tool filtering yet. Until it does, clients
-that need MCP Apps `interactive-ui` tools must send the non-standard
-`X-MCP-Extensions: io.modelcontextprotocol/ui` header on each HTTP request.
-Multiple extension IDs may be comma-separated (recommended) or whitespace-
-separated.
+Stateless streamable HTTP does not retain initialize-time client capabilities
+internally. For clients that declare extensions at initialize, the server
+returns a self-describing `Mcp-Session-Id`, and spec-compliant clients echo it
+on subsequent requests. This makes MCP Apps `interactive-ui` tools available
+without a client-specific header. Clients that do not echo session IDs can use
+the explicit fallback `X-MCP-Extensions: io.modelcontextprotocol/ui` header on
+each HTTP request. Multiple extension IDs may be comma-separated (recommended)
+or whitespace-separated.
+
+The eventual spec-aligned replacement is per-request `_meta` under
+`io.modelcontextprotocol/clientCapabilities`. That path exists in the modern
+`mcp` 2.0.0 server architecture, but `fastmcp` 3.4.5 requires `mcp<2.0`, so
+using it requires a stack migration rather than a version-only change.
 
 Environment variables:
 
@@ -58,8 +63,10 @@ from fastmcp_extensions import (
     assert_http_trusted_execution_disabled,
     register_landing_page,
 )
+from starlette.middleware import Middleware
 
 from airbyte.constants import set_hosted_mcp_mode
+from airbyte.mcp._capability_tokens import CapabilityTokenMiddleware
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
@@ -143,6 +150,7 @@ def main() -> None:
         host=DEFAULT_HTTP_HOST,
         port=DEFAULT_HTTP_PORT,
         path=mcp_path,
+        middleware=[Middleware(CapabilityTokenMiddleware)],
         stateless_http=True,
     )
 

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -156,20 +156,30 @@ def test_stdio_ui_tool_visibility(
 
 
 @pytest.mark.parametrize(
-    "extension_ids",
+    "extension_ids, expected",
     [
-        pytest.param({"io.modelcontextprotocol/ui"}, id="single-extension"),
         pytest.param(
+            {"io.modelcontextprotocol/ui"},
+            {"io.modelcontextprotocol/ui"},
+            id="single-extension",
+        ),
+        pytest.param(
+            {"io.modelcontextprotocol/ui", "io.modelcontextprotocol/roots"},
             {"io.modelcontextprotocol/ui", "io.modelcontextprotocol/roots"},
             id="multiple-extensions",
         ),
-        pytest.param(set(), id="empty"),
+        pytest.param(set(), set(), id="empty"),
+        pytest.param({"foo bar"}, set(), id="whitespace-containing-id"),
+        pytest.param({" \t\n"}, set(), id="all-whitespace-ids"),
     ],
 )
-def test_capability_token_round_trip(extension_ids: set[str]) -> None:
+def test_capability_token_round_trip(
+    extension_ids: set[str],
+    expected: set[str],
+) -> None:
     """Capability tokens round-trip extension IDs."""
     token = encode_capability_token(extension_ids)
-    assert decode_capability_token(token) == extension_ids
+    assert decode_capability_token(token) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_http.py
+++ b/tests/unit_tests/test_mcp_http.py
@@ -17,8 +17,14 @@ from mcp import types
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamable_http_client
+from starlette.middleware import Middleware
 
 from airbyte.mcp import _tool_utils
+from airbyte.mcp._capability_tokens import (
+    CapabilityTokenMiddleware,
+    decode_capability_token,
+    encode_capability_token,
+)
 from airbyte.mcp.server import app
 
 
@@ -55,6 +61,7 @@ def _http_app() -> Any:
     """Build the in-process HTTP app, mirroring `http_main`'s stateless config."""
     return app.http_app(
         path="/mcp",
+        middleware=[Middleware(CapabilityTokenMiddleware)],
         transport="streamable-http",
         stateless_http=True,
     )
@@ -88,21 +95,30 @@ async def _http_session(
     *,
     headers: dict[str, str] | None,
     configure_client_capabilities: Any,
+    ui: bool = False,
     wire_headers: list[list[tuple[bytes, bytes]]] | None = None,
+    response_headers: list[list[tuple[bytes, bytes]]] | None = None,
 ) -> AsyncIterator[ClientSession]:
-    configure_client_capabilities(False)
+    configure_client_capabilities(ui)
     http_app = _http_app()
 
     async def capture_request(request: httpx.Request) -> None:
         if wire_headers is not None:
             wire_headers.append(request.headers.raw)
 
+    async def capture_response(response: httpx.Response) -> None:
+        if response_headers is not None:
+            response_headers.append(response.headers.raw)
+
     async with http_app.router.lifespan_context(http_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=http_app),
             base_url="http://testserver",
             headers=headers,
-            event_hooks={"request": [capture_request]},
+            event_hooks={
+                "request": [capture_request],
+                "response": [capture_response],
+            },
         ) as http_client:
             async with streamable_http_client(
                 "http://testserver/mcp",
@@ -137,6 +153,78 @@ def test_stdio_ui_tool_visibility(
         assert UI_TOOL_NAMES <= names
     else:
         assert UI_TOOL_NAMES.isdisjoint(names)
+
+
+@pytest.mark.parametrize(
+    "extension_ids",
+    [
+        pytest.param({"io.modelcontextprotocol/ui"}, id="single-extension"),
+        pytest.param(
+            {"io.modelcontextprotocol/ui", "io.modelcontextprotocol/roots"},
+            id="multiple-extensions",
+        ),
+        pytest.param(set(), id="empty"),
+    ],
+)
+def test_capability_token_round_trip(extension_ids: set[str]) -> None:
+    """Capability tokens round-trip extension IDs."""
+    token = encode_capability_token(extension_ids)
+    assert decode_capability_token(token) == extension_ids
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        pytest.param("garbage", id="garbage"),
+        pytest.param(
+            "00000000000000000000000000000000.not-base64!",
+            id="non-base64",
+        ),
+        pytest.param("00000000-0000-0000-0000-000000000000", id="uuid-only"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_capability_token_decode_fails_closed(token: str) -> None:
+    """Malformed capability tokens do not expose extensions."""
+    assert decode_capability_token(token) == set()
+
+
+def test_stateless_http_initialize_capabilities_survive_via_session_token(
+    configure_client_capabilities: Any,
+) -> None:
+    """Stateless HTTP carries initialize extensions through the session token."""
+    names = asyncio.run(
+        _tool_names(
+            _http_session(
+                headers={},
+                ui=True,
+                configure_client_capabilities=configure_client_capabilities,
+            )
+        )
+    )
+    assert UI_TOOL_NAMES <= names
+
+
+def test_stateless_http_without_extensions_mints_no_session_token(
+    configure_client_capabilities: Any,
+) -> None:
+    """Clients without extensions receive no session token or UI tools."""
+    response_headers: list[list[tuple[bytes, bytes]]] = []
+    names = asyncio.run(
+        _tool_names(
+            _http_session(
+                headers={},
+                configure_client_capabilities=configure_client_capabilities,
+                response_headers=response_headers,
+            )
+        )
+    )
+    assert UI_TOOL_NAMES.isdisjoint(names)
+    assert all(
+        header_name.lower() != b"mcp-session-id"
+        for headers in response_headers
+        for header_name, _ in headers
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR targets PR airbytehq/PyAirbyte#1097:
- airbytehq/PyAirbyte#1097

---

## Summary

airbytehq/PyAirbyte#1097 lets a UI-capable client re-declare itself on every stateless HTTP request via `X-MCP-Extensions`. That only helps clients we control. Off-the-shelf MCP Apps hosts declare the UI extension the standard way — once, in `initialize` — and stateless HTTP throws it away, so they never see the `show_*` tools.

Wire capture of Goose Desktop 1.36.0 against this server (both transports, identical):

```jsonc
// initialize
"capabilities": {"extensions": {"io.modelcontextprotocol/ui": {"mimeTypes": ["text/html;profile=mcp-app"]}}}
// tools/list -- capability is gone, only Goose's own bookkeeping remains
"params": {"_meta": {"agent-session-id": "...", "progressToken": 0}}
```

No per-request standard signal exists to key off: no MCP Apps header, and `_meta` carries no `io.modelcontextprotocol/clientCapabilities`.

So instead of storing the declaration server-side, this PR hands it back to the client to carry. The 2025-03-26 transport says a server MAY assign `Mcp-Session-Id` at initialize and clients MUST echo it on subsequent requests — so the session ID *becomes* the capability data rather than a key into server state:

```python
# on the initialize response, only when the client declared extensions
token = f"{uuid4().hex}.{b64url(' '.join(sorted(extension_ids)))}"   # "<nonce>.<payload>"
response.headers["Mcp-Session-Id"] = token

# on every later request, in the tool filter
extensions = decode_capability_token(headers["mcp-session-id"]) or parse(headers["x-mcp-extensions"])
```

The server stays `stateless_http=True` and stores nothing: the token survives restarts and any number of replicas, because it *is* the state. Resolution order is unchanged-first: FastMCP session capabilities (stdio) → session token (new) → `X-MCP-Extensions` (PR 1097's fallback, still supported for clients that don't echo session IDs).

Notes on the edges:

- Nothing is minted when a client declares no extensions, so non-UI clients stay entirely session-free rather than being handed a session ID that buys them nothing.
- The nonce exists because the spec says session IDs SHOULD be globally unique; the payload is what we actually read.
- `decode_capability_token` fails closed on anything it doesn't recognize and never raises. Stateless FastMCP accepts session IDs it never minted, so foreign values do arrive.
- A forged token only widens tool visibility — the same property `X-MCP-Extensions` already has. This is not an authorization boundary.
- `_capability_tokens.py` deliberately knows nothing about Airbyte or the UI extension; it deals in opaque extension IDs, so it can be lifted into [`fastmcp-extensions`](https://github.com/airbytehq/fastmcp-extensions) as a file move plus an import change.
- Known expiry: the 2026-07-28 revision removes protocol sessions and moves capabilities into per-request `_meta`. That path exists only in `mcp` 2.0.0's modern server architecture, and `fastmcp` 3.4.5 pins `mcp<2.0` — a stack migration, not a version knob. Both this token and the header retire then.

Requested by AJ Steers.

## Test plan

- New in-process regression test: a client declaring `io.modelcontextprotocol/ui` at initialize and sending **no** custom header sees all three `show_*` tools over stateless HTTP. This is the case that reproduces the Goose failure.
- A client declaring nothing sees none of them (asserted disjoint, so a partial leak fails) and receives no `Mcp-Session-Id` at all.
- Codec round-trip and fail-closed parametrized cases: garbage, non-base64 payload, bare UUID, empty.
- Real-process check against `airbyte-mcp-http`: 44 tools including all three `show_*`, with no custom header; `GET /mcp` still returns the HTML landing page.
- Goose Desktop end-to-end evidence to follow as a comment.


Link to Devin session: https://app.devin.ai/sessions/26b42c83920e467ea4a8242915c17dc7
Requested by: @aaronsteers