### PR TITLE
fix(declarative): [DO-NOT-MERGE] pass config into declarative source

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -45,6 +45,7 @@ class DeclarativeExecutor(Executor):
         self,
         name: str,
         manifest: dict | Path,
+        config: dict[str, Any] = {},
         components_py: str | Path | None = None,
         components_py_checksum: str | None = None,
     ) -> None:
@@ -66,7 +67,7 @@ class DeclarativeExecutor(Executor):
         elif isinstance(manifest, dict):
             self._manifest_dict = manifest
 
-        config_dict: dict[str, Any] = {}
+        config_dict: dict[str, Any] = config
         if components_py:
             if isinstance(components_py, Path):
                 components_py = components_py.read_text()

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -116,6 +116,16 @@ class DeclarativeExecutor(Executor):
             source_config=self._manifest_dict,
         )
 
+    def _get_effective_config(self, args_config: dict[str, Any]) -> dict[str, Any]:
+        config = {**self._config_dict, **args_config}
+        for key in (
+            "__injected_components_py",
+            "__injected_components_py_checksums",
+        ):
+            if key in self._config_dict:
+                config[key] = self._config_dict[key]
+        return config
+
     @property
     def declarative_source(self) -> ConcurrentDeclarativeSource:
         """Get the declarative source object.
@@ -156,9 +166,7 @@ class DeclarativeExecutor(Executor):
         mapped_args: list[str] = self.map_cli_args(args)
         args_config = _get_config_from_args(mapped_args)
         source_entrypoint = AirbyteEntrypoint(
-            self._create_declarative_source(
-                {**self._config_dict, **args_config},
-            )
+            self._create_declarative_source(self._get_effective_config(args_config))
         )
         parsed_args: Namespace = source_entrypoint.parse_args(mapped_args)
         yield from source_entrypoint.run(parsed_args)

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -67,6 +67,7 @@ class DeclarativeExecutor(Executor):
         self,
         name: str,
         manifest: dict | Path,
+        *,
         config: dict[str, Any] | None = None,
         components_py: str | Path | None = None,
         components_py_checksum: str | None = None,

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -107,6 +107,15 @@ class DeclarativeExecutor(Executor):
         self.reported_version: str | None = self._manifest_dict.get("version", None)
         self._config_dict = config_dict
 
+    def _create_declarative_source(
+        self,
+        config: dict[str, Any],
+    ) -> ConcurrentDeclarativeSource:
+        return ConcurrentDeclarativeSource(
+            config=config,
+            source_config=self._manifest_dict,
+        )
+
     @property
     def declarative_source(self) -> ConcurrentDeclarativeSource:
         """Get the declarative source object.
@@ -118,10 +127,7 @@ class DeclarativeExecutor(Executor):
         3. Rather than cache the source object, we recreate it each time we need it, to
            avoid any issues with re-using the same object.
         """
-        return ConcurrentDeclarativeSource(
-            config=self._config_dict,
-            source_config=self._manifest_dict,
-        )
+        return self._create_declarative_source(self._config_dict)
 
     def get_installed_version(
         self,
@@ -150,9 +156,8 @@ class DeclarativeExecutor(Executor):
         mapped_args: list[str] = self.map_cli_args(args)
         args_config = _get_config_from_args(mapped_args)
         source_entrypoint = AirbyteEntrypoint(
-            ConcurrentDeclarativeSource(
-                config={**self._config_dict, **args_config},
-                source_config=self._manifest_dict,
+            self._create_declarative_source(
+                {**self._config_dict, **args_config},
             )
         )
         parsed_args: Namespace = source_entrypoint.parse_args(mapped_args)

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import warnings
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, cast
@@ -36,6 +37,27 @@ def _suppress_cdk_pydantic_deprecation_warnings() -> None:
         "ignore",
         category=pydantic.warnings.PydanticDeprecatedSince20,
     )
+
+
+def _get_config_from_args(args: list[str]) -> dict[str, Any]:
+    config_path: str | None = None
+    try:
+        config_path = args[args.index("--config") + 1]
+    except (IndexError, ValueError):
+        for arg in args:
+            if arg.startswith("--config="):
+                config_path = arg.partition("=")[2]
+                break
+
+    if not config_path:
+        return {}
+
+    try:
+        config = json.loads(Path(config_path).read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+
+    return config if isinstance(config, dict) else {}
 
 
 class DeclarativeExecutor(Executor):
@@ -124,9 +146,14 @@ class DeclarativeExecutor(Executor):
     ) -> Iterator[str]:
         """Execute the declarative source."""
         _ = stdin, suppress_stderr  # Not used
-        source_entrypoint = AirbyteEntrypoint(self.declarative_source)
-
         mapped_args: list[str] = self.map_cli_args(args)
+        args_config = _get_config_from_args(mapped_args)
+        source_entrypoint = AirbyteEntrypoint(
+            ConcurrentDeclarativeSource(
+                config={**self._config_dict, **args_config},
+                source_config=self._manifest_dict,
+            )
+        )
         parsed_args: Namespace = source_entrypoint.parse_args(mapped_args)
         yield from source_entrypoint.run(parsed_args)
 

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -45,7 +45,7 @@ class DeclarativeExecutor(Executor):
         self,
         name: str,
         manifest: dict | Path,
-        config: dict[str, Any] = {},
+        config: dict[str, Any] | None = None,
         components_py: str | Path | None = None,
         components_py_checksum: str | None = None,
     ) -> None:
@@ -54,6 +54,7 @@ class DeclarativeExecutor(Executor):
         - If `manifest` is a path, it will be read as a json file.
         - If `manifest` is a string, it will be parsed as an HTTP path.
         - If `manifest` is a dict, it will be used as is.
+        - If `config` is provided, it will be used to resolve manifest interpolations.
         - If `components_py` is provided, components will be injected into the source.
         - If `components_py_checksum` is not provided, it will be calculated automatically.
         """
