### PR TITLE
fix(cloud): expose connector `definition_id` on `CloudConnector`, `CloudSourceInfo`, and `CloudDestinationInfo`

### DIFF
--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -125,6 +125,17 @@ class CloudConnector(abc.ABC):
 
         return self._connector_info.name
 
+    @property
+    def definition_id(self) -> str:
+        """Get the connector definition ID.
+
+        E.g. the definition ID for `source-postgres`, not the ID of this deployed connector.
+        """
+        if not self._connector_info:
+            self._connector_info = self._fetch_connector_info()
+
+        return self._connector_info.definition_id
+
     @abc.abstractmethod
     def _fetch_connector_info(self) -> CloudSourceInfo | CloudDestinationInfo:
         """Populate the connector with data from the API."""

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -40,11 +40,13 @@ class _JobResponseLike(Protocol):
 class _SourceResponseLike(Protocol):
     source_id: str
     name: str
+    definition_id: str
 
 
 class _DestinationResponseLike(Protocol):
     destination_id: str
     name: str
+    definition_id: str
 
 
 class _DeclarativeSourceDefinitionResponseLike(Protocol):
@@ -198,10 +200,17 @@ class CloudSourceInfo(BaseModel):
     name: str
     """The source name."""
 
+    definition_id: str
+    """The connector definition ID (for example, the ID for `source-postgres`)."""
+
     @classmethod
     def from_api_response(cls, source: _SourceResponseLike) -> CloudSourceInfo:
         """Create a public model from an internal API source response."""
-        return cls(source_id=source.source_id, name=source.name)
+        return cls(
+            source_id=source.source_id,
+            name=source.name,
+            definition_id=source.definition_id,
+        )
 
 
 class CloudDestinationInfo(BaseModel):
@@ -213,13 +222,20 @@ class CloudDestinationInfo(BaseModel):
     name: str
     """The destination name."""
 
+    definition_id: str
+    """The connector definition ID (for example, the ID for `destination-snowflake`)."""
+
     @classmethod
     def from_api_response(
         cls,
         destination: _DestinationResponseLike,
     ) -> CloudDestinationInfo:
         """Create a public model from an internal API destination response."""
