### PR TITLE
chore(deps): require fastmcp-extensions 0.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "typing-extensions",
     "uuid7>=0.1.0,<1.0",
     "fastmcp>=3.0,<4.0",
-    "fastmcp-extensions>=0.19.0,<1.0.0",
+    "fastmcp-extensions>=0.19.1,<1.0.0",
     "starlette",  # Transitive dependency of fastmcp, imported directly
     "uv>=0.5.0,<0.9.0",
     "prefab-ui>=0.20.1,<0.21",

--- a/tests/unit_tests/test_mcp_http_main.py
+++ b/tests/unit_tests/test_mcp_http_main.py
@@ -169,7 +169,6 @@ def test_event_stream_get_content_negotiation(
     )
     run_mcp_http_server(
         FakeServer(),  # type: ignore[arg-type]
-        path="/mcp",
         transport="streamable-http",
         stateless_http=True,
     )

--- a/tests/unit_tests/test_mcp_http_main.py
+++ b/tests/unit_tests/test_mcp_http_main.py
@@ -169,6 +169,7 @@ def test_event_stream_get_content_negotiation(
     )
     run_mcp_http_server(
         FakeServer(),  # type: ignore[arg-type]
+        path="/mcp",
         transport="streamable-http",
         stateless_http=True,
     )
@@ -179,6 +180,7 @@ def test_event_stream_get_content_negotiation(
             {
                 "type": "http",
                 "method": "GET",
+                "path": "/mcp",
                 "headers": [(b"accept", accept)],
             },
             receive,

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "duckdb", specifier = "==1.4.3" },
     { name = "duckdb-engine", specifier = "==0.17.0" },
     { name = "fastmcp", specifier = ">=3.0,<4.0" },
-    { name = "fastmcp-extensions", specifier = ">=0.19.0,<1.0.0" },
+    { name = "fastmcp-extensions", specifier = ">=0.19.1,<1.0.0" },
     { name = "google-auth", specifier = ">=2.27.0,<3.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.12.0,<4.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.25.0,<3.0" },
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-extensions"
-version = "0.19.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp" },
@@ -1141,9 +1141,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/ac/80c3db8957750fbf4778bb789a1e5316800cafda8d764b6e6a4986de23ae/fastmcp_extensions-0.19.0.tar.gz", hash = "sha256:7bf5af20600b15dba646dc0003e688fd055004908f8654bb3fc96a9a1c91e2c4", size = 231246, upload-time = "2026-08-14T02:35:48.238Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/88/17a5afce641d5198fc2c67bd35510bfdb0285760aa13c1e3e9c86ec7d870/fastmcp_extensions-0.19.1.tar.gz", hash = "sha256:38cf65eb5a027e699217c4122fd4ee15851618daac08701a28e02f65739c3c6a", size = 231869, upload-time = "2026-08-14T03:04:31.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/93/1b8a88e93420839cb5ca35a0e5afa7aefe94c41f5a959ea4e82d9c17fe7d/fastmcp_extensions-0.19.0-py3-none-any.whl", hash = "sha256:6114360c82b9790fb5301636a274c78cea102dc25de56880e9c7206b8022f38f", size = 86476, upload-time = "2026-08-14T02:35:47.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/4de942bce3cce750a25f4eb13c8bca283ec49c0203b23c1ad19f6a0c7845/fastmcp_extensions-0.19.1-py3-none-any.whl", hash = "sha256:0d6883441fcb789560acfb6ab448db5b478eb4fe515f17f8512d5b5c7fadcfdc", size = 86717, upload-time = "2026-08-14T03:04:30.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

```diff
-"fastmcp-extensions>=0.19.0,<1.0.0",
+"fastmcp-extensions>=0.19.1,<1.0.0",
```

0.19.0 installed the SSE-GET rejection over the entire ASGI app instead of the MCP path; airbytehq/fastmcp-extensions#107 scoped it, released as 0.19.1. PyAirbyte serves only `/mcp` plus the landing page, so nothing here was broken — this closes the door on anyone resolving back to the version that would bite a server with its own event-stream route.

The test change is the interesting part. `test_event_stream_get_content_negotiation` was passing a scope with no `path` key at all, which only worked because 0.19.0's middleware never looked at the path. Under 0.19.1 that scope matches nothing and the SSE GET sails through to the landing page. The scope now carries `path: "/mcp"`, and the `run_mcp_http_server()` call deliberately does **not** pass `path=` — matching `http_main.py`, so the test exercises the default resolution from `fastmcp.settings.streamable_http_path` rather than asserting against a value it supplied itself.

## Test plan

`tests/unit_tests/test_mcp_http_main.py` (13 passed) and the focused MCP modules (81 passed). Confirmed the failure is real by running the updated test against 0.19.0 first: the browser-GET and SSE-GET cases become indistinguishable, which is exactly the regression the scoping fix addresses.

Link to Devin session: https://app.devin.ai/sessions/26b42c83920e467ea4a8242915c17dc7
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content-negotiation testing to use the correct `/mcp` endpoint path.

* **Maintenance**
  * Updated the minimum supported extension version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->