@@ -67,7 +68,7 @@ class DeclarativeExecutor(Executor):
         elif isinstance(manifest, dict):
             self._manifest_dict = manifest
 
-        config_dict: dict[str, Any] = config
+        config_dict: dict[str, Any] = dict(config or {})
         if components_py:
             if isinstance(components_py, Path):
                 components_py = components_py.read_text()

--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -53,7 +53,7 @@ def _get_config_from_args(args: list[str]) -> dict[str, Any]:
         return {}
 
     try:
-        config = json.loads(Path(config_path).read_text())
+        config = json.loads(Path(config_path).read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError):
         return {}
 

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -184,6 +184,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
     install_root: Path | None = None,
     use_python: bool | Path | str | None = None,
     no_executor: bool = False,
+    config: dict[str, Any] = {}
 ) -> Executor:
     """This factory function creates an executor for a connector.
 
@@ -349,6 +350,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             return DeclarativeExecutor(
                 name=name,
                 manifest=source_manifest,
+                config=config,
                 components_py=components_py_path,
             )
 
@@ -364,6 +366,7 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
             return DeclarativeExecutor(
                 name=name,
                 manifest=manifest_dict,
+                config=config,
                 components_py=components_py,
                 components_py_checksum=components_py_checksum,
             )

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -184,11 +184,14 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
     install_root: Path | None = None,
     use_python: bool | Path | str | None = None,
     no_executor: bool = False,
-    config: dict[str, Any] = {}
+    config: dict[str, Any] | None = None,
 ) -> Executor:
     """This factory function creates an executor for a connector.
 
     For documentation of each arg, see the function `airbyte.sources.util.get_source()`.
+
+    Args:
+        config: Connector config used to resolve declarative manifest interpolations.
     """
     install_method_count = sum(
         [

--- a/airbyte/_executors/util.py
+++ b/airbyte/_executors/util.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import requests
 import yaml
@@ -188,10 +188,8 @@ def get_connector_executor(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, C901 # 
 ) -> Executor:
     """This factory function creates an executor for a connector.
 
-    For documentation of each arg, see the function `airbyte.sources.util.get_source()`.
-
-    Args:
-        config: Connector config used to resolve declarative manifest interpolations.
+    For documentation of each arg, see the function `airbyte.sources.util.get_source()`. The
+    `config` argument is also used to resolve declarative manifest interpolations.
     """
     install_method_count = sum(
         [

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -128,7 +128,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
         install_if_missing=install_if_missing,
         install_root=install_root,
         no_executor=no_executor,
-        config=config
+        config=config,
     )
 
     return Source(

--- a/airbyte/sources/util.py
+++ b/airbyte/sources/util.py
@@ -128,6 +128,7 @@ def get_source(  # noqa: PLR0913 # Too many arguments
         install_if_missing=install_if_missing,
         install_root=install_root,
         no_executor=no_executor,
+        config=config
     )
 
     return Source(

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -19,6 +19,7 @@ def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
             name=kwargs["name"],
             manifest=kwargs["source_manifest"],
             config=kwargs["config"],
+            components_py="class Component:\n    pass\n",
         )
 
     monkeypatch.setattr(
@@ -40,6 +41,7 @@ def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
 
     assert source.executor.declarative_source["config"] == config
     assert captured["config"] == config
+    assert config == {"api_key": "configured"}
 
 
 def test_execute_uses_config_set_after_get_source_and_preserves_injected_components(

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -96,8 +96,13 @@ def test_execute_uses_config_set_after_get_source_and_preserves_injected_compone
     )
     source.set_config(late_config, validate=False)
     config_path = tmp_path / "config.json"
+    config_file_config = {
+        **source._hydrated_config,
+        "__injected_components_py": "bogus",
+        "__injected_components_py_checksums": {"md5": "bogus"},
+    }
     config_path.write_text(
-        json.dumps(source._hydrated_config),
+        json.dumps(config_file_config),
         encoding="utf-8",
     )
 

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -1,20 +1,27 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for declarative executor configuration resolution."""
+
 from __future__ import annotations
 