-        return cls(destination_id=destination.destination_id, name=destination.name)
+        return cls(
+            destination_id=destination.destination_id,
+            name=destination.name,
+            definition_id=destination.definition_id,
+        )
 
 
 class CloudCustomSourceDefinitionInfo(BaseModel):

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -947,14 +947,13 @@ def describe_cloud_source(
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     source = workspace.get_source(source_id=source_id)
 
-    # Access name property to ensure _connector_info is populated
     source_name = cast(str, source.name)
 
     return CloudSourceDetails(
         source_id=source.source_id,
         source_name=source_name,
         source_url=source.connector_url,
-        connector_definition_id=source._connector_info.definition_id,  # noqa: SLF001  # type: ignore[union-attr]
+        connector_definition_id=source.definition_id,
     )
 
 
@@ -983,14 +982,13 @@ def describe_cloud_destination(
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     destination = workspace.get_destination(destination_id=destination_id)
 
-    # Access name property to ensure _connector_info is populated
     destination_name = cast(str, destination.name)
 
     return CloudDestinationDetails(
         destination_id=destination.destination_id,
         destination_name=destination_name,
         destination_url=destination.connector_url,
-        connector_definition_id=destination._connector_info.definition_id,  # noqa: SLF001  # type: ignore[union-attr]
+        connector_definition_id=destination.definition_id,
     )
 
 

--- a/tests/unit_tests/test_cloud_models.py
+++ b/tests/unit_tests/test_cloud_models.py
@@ -1,0 +1,107 @@
+"""Unit tests for Airbyte Cloud response models and connectors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from airbyte.cloud import CloudWorkspace
+from airbyte.cloud.connectors import CloudDestination, CloudSource
+from airbyte.cloud.models import CloudDestinationInfo, CloudSourceInfo
+from airbyte_api.models import (
+    DestinationDuckdb,
+    DestinationResponse,
+    SourceFaker,
+    SourceResponse,
+)
+
+
+@pytest.mark.parametrize(
+    "response,from_api_response,expected_definition_id",
+    [
+        pytest.param(
+            SourceResponse(
+                configuration=SourceFaker(),
+                created_at=1,
+                definition_id="source-faker-definition",
+                name="Test source",
+                source_id="source-id",
+                source_type="faker",
+                workspace_id="workspace-id",
+            ),
+            CloudSourceInfo.from_api_response,
+            "source-faker-definition",
+            id="source",
+        ),
+        pytest.param(
+            DestinationResponse(
+                configuration=DestinationDuckdb(destination_path="/tmp/test.duckdb"),
+                created_at=1,
+                definition_id="destination-duckdb-definition",
+                destination_id="destination-id",
+                destination_type="duckdb",
+                name="Test destination",
+                workspace_id="workspace-id",
+            ),
+            CloudDestinationInfo.from_api_response,
+            "destination-duckdb-definition",
+            id="destination",
+        ),
+    ],
+)
+def test_cloud_connector_info_from_api_response_populates_definition_id(
+    response: SourceResponse | DestinationResponse,
+    from_api_response: Callable[..., CloudSourceInfo | CloudDestinationInfo],
+    expected_definition_id: str,
+) -> None:
+    """Verify Cloud connector info models retain the API definition ID."""
+    info = from_api_response(response)
+
+    assert info.definition_id == expected_definition_id
+
+
+@pytest.mark.parametrize(
+    "connector_factory,response,expected_definition_id",
+    [
+        pytest.param(
+            CloudSource._from_source_response,
+            SourceResponse(
+                configuration=SourceFaker(),
+                created_at=1,
+                definition_id="source-faker-definition",
+                name="Test source",
+                source_id="source-id",
+                source_type="faker",
+                workspace_id="workspace-id",
+            ),
+            "source-faker-definition",
+            id="source",
+        ),
+        pytest.param(
+            CloudDestination._from_destination_response,
+            DestinationResponse(
+                configuration=DestinationDuckdb(destination_path="/tmp/test.duckdb"),
+                created_at=1,
+                definition_id="destination-duckdb-definition",
+                destination_id="destination-id",
+                destination_type="duckdb",
+                name="Test destination",
+                workspace_id="workspace-id",
+            ),
+            "destination-duckdb-definition",
+            id="destination",
+        ),
+    ],
+)
+def test_cloud_connector_definition_id_uses_cached_info(
+    connector_factory: Callable[..., CloudSource | CloudDestination],
+    response: SourceResponse | DestinationResponse,
+    expected_definition_id: str,
+) -> None:
+    """Verify Cloud connector definition IDs are available from cached API info."""
+    connector = connector_factory(
+        CloudWorkspace(workspace_id="workspace-id", bearer_token="token"),
+        response,
+    )
+
+    assert connector.definition_id == expected_definition_id


### PR DESCRIPTION
## Summary

Fixes #1109. `describe_cloud_source` and `describe_cloud_destination` failed unconditionally with `'CloudSourceInfo' object has no attribute 'definition_id'`, because the MCP tools read `source._connector_info.definition_id` while `CloudSourceInfo` / `CloudDestinationInfo` only carried the id and name. The `# type: ignore[union-attr]` at both call sites hid the missing attribute from mypy.

- `CloudSourceInfo` / `CloudDestinationInfo` now carry `definition_id`, populated in `from_api_response` from the API response's `definition_id` (the real attribute name on airbyte_api `SourceResponse` / `DestinationResponse`); the corresponding `Protocol`s declare it too.
- `CloudConnector` gains a public `definition_id` property that lazily fetches connector info, mirroring the existing `name` property, so the MCP tools no longer reach into `_connector_info`:
  ```diff
  -    connector_definition_id=source._connector_info.definition_id,  # noqa: SLF001  # type: ignore[union-attr]
  +    connector_definition_id=source.definition_id,
  ```

Requested by AJ.

## Test plan

New unit tests in `tests/unit_tests/test_cloud_models.py` (no credentials, run in Pytest (Fast)) build real `SourceResponse` / `DestinationResponse` objects and assert `definition_id` is populated on both info models and on `CloudSource.definition_id` / `CloudDestination.definition_id` via the cached-info factories — this is the path that previously raised `AttributeError`.

Ran locally:
- `uv run ruff format .` and `uv run ruff check .` — clean
- `uv run poe test-fast` — 612 passed, 1 skipped, 71 deselected, 1 xpassed
- `uv run --with mypy mypy airbyte/cloud/models.py airbyte/cloud/connectors.py airbyte/mcp/cloud.py tests/unit_tests/test_cloud_models.py` — no issues (a full-repo mypy run hits preexisting duplicate-module errors in generated integration-test fixtures)

Not verified against the hosted `cloud-mcp` server: that runs the last published PyPI version, so this branch can't be exercised there until release.

Link to Devin session: https://app.devin.ai/sessions/ae6835ba55954657a575e7e9e2b35be5
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source and destination details now expose the connector definition ID.
  * Connector definition IDs are clearly distinguished from deployed connector IDs.
  * Connector metadata is loaded automatically when the definition ID is requested.
* **Bug Fixes**
  * Improved consistency when retrieving connector definition IDs across cloud source and destination details.
* **Tests**
  * Added coverage to verify connector definition IDs are preserved and exposed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._