### PR TITLE
fix(mcp): drop `X-Airbyte-Cloud-Client-Id`/`-Secret` request headers

### DIFF
--- a/airbyte/constants.py
+++ b/airbyte/constants.py
@@ -349,12 +349,6 @@ MCP_BEARER_TOKEN_HEADER: str = "Authorization"
 MCP_EXTENSIONS_HEADER: str = "X-MCP-Extensions"
 """HTTP header key for client-declared MCP extension IDs."""
 
-MCP_CLIENT_ID_HEADER: str = "X-Airbyte-Cloud-Client-Id"
-"""HTTP header key for client ID."""
-
-MCP_CLIENT_SECRET_HEADER: str = "X-Airbyte-Cloud-Client-Secret"
-"""HTTP header key for client secret."""
-
 # Security Note: The API root and Config API root are intentionally NOT exposed as HTTP
 # headers. Each hosted MCP deployment is paired to a single backend, so allowing
 # a caller to override these URLs per-request would let them redirect the

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -51,8 +51,6 @@ from airbyte.constants import (
     CLOUD_CLIENT_SECRET_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
     MCP_BEARER_TOKEN_HEADER,
-    MCP_CLIENT_ID_HEADER,
-    MCP_CLIENT_SECRET_HEADER,
     MCP_WORKSPACE_ID_HEADER,
     is_hosted_mcp_mode,
 )
@@ -248,13 +246,13 @@ class AirbyteNoCloudCredentialsError(PyAirbyteInputError):
             if self._allow_bearer:
                 self.guidance = (
                     f"Provide a bearer token via the `{MCP_BEARER_TOKEN_HEADER}` header, "
-                    f"or client credentials via the `{MCP_CLIENT_ID_HEADER}` and "
-                    f"`{MCP_CLIENT_SECRET_HEADER}` headers."
+                    "or client credentials via the transport `Client-Id` and "
+                    "`Client-Secret` headers."
                 )
             else:
                 self.guidance = (
-                    f"Provide client credentials via the `{MCP_CLIENT_ID_HEADER}` and "
-                    f"`{MCP_CLIENT_SECRET_HEADER}` headers."
+                    "Provide client credentials via the transport `Client-Id` and "
+                    "`Client-Secret` headers."
                 )
         elif self._allow_bearer and self._env_vars:
             self.guidance = (

--- a/airbyte/mcp/_tool_utils.py
+++ b/airbyte/mcp/_tool_utils.py
@@ -42,8 +42,6 @@ from airbyte.constants import (
     CLOUD_CONFIG_API_ROOT_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
     MCP_BEARER_TOKEN_HEADER,
-    MCP_CLIENT_ID_HEADER,
-    MCP_CLIENT_SECRET_HEADER,
     MCP_CONFIG_API_URL,
     MCP_CONFIG_BEARER_TOKEN,
     MCP_CONFIG_CLIENT_ID,
@@ -244,21 +242,39 @@ carries the proxy's self-minted reference JWT, which Airbyte Cloud rejects with
 
 CLIENT_ID_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CLIENT_ID,
-    http_header_key=MCP_CLIENT_ID_HEADER,
     env_var=CLOUD_CLIENT_ID_ENV_VAR,
     required=False,
     sensitive=True,
 )
-"""Config arg for client ID, supporting HTTP header and env var."""
+"""Config arg for client ID, supporting env var only.
+
+Deliberately has no `http_header_key`: the supported headless transport path
+uses standard `Client-Id` and `Client-Secret` headers, or
+`Authorization: Basic base64(client_id:client_secret)`, handled by
+`airbyte/mcp/_client_credentials.py` and
+`fastmcp_extensions.wrap_client_credentials`. That exchange produces a
+short-lived bearer token server-side and rewrites the request to
+`Authorization: Bearer`. A per-request downstream credential header would let
+a caller act as a Cloud identity other than the authenticated one.
+"""
 
 CLIENT_SECRET_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CLIENT_SECRET,
-    http_header_key=MCP_CLIENT_SECRET_HEADER,
     env_var=CLOUD_CLIENT_SECRET_ENV_VAR,
     required=False,
     sensitive=True,
 )