+from collections.abc import Iterator
 import json
+from pathlib import Path
 from typing import Any
+
+import pytest
 
 from airbyte._executors import declarative
 from airbyte._executors.declarative import DeclarativeExecutor
 from airbyte.sources import util as sources_util
 
 
-def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
-    captured: dict[str, Any] = {}
+def test_get_source_passes_config_to_declarative_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manifest = {"version": "1.0.0"}
     config = {"api_key": "configured"}
 
     def fake_get_connector_executor(**kwargs: Any) -> DeclarativeExecutor:
-        captured.update(kwargs)
         return DeclarativeExecutor(
             name=kwargs["name"],
             manifest=kwargs["source_manifest"],
@@ -42,13 +49,12 @@ def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
     declarative_config = source.executor.declarative_source["config"]
     assert declarative_config["api_key"] == config["api_key"]
     assert declarative_config["__injected_components_py"]
-    assert captured["config"] == config
     assert config == {"api_key": "configured"}
 
 
 def test_execute_uses_config_set_after_get_source_and_preserves_injected_components(
-    monkeypatch,
-    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     captured: dict[str, Any] = {}
     manifest = {"version": "1.0.0"}
@@ -69,7 +75,7 @@ def test_execute_uses_config_set_after_get_source_and_preserves_injected_compone
         def parse_args(self, args: list[str]) -> list[str]:
             return args
 
-        def run(self, args: list[str]):
+        def run(self, args: list[str]) -> Iterator[str]:
             yield from args
 
     monkeypatch.setattr(
@@ -90,7 +96,10 @@ def test_execute_uses_config_set_after_get_source_and_preserves_injected_compone
     )
     source.set_config(late_config, validate=False)
     config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps(source._hydrated_config))
+    config_path.write_text(
+        json.dumps(source._hydrated_config),
+        encoding="utf-8",
+    )
 
     list(source.executor.execute(["read", "--config", str(config_path)]))
 

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -39,7 +39,9 @@ def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
         source_manifest=manifest,
     )
 
