### PR TITLE
refactor: apply complexipy refactor suggestions (evaluation demo, do not merge)

### DIFF
--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -324,6 +324,11 @@ class ConnectorBase(abc.ABC):
             # Version not detected, so return None.
             return None
 
+    # TK: C002/loop_guards; complexity 8 -> 7; measured=False.
+    # TK: Suggested replacement: if not msg.type == Type.CONNECTION_STATUS and msg.connectionStatus: continue  # noqa: E501
+    # TK: Rejected; the negation is wrong and continue skips FAILED handling
+    # TK: and the post-loop raise.
+    # TK: Reviewer: confirm this behavior-changing suggestion remains unapplied before merge.
     def check(self) -> None:
         """Call check on the connector.
 

--- a/airbyte/_connector_base.py
+++ b/airbyte/_connector_base.py
@@ -326,8 +326,10 @@ class ConnectorBase(abc.ABC):
 
     # TK: C002/loop_guards; complexity 8 -> 7; measured=False.
     # TK: Suggested replacement: if not msg.type == Type.CONNECTION_STATUS and msg.connectionStatus: continue  # noqa: E501
-    # TK: Rejected; the negation is wrong and continue skips FAILED handling
-    # TK: and the post-loop raise.
+    # TK: Rejected; guard 1 is `(not A) and B`, not the complement of
+    # TK: `A and B`, so it misses some non-status messages.
+    # TK: Guard 2 lets FAILED messages continue past the
+    # TK: `AirbyteConnectorCheckFailedError` raise.
     # TK: Reviewer: confirm this behavior-changing suggestion remains unapplied before merge.
     def check(self) -> None:
         """Call check on the connector.

