### PR TITLE
test(mcp): pin API-root, credential, and trust config args as non-header-controllable

### DIFF
--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
+from fastmcp_extensions import MCPServerConfigArg
 
 from airbyte.mcp._tool_utils import (
     API_URL_CONFIG_ARG,
@@ -155,11 +156,11 @@ def test_duplicate_guid_registration_is_idempotent() -> None:
         pytest.param(TRUSTED_EXECUTION_CONFIG_ARG, id="trusted_execution"),
     ],
 )
-def test_config_args_are_not_caller_controllable(config_arg: object) -> None:
+def test_config_args_are_not_caller_controllable(config_arg: MCPServerConfigArg) -> None:
     """API roots, downstream credentials, and the trust gate are server-side only.
 
     A request header source for these would let a caller redirect the server's
     credentialed outbound requests, act as another Cloud identity, or widen the
     tool surface.
     """
-    assert config_arg.http_header_key is None  # type: ignore[attr-defined]
+    assert config_arg.http_header_key is None

--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -9,6 +9,11 @@ from unittest.mock import patch
 import pytest
 
 from airbyte.mcp._tool_utils import (
+    API_URL_CONFIG_ARG,
+    CLIENT_ID_CONFIG_ARG,
+    CLIENT_SECRET_CONFIG_ARG,
+    CONFIG_API_URL_CONFIG_ARG,
+    TRUSTED_EXECUTION_CONFIG_ARG,
     SafeModeError,
     _GUIDS_CREATED_IN_SESSION,
     _resolve_transport_bearer_token,
@@ -138,3 +143,23 @@ def test_duplicate_guid_registration_is_idempotent() -> None:
     register_guid_created_in_session("duplicate-guid")
     register_guid_created_in_session("duplicate-guid")
     assert "duplicate-guid" in _GUIDS_CREATED_IN_SESSION
+
+
+@pytest.mark.parametrize(
+    "config_arg",
+    [
+        pytest.param(API_URL_CONFIG_ARG, id="api_url"),
+        pytest.param(CONFIG_API_URL_CONFIG_ARG, id="config_api_url"),
+        pytest.param(CLIENT_ID_CONFIG_ARG, id="client_id"),
+        pytest.param(CLIENT_SECRET_CONFIG_ARG, id="client_secret"),
+        pytest.param(TRUSTED_EXECUTION_CONFIG_ARG, id="trusted_execution"),
+    ],
+)
+def test_config_args_are_not_caller_controllable(config_arg: object) -> None:
+    """API roots, downstream credentials, and the trust gate are server-side only.
+
+    A request header source for these would let a caller redirect the server's
+    credentialed outbound requests, act as another Cloud identity, or widen the
+    tool surface.
+    """
+    assert config_arg.http_header_key is None  # type: ignore[attr-defined]

--- a/tests/unit_tests/test_mcp_tool_utils.py
+++ b/tests/unit_tests/test_mcp_tool_utils.py
@@ -156,7 +156,9 @@ def test_duplicate_guid_registration_is_idempotent() -> None:
         pytest.param(TRUSTED_EXECUTION_CONFIG_ARG, id="trusted_execution"),
     ],
 )
-def test_config_args_are_not_caller_controllable(config_arg: MCPServerConfigArg) -> None:
+def test_config_args_are_not_caller_controllable(
+    config_arg: MCPServerConfigArg,
+) -> None:
     """API roots, downstream credentials, and the trust gate are server-side only.
 
     A request header source for these would let a caller redirect the server's


### PR DESCRIPTION
## Summary

Adds a regression guard for the hardening landed in #1080 (API base URLs), #1082 (trusted execution), and #1111 (client id/secret): those config args intentionally have no `http_header_key`, but nothing in the test suite asserted it, so re-adding a header source would pass CI silently.

```python
@pytest.mark.parametrize("config_arg", [API_URL_CONFIG_ARG, CONFIG_API_URL_CONFIG_ARG,
                                        CLIENT_ID_CONFIG_ARG, CLIENT_SECRET_CONFIG_ARG,
                                        TRUSTED_EXECUTION_CONFIG_ARG])
def test_config_args_are_not_caller_controllable(config_arg):
    assert config_arg.http_header_key is None
```

Motivation: an externally reported issue described redirecting the server's Airbyte Cloud client-credentials token exchange via a caller-supplied API-root header, against a commit predating #1080. The behavior is already fixed on `main`; this only locks the invariant in place. No production code changes.

Requested by Pablo Vega while assessing that report.

## Test Plan

`poetry run pytest tests/unit_tests/test_mcp_tool_utils.py` (16 passed locally), plus a manual check against the HTTP MCP server on `main`: a `tools/call` request carrying `X-Airbyte-Cloud-Api-Url` pointing at a local listener never reached the listener — the token exchange still went to the configured Airbyte Cloud endpoint.


Link to Devin session: https://app.devin.ai/sessions/bca7038d86fd453998a2f1f5218776e3
Requested by: @pablo-airbyte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that MCP configuration arguments cannot be overridden through caller-provided HTTP headers.
  * Added parameterized validation across five supported MCP configuration arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->