-"""Config arg for client secret, supporting HTTP header and env var."""
+"""Config arg for client secret, supporting env var only.
+
+Deliberately has no `http_header_key`: the supported headless transport path
+uses standard `Client-Id` and `Client-Secret` headers, or
+`Authorization: Basic base64(client_id:client_secret)`, handled by
+`airbyte/mcp/_client_credentials.py` and
+`fastmcp_extensions.wrap_client_credentials`. That exchange produces a
+short-lived bearer token server-side and rewrites the request to
+`Authorization: Bearer`. A per-request downstream credential header would let
+a caller act as a Cloud identity other than the authenticated one.
+"""
 
 API_URL_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_API_URL,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -30,8 +30,6 @@ from airbyte.constants import (
     CLOUD_CLIENT_SECRET_ENV_VAR,
     CLOUD_WORKSPACE_ID_ENV_VAR,
     MCP_BEARER_TOKEN_HEADER,
-    MCP_CLIENT_ID_HEADER,
-    MCP_CLIENT_SECRET_HEADER,
     MCP_CONFIG_API_URL,
     MCP_CONFIG_BEARER_TOKEN,
     MCP_CONFIG_CLIENT_ID,
@@ -56,8 +54,8 @@ from airbyte.mcp._tool_utils import (
 
 CLOUD_AUTH_TIP_TEXT = (
     f"When connecting to a hosted MCP server, provide a bearer token via the "
-    f"`{MCP_BEARER_TOKEN_HEADER}` header, or client credentials via the "
-    f"`{MCP_CLIENT_ID_HEADER}` and `{MCP_CLIENT_SECRET_HEADER}` headers, plus "
+    f"`{MCP_BEARER_TOKEN_HEADER}` header, or client credentials via the transport "
+    f"`Client-Id` and `Client-Secret` headers, plus "
     f"the workspace ID via the `{MCP_WORKSPACE_ID_HEADER}` header. For local or "
     f"stdio connections, set the `{CLOUD_BEARER_TOKEN_ENV_VAR}` environment "
     f"variable, or both `{CLOUD_CLIENT_ID_ENV_VAR}` and "

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -40,15 +40,15 @@ def test_exceptions():
             True,
             True,
             "Provide a bearer token via the `Authorization` header, or client credentials "
-            "via the `X-Airbyte-Cloud-Client-Id` and `X-Airbyte-Cloud-Client-Secret` headers.",
+            "via the transport `Client-Id` and `Client-Secret` headers.",
             id="hosted_with_bearer",
         ),
         pytest.param(
             True,
             False,
             False,
-            "Provide client credentials via the `X-Airbyte-Cloud-Client-Id` and "
-            "`X-Airbyte-Cloud-Client-Secret` headers.",
+            "Provide client credentials via the transport `Client-Id` and "
+            "`Client-Secret` headers.",
             id="hosted_client_credentials_only",
         ),
         pytest.param(


### PR DESCRIPTION
## Summary

`X-Airbyte-Cloud-Client-Id` / `X-Airbyte-Cloud-Client-Secret` let a caller supply *downstream* Cloud credentials per request, so the Cloud identity the server acts as could differ from the identity that authenticated to the MCP server. These header names also predate the standard spelling: the same function is served by the transport-level `Client-Id` / `Client-Secret` headers (or `Authorization: Basic base64(client_id:client_secret)`) already handled by `airbyte/mcp/_client_credentials.py` → `fastmcp_extensions.wrap_client_credentials`, which exchanges them server-side for a short-lived token and rewrites the request to `Authorization: Bearer`. The bearer resolver then picks that up, so no per-request downstream credential header is needed.

So client id/secret become env-var-only config args, matching `API_URL_CONFIG_ARG`, which is already header-less for the analogous reason:

```diff
 CLIENT_ID_CONFIG_ARG = MCPServerConfigArg(
     name=MCP_CONFIG_CLIENT_ID,
-    http_header_key=MCP_CLIENT_ID_HEADER,
     env_var=CLOUD_CLIENT_ID_ENV_VAR,
```

`MCP_CLIENT_ID_HEADER` / `MCP_CLIENT_SECRET_HEADER` are removed from `airbyte/constants.py`; `MCP_BEARER_TOKEN_HEADER`, `MCP_WORKSPACE_ID_HEADER`, and the `AIRBYTE_CLOUD_CLIENT_ID` / `_SECRET` env vars are untouched. The hosted-mode guidance in `AirbyteNoCloudCredentialsError` and `CLOUD_AUTH_TIP_TEXT` named the removed headers, so both now point at the bearer token or the transport `Client-Id`/`Client-Secret` form, with the matching expectations updated in `tests/unit_tests/test_exceptions.py`.

**User-visible impact:** a hosted client that sends the two `X-Airbyte-Cloud-*` credential headers loses that path and must send `Client-Id`/`Client-Secret` (or Basic, or a bearer token) instead. On the `cloud-mcp` deployment that transport path is already enabled (`AIRBYTE_MCP_AUTH_ALLOW_CLIENT_CREDENTIALS=true`). Requested by AJ Steers as follow-up to the equivalent removal in the ops MCP server (airbytehq/airbyte-ops-mcp#1287).

## Test plan

- `uv run ruff check .` and `uv run ruff format --check .` — pass.
- `uv run --with mypy mypy airbyte` — passes (135 files). The repo-wide `mypy .` fails only on a pre-existing duplicate `setup` module under `tests/integration_tests/fixtures/`, unrelated to this change.
- `uv run pytest tests/unit_tests/test_exceptions.py tests/unit_tests/test_mcp_tool_utils.py` — 20 passed.
- Not exercised: a live hosted request against a deployed `cloud-mcp`; the transport `Client-Id`/`Client-Secret` exchange path itself is unchanged by this PR.


Link to Devin session: https://app.devin.ai/sessions/ef3342fef3fa4cf5bf45fb7c17adcff7
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated hosted MCP authentication guidance to use the standard `Client-Id` and `Client-Secret` headers.
  * Removed support for configuring client credentials through custom HTTP header settings.
  * Client credentials are now accepted through environment variables for supported exchanges.
  * Retained bearer-token and extension header support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->