--- a/airbyte/_registry_utils.py
+++ b/airbyte/_registry_utils.py
@@ -88,7 +88,13 @@ def fetch_registry_version_date(connector_name: str, version: str) -> str | None
 
     Returns the release date string (YYYY-MM-DD) if found, None otherwise.
     """
-    try:  # noqa: PLR1702
+    # TK: C007/collapsible_if; complexity 16 -> 8; measured=True.
+    # TK: Suggested replacement: if version in release_candidates and commit_timestamp and date_match:  # noqa: E501
+    # TK: Applied continue guards for nonmatching repositories and preserved
+    # TK: the matching-connector break.
+    # TK: Reviewer: confirm the for-else, broad debug exception, early return,
+    # TK: and trailing return semantics.
+    try:
         registry_url = "https://connectors.airbyte.com/files/registries/v0/oss_registry.json"
         response = requests.get(registry_url, timeout=10)
         response.raise_for_status()
@@ -98,22 +104,24 @@ def fetch_registry_version_date(connector_name: str, version: str) -> str | None
 
         for connector in connector_list:
             docker_repo = connector.get("dockerRepository", "")
-            if docker_repo == f"airbyte/{connector_name}":
-                releases = connector.get("releases", {})
-                release_candidates = releases.get("releaseCandidates", {})
+            if docker_repo != f"airbyte/{connector_name}":
+                continue
 
-                if version in release_candidates:
-                    version_data = release_candidates[version]
-                    generated = version_data.get("generated", {})
-                    git_info = generated.get("git", {})
-                    commit_timestamp = git_info.get("commit_timestamp")
+            releases = connector.get("releases", {})
+            release_candidates = releases.get("releaseCandidates", {})
 
-                    if commit_timestamp:
-                        date_match = re.match(r"(\d{4}-\d{2}-\d{2})", commit_timestamp)
-                        if date_match:
-                            return date_match.group(1)
+            if version in release_candidates:
+                version_data = release_candidates[version]
+                generated = version_data.get("generated", {})
+                git_info = generated.get("git", {})
+                commit_timestamp = git_info.get("commit_timestamp")
 
-                break
+                if commit_timestamp:
+                    date_match = re.match(r"(\d{4}-\d{2}-\d{2})", commit_timestamp)
+                    if date_match:
+                        return date_match.group(1)
+
+            break
         else:
             return None
     except Exception as e:

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -181,6 +181,13 @@ def get_web_url_root(api_root: str) -> str:
     return api_root
 
 
+# TK: C005/extract_predicate; complexity 7 -> 5; measured=False.
+# TK: Suggested replacement: def _check_condition_L210() -> bool: return bearer_token is None and (client_id is None or client_secret is None)  # noqa: E501
+# TK: Suggested replacement: def _check_condition_L217() -> bool: return bearer_token is not None and (client_id is not None or client_secret is not None)  # noqa: E501
+# TK: Rejected; line-derived closure names rot, and closures are folded into
+# TK: the parent score.
+# TK: Reviewer: confirm the auth checks remain inline and both authentication
+# TK: branches stay unchanged.
 def get_airbyte_server_instance(
     *,
     api_root: str,

--- a/airbyte/secrets/util.py
+++ b/airbyte/secrets/util.py
@@ -110,6 +110,12 @@ def get_secret(
         sources = [sources]  # type: ignore [unreachable]  # This is a 'just in case' catch.
 
     # Replace any SecretSourceEnum strings with the matching SecretManager object
+    # TK: C002/loop_guards; complexity 18 -> 17; measured=False.
+    # TK: Suggested replacement: if not isinstance(source, SecretSourceEnum): continue / if not source not in available_sources: continue  # noqa: E501
+    # TK: Rejected; continue skips the following sources[...] mapping
+    # TK: assignment and breaks resolution.
+    # TK: Reviewer: confirm both guards remain nested so invalid-source
+    # TK: handling and mapping semantics are intact.
     for source in list(sources):
         if isinstance(source, SecretSourceEnum):
             if source not in available_sources:

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -64,6 +64,47 @@ from airbyte.constants import (
 )
 
 
+def _build_sample_table(
+    dataset: InMemoryDataset,
+    *,
+    internal_cols: list[str],
+    col_limit: int,
+) -> Table:
+    """Build a rich table for one stream's sample records."""
+    table = Table(
+        show_header=True,
+        show_lines=True,
+    )
+    if len(dataset.column_names) > col_limit:
+        # We'll pivot the columns so each column is its own row
+        table.add_column("Column Name")
+        for _ in range(len(dataset)):
+            table.add_column(overflow="fold")
+        for col in dataset.column_names:
+            table.add_row(
+                Markdown(f"**`{col}`**"),
+                *[escape(str(record[col])) for record in dataset],
+            )
+    else:
+        for col in dataset.column_names:
+            table.add_column(
+                Markdown(f"**`{col}`**"),
+                overflow="fold",
+            )
+
+        for record in dataset:
+            table.add_row(
+                *[
+                    escape(str(val))
+                    for key, val in record.items()
+                    # Exclude internal Airbyte columns.
+                    if key not in internal_cols
+                ]
+            )
+
+    return table
+
+
 class Source(ConnectorBase):  # noqa: PLR0904
     """A class representing a source that can be called."""
 
@@ -661,6 +702,11 @@ class Source(ConnectorBase):  # noqa: PLR0904
 
         return results
 
+    # TK: C003/extract_helper; complexity 20 -> 4; measured=False.
+    # TK: Suggested replacement: Extract lines 692-738 into a named helper function.
+    # TK: Applied a module-level table builder; print_samples still prints the same Table.
+    # TK: Reviewer: confirm rendered output remains byte-identical and note
+    # TK: the module total is unchanged.
     def print_samples(
         self,
         streams: list[str] | Literal["*"] | None = None,
@@ -698,43 +744,17 @@ class Source(ConnectorBase):  # noqa: PLR0904
             )
             dataset = samples[stream]
 
-            table = Table(
-                show_header=True,
-                show_lines=True,
-            )
             if dataset is None:
                 console.print(
                     Markdown("**⚠️ `Error fetching sample records.` ⚠️**"),
                 )
                 continue
 
-            if len(dataset.column_names) > col_limit:
-                # We'll pivot the columns so each column is its own row
-                table.add_column("Column Name")
-                for _ in range(len(dataset)):
-                    table.add_column(overflow="fold")
-                for col in dataset.column_names:
-                    table.add_row(
-                        Markdown(f"**`{col}`**"),
-                        *[escape(str(record[col])) for record in dataset],
-                    )
-            else:
-                for col in dataset.column_names:
-                    table.add_column(
-                        Markdown(f"**`{col}`**"),
-                        overflow="fold",
-                    )
-
-                for record in dataset:
-                    table.add_row(
-                        *[
-                            escape(str(val))
-                            for key, val in record.items()
-                            # Exclude internal Airbyte columns.
-                            if key not in internal_cols
-                        ]
-                    )
-
+            table = _build_sample_table(
+                dataset,
+                internal_cols=internal_cols,
+                col_limit=col_limit,
+            )
             console.print(table)
 
         console.print(Markdown("--------------"))