-    assert source.executor.declarative_source["config"] == config
+    declarative_config = source.executor.declarative_source["config"]
+    assert declarative_config["api_key"] == config["api_key"]
+    assert declarative_config["__injected_components_py"]
     assert captured["config"] == config
     assert config == {"api_key": "configured"}
 

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from airbyte._executors import declarative
+from airbyte._executors.declarative import DeclarativeExecutor
+from airbyte.sources import util as sources_util
+
+
+def test_get_source_passes_config_to_declarative_executor(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    manifest = {"version": "1.0.0"}
+    config = {"api_key": "configured"}
+
+    def fake_get_connector_executor(**kwargs: Any) -> DeclarativeExecutor:
+        captured.update(kwargs)
+        return DeclarativeExecutor(
+            name=kwargs["name"],
+            manifest=kwargs["source_manifest"],
+            config=kwargs["config"],
+        )
+
+    monkeypatch.setattr(
+        sources_util,
+        "get_connector_executor",
+        fake_get_connector_executor,
+    )
+    monkeypatch.setattr(
+        declarative,
+        "ConcurrentDeclarativeSource",
+        lambda **kwargs: kwargs,
+    )
+
+    source = sources_util.get_source(
+        name="source-test",
+        config=config,
+        source_manifest=manifest,
+    )
+
+    assert source.executor.declarative_source["config"] == config
+    assert captured["config"] == config
+
+
+def test_execute_uses_config_set_after_get_source_and_preserves_injected_components(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+    manifest = {"version": "1.0.0"}
+    late_config = {"api_key": "configured-later"}
+
+    def fake_get_connector_executor(**kwargs: Any) -> DeclarativeExecutor:
+        return DeclarativeExecutor(
+            name=kwargs["name"],
+            manifest=kwargs["source_manifest"],
+            config=kwargs["config"],
+            components_py="class Component:\n    pass\n",
+        )
+
+    class FakeEntrypoint:
+        def __init__(self, source: Any) -> None:
+            captured["source"] = source
+
+        def parse_args(self, args: list[str]) -> list[str]:
+            return args
+
+        def run(self, args: list[str]):
+            yield from args
+
+    monkeypatch.setattr(
+        sources_util,
+        "get_connector_executor",
+        fake_get_connector_executor,
+    )
+    monkeypatch.setattr(
+        declarative,
+        "ConcurrentDeclarativeSource",
+        lambda **kwargs: kwargs,
+    )
+    monkeypatch.setattr(declarative, "AirbyteEntrypoint", FakeEntrypoint)
+
+    source = sources_util.get_source(
+        name="source-test",
+        source_manifest=manifest,
+    )
+    source.set_config(late_config, validate=False)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(source._hydrated_config))
+
+    list(source.executor.execute(["read", "--config", str(config_path)]))
+
+    config = captured["source"]["config"]
+    assert config["api_key"] == late_config["api_key"]
+    assert config["__injected_components_py"] == "class Component:\n    pass\n"
+    assert config["__injected_components_py_checksums"]["md5"]
+
+
+def test_declarative_executor_copies_config_before_component_injection() -> None:
+    config = {"api_key": "configured"}
+
+    DeclarativeExecutor(
+        name="source-test",
+        manifest={"version": "1.0.0"},
+        config=config,
+        components_py="class Component:\n    pass\n",
+    )
+
+    assert config == {"api_key": "configured"}


### PR DESCRIPTION
Replaces: airbytehq/PyAirbyte#869

## Summary

This PR extends the contribution from @adileo (_thank you! 🙏_), cherry-picked from airbytehq/PyAirbyte#869 so the original commit authorship is preserved. Requested by @aaronsteers.

Closes airbytehq/PyAirbyte#868.

Declarative sources were built with an effectively empty config, so every `{{ config[...] }}` interpolation a manifest performs at resolution time (dynamic streams, stream templates) resolved to nothing:

```python
# before
ConcurrentDeclarativeSource(config=self._config_dict, ...)  # only ever held the components.py payload
```

The contributor's commits thread `config` from `get_source()` → `get_connector_executor()` → `DeclarativeExecutor.__init__`. The maintainer follow-ups then cover the paths that construction-time config alone misses — config supplied later via `source.set_config()`, and `secret_reference::` values, which are only hydrated into the `--config` temp file at execute time:

```python
def execute(self, args, ...):
    mapped_args = self.map_cli_args(args)
    args_config = _get_config_from_args(mapped_args)   # reads the --config temp file
    source = self._create_declarative_source({**self._config_dict, **args_config})
```

Constructor config stays as the fallback, and the merge order keeps the injected `__injected_components_py` keys intact. A missing, malformed or non-dict `--config` file falls back to the constructor config rather than raising.

Also in the follow-ups: `config` no longer defaults to a mutable `{}` (ruff B006) and is copied into the executor, so component injection can't mutate the caller's dict; parameters after `manifest` are now keyword-only, so `config` can't be silently bound positionally where `components_py` used to sit.

## Test plan

New offline unit tests in `tests/unit_tests/test_declarative_executor.py` cover config via `get_source()`, config via `set_config()` after construction, survival of the injected components keys, and caller-dict immutability. All three fail with the fix reverted.

Manual repro of #868 against a local HTTP server, using a manifest whose `url_base` is `{{ config['base_url'] }}`, so a resolved config is observable as a real request rather than inferred:

| checkout | config supplied via | `source.check()` | records read | requests reaching the server |
| --- | --- | --- | --- | --- |
| `main` (f65f227) | `get_source()` | fail (`MissingSchema`) | fail | 0 |
| `main` (f65f227) | `set_config()` | fail (`MissingSchema`) | fail | 0 |
| this branch | `get_source()` | pass | 2 | `/items` |
| this branch | `set_config()` | pass | 2 | `/items` |

Local checks: `ruff check .`, `ruff format --check .`, `mypy airbyte`, `pytest tests/unit_tests/test_declarative_executor.py`, `pytest tests/integration_tests/destinations/test_source_to_destination.py` — all pass. Credential-gated suites were not run locally.

Link to Devin session: https://app.devin.ai/sessions/e76350e6c7c043c791504ee50fc27bbe