### PR DESCRIPTION
## Summary

**Do not merge.** This is an evaluation artifact requested by AJ: it shows what `complexipy --suggest-refactors` (v7.0.1) actually recommends on this repo and what an agent does with those recommendations. Every touched function carries a `# TK:` block quoting the tool's literal suggestion and recording the verdict — those blocks intentionally block merge.

`complexipy` emitted 97 refactor plans over 81 first-party functions here (`C003 extract_helper` 40, `C007 collapsible_if` 29, `C001 flatten_condition` 16, `C005 extract_predicate` 5, `C002 loop_guards` 4, `C004 split_dispatcher` 3), 38 of them labeled `MachineApplicable`. Two were worth applying; three representative ones are documented and deliberately not applied.

**Applied**

1. `fetch_registry_version_date` (`C007`, 16 → 8, `MachineApplicable`, measured). The tool's literal patch was `if version in release_candidates and commit_timestamp and date_match:` — invalid, because `commit_timestamp` and `date_match` are assigned in statements *between* the nested `if`s. The finding was right, so the loop was flattened by hand with a `continue` guard, preserving the `for/else → return None`, the `break`, and the broad `except` path. The now-unneeded `# noqa: PLR1702` came off.
2. `Source.print_samples` (`C003`, claims 20 → 4, unmeasured). Table construction moved to a module-level `_build_sample_table(dataset, *, internal_cols, col_limit) -> Table`. Note the honest caveat recorded in the code: the per-function score drops because code moved, not because anything got simpler — module total is roughly unchanged.

**Rejected, with the reasoning left in the source**

3. `ConnectorBase.check` (`C002`): the plan emitted two guards, `if not msg.type == Type.CONNECTION_STATUS and msg.connectionStatus: continue` and `if not msg.connectionStatus.status != Status.FAILED: continue`. The first is `(not A) and B` where the complement of `A and B` is `not A or not B`, so it misses some non-status messages; the second lets a FAILED message `continue` past the `AirbyteConnectorCheckFailedError` raise.
4. `get_secret` (`C002`): the emitted guards are logically equivalent, but `continue` skips the `sources[sources.index(source)] = available_sources[source]` mapping assignment that follows, silently breaking secret-source resolution.
5. `get_airbyte_server_instance` (`C005`): suggests closures literally named `_check_condition_L210` / `_check_condition_L217`. Line-derived names rot on the next edit, and complexipy folds closures into the parent score, so the claimed reduction is unmeasured and probably illusory.

The headline evaluation result: across all 29 `C007` "collapsible if" plans in this repo, **zero** point at an `if` whose body is a single nested `if` — i.e. none are literally collapsible as emitted, yet most are labeled `MachineApplicable` with a measured reduction. The findings are useful as pointers; the patches are not safe to apply mechanically.

Also surfaced during review, and *not* fixed here because it predates this PR: `print_samples` builds headers from every column but strips `_airbyte_*` internal columns from the row values, so non-pivoted sample tables render shifted values on `main` today. See the review thread — a separate PR is the right home for that fix.

Companion PR in `airbyte-ops-mcp`: https://github.com/airbytehq/airbyte-ops-mcp/pull/1294

## Test plan

- `poetry run ruff format --check .` and `poetry run ruff check .` — clean.
- `pytest tests/unit_tests/ -m 'not slow and not requires_creds'` — 489 passed, 1 skipped.
- `mypy` was not available in the local environment and was not run; CI covers it (all 20 checks green).
- Both applied refactors are behavior-preserving by inspection; `print_samples` output is unchanged (rendering logic moved verbatim).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal processing for registry version lookup and sample-table generation.
  * Preserved existing connector checks, authentication, secret retrieval, version lookup, and sample output behavior.

* **Documentation**
  * Added developer guidance and complexity-analysis notes to support code review and maintenance.

* **Bug Fixes**
  * No user-facing bug fixes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Link to Devin session: https://app.devin.ai/sessions/4049f7c11fde48d3a4fe007221666f5e
Requested by: @aaronsteers