### PR TITLE
feat(mcp): Instrument MCP tool calls with telemetry

### DIFF
--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -51,7 +51,7 @@ from airbyte._util.connector_info import (
     WriterRuntimeInfo,
 )
 from airbyte._util.hashing import one_way_hash
-from airbyte.constants import AIRBYTE_OFFLINE_MODE
+from airbyte.constants import AIRBYTE_OFFLINE_MODE, is_hosted_mcp_mode
 from airbyte.version import get_version
 
 
@@ -184,14 +184,14 @@ class EventType(str, Enum):
     SYNC = "sync"
     VALIDATE = "validate"
     CHECK = "check"
+    MCP_TOOL_CALL = "mcp_tool_call"
 
 
 @lru_cache
-def get_env_flags() -> dict[str, Any]:
+def _get_static_env_flags() -> dict[str, Any]:
     flags: dict[str, bool | str] = {
         "CI": meta.is_ci(),
         "LANGCHAIN": meta.is_langchain(),
-        "MCP": meta.is_mcp_mode(),
         "NOTEBOOK_RUNTIME": (
             "GOOGLE_COLAB"
             if meta.is_colab()
@@ -206,7 +206,17 @@ def get_env_flags() -> dict[str, Any]:
     return {k: v for k, v in flags.items() if v is not None and v is not False}
 
 
-def send_telemetry(
+def get_env_flags() -> dict[str, Any]:
+    """Return the current environment flags used by telemetry."""
+    flags = {
+        **_get_static_env_flags(),
+        "MCP": meta.is_mcp_mode(),
+        "HOSTED_MCP": is_hosted_mcp_mode(),
+    }
+    return {k: v for k, v in flags.items() if v is not None and v is not False}
+
+
+def send_telemetry(  # noqa: PLR0913
     *,
     source: ConnectorRuntimeInfo | None,
     destination: ConnectorRuntimeInfo | None,
@@ -215,6 +225,8 @@ def send_telemetry(
     event_type: EventType,
     number_of_records: int | None = None,
     exception: Exception | None = None,
+    tool_name: str | None = None,
+    duration_ms: int | None = None,
 ) -> None:
     # If DO_NOT_TRACK is set, we don't send any telemetry
     if os.environ.get(DO_NOT_TRACK) or AIRBYTE_OFFLINE_MODE:
@@ -238,6 +250,12 @@ def send_telemetry(
 
     if cache:
         payload_props["cache"] = cache.to_dict()
+
+    if tool_name is not None:
+        payload_props["tool_name"] = tool_name
+
+    if duration_ms is not None:
+        payload_props["duration_ms"] = duration_ms
 
     if exception:
         if isinstance(exception, exc.AirbyteError):
@@ -299,6 +317,25 @@ def log_connector_check_result(
         cache=None,
         state=state,
         event_type=EventType.CHECK,
+        exception=exception,
+    )
+
+
+def log_mcp_tool_call(
+    tool_name: str,
+    state: EventState,
+    duration_ms: int,
+    exception: Exception | None = None,
+) -> None:
+    """Log an MCP tool call result."""
+    send_telemetry(
+        source=None,
+        destination=None,
+        cache=None,
+        state=state,
+        event_type=EventType.MCP_TOOL_CALL,
+        tool_name=tool_name,
+        duration_ms=duration_ms,
         exception=exception,
     )
 

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -76,6 +76,9 @@ It is not a unique identifier for the user.
 DO_NOT_TRACK = "DO_NOT_TRACK"
 """Environment variable to opt-out of telemetry."""
 
+TELEMETRY_REQUEST_TIMEOUT_SECONDS = 2
+# Keep a stalled telemetry endpoint from blocking callers indefinitely.
+
 _ENV_ANALYTICS_ID = "AIRBYTE_ANALYTICS_ID"  # Allows user to override the anonymous user ID
 _ANALYTICS_FILE = Path.home() / ".airbyte" / "analytics.yml"
 _ANALYTICS_ID: str | bool | None = None
@@ -278,6 +281,7 @@ def send_telemetry(  # noqa: PLR0913
                 "properties": payload_props,
                 "timestamp": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
             },
+            timeout=TELEMETRY_REQUEST_TIMEOUT_SECONDS,
         )
 
 

--- a/airbyte/_util/telemetry.py
+++ b/airbyte/_util/telemetry.py
@@ -77,7 +77,7 @@ DO_NOT_TRACK = "DO_NOT_TRACK"
 """Environment variable to opt-out of telemetry."""
 
 TELEMETRY_REQUEST_TIMEOUT_SECONDS = 2
-# Keep a stalled telemetry endpoint from blocking callers indefinitely.
+"""Keep a stalled telemetry endpoint from blocking callers indefinitely."""
 
 _ENV_ANALYTICS_ID = "AIRBYTE_ANALYTICS_ID"  # Allows user to override the anonymous user ID
 _ANALYTICS_FILE = Path.home() / ".airbyte" / "analytics.yml"

--- a/airbyte/mcp/_telemetry.py
+++ b/airbyte/mcp/_telemetry.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
+from functools import partial
 from time import perf_counter
 from typing import TYPE_CHECKING
 
@@ -16,6 +18,9 @@ if TYPE_CHECKING:
     from fastmcp.server.middleware import CallNext, MiddlewareContext
     from fastmcp.tools.base import ToolResult
     from mcp.types import CallToolRequestParams
+
+
+_TELEMETRY_FUTURES: set[asyncio.Future[None]] = set()
 
 
 class MCPToolCallTelemetryMiddleware(Middleware):
@@ -58,9 +63,43 @@ class MCPToolCallTelemetryMiddleware(Middleware):
         exception: Exception | None = None,
     ) -> None:
         with suppress(Exception):
-            log_mcp_tool_call(
-                tool_name=tool_name,
-                state=state,
-                duration_ms=duration_ms,
-                exception=exception,
+            future: asyncio.Future[None] = asyncio.get_running_loop().run_in_executor(
+                None,
+                partial(
+                    _send_telemetry,
+                    tool_name=tool_name,
+                    state=state,
+                    duration_ms=duration_ms,
+                    exception=exception,
+                ),
             )
+            _TELEMETRY_FUTURES.add(future)
+            future.add_done_callback(_cleanup_telemetry_future)
+
+
+def _send_telemetry(
+    *,
+    tool_name: str,
+    state: EventState,
+    duration_ms: int,
+    exception: Exception | None,
+) -> None:
+    with suppress(Exception):
+        log_mcp_tool_call(
+            tool_name=tool_name,
+            state=state,
+            duration_ms=duration_ms,
+            exception=exception,
+        )
+
+
+def _cleanup_telemetry_future(future: asyncio.Future[None]) -> None:
+    _TELEMETRY_FUTURES.discard(future)
+    with suppress(asyncio.CancelledError, Exception):
+        future.result()
+
+
+async def _wait_for_pending_telemetry() -> None:
+    pending_futures = tuple(_TELEMETRY_FUTURES)
+    if pending_futures:
+        await asyncio.gather(*pending_futures, return_exceptions=True)

--- a/airbyte/mcp/_telemetry.py
+++ b/airbyte/mcp/_telemetry.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""FastMCP middleware for MCP tool-call telemetry."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from time import perf_counter
+from typing import TYPE_CHECKING
+
+from fastmcp.server.middleware import Middleware
+
+from airbyte._util.telemetry import EventState, log_mcp_tool_call
+
+
+if TYPE_CHECKING:
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.base import ToolResult
+    from mcp.types import CallToolRequestParams
+
+
+class MCPToolCallTelemetryMiddleware(Middleware):
+    """Record the outcome and duration of each MCP tool call."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        started_at = perf_counter()
+        try:
+            result = await call_next(context)
+        except Exception as exception:
+            self._log(
+                tool_name=context.message.name,
+                state=EventState.FAILED,
+                duration_ms=self._duration_ms(started_at),
+                exception=exception,
+            )
+            raise
+        else:
+            self._log(
+                tool_name=context.message.name,
+                state=EventState.SUCCEEDED,
+                duration_ms=self._duration_ms(started_at),
+            )
+            return result
+
+    @staticmethod
+    def _duration_ms(started_at: float) -> int:
+        return int((perf_counter() - started_at) * 1000)
+
+    @staticmethod
+    def _log(
+        *,
+        tool_name: str,
+        state: EventState,
+        duration_ms: int,
+        exception: Exception | None = None,
+    ) -> None:
+        with suppress(Exception):
+            log_mcp_tool_call(
+                tool_name=tool_name,
+                state=state,
+                duration_ms=duration_ms,
+                exception=exception,
+            )

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
 
 from airbyte._util.meta import set_mcp_mode
 from airbyte.mcp._config import load_secrets_to_env_vars
+from airbyte.mcp._telemetry import MCPToolCallTelemetryMiddleware
 from airbyte.mcp._tool_utils import (
     AIRBYTE_EXCLUDE_MODULES_CONFIG_ARG,
     AIRBYTE_INCLUDE_MODULES_CONFIG_ARG,
@@ -319,6 +320,7 @@ app = mcp_server(
         airbyte_readonly_mode_filter,
         airbyte_module_filter,
     ],
+    middleware=[MCPToolCallTelemetryMiddleware()],
     auth=_create_auth(),
 )
 """The Airbyte MCP Server application instance."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ fix-and-check = { shell = "poe fix && poe check" }
 
 # MCP Server Tasks
 mcp-serve-local = { cmd = "airbyte-mcp", help = "Start the MCP server with STDIO transport" }
-mcp-serve-http = { cmd = "python -c \"from airbyte.mcp.server import app; app.run(transport='http', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with HTTP transport" }
+mcp-serve-http = { cmd = "airbyte-mcp-http", help = "Start the MCP server with HTTP transport" }
 mcp-serve-sse = { cmd = "python -c \"from airbyte.mcp.server import app; app.run(transport='sse', host='127.0.0.1', port=8000)\"", help = "Start the MCP server with SSE transport" }
 mcp-inspect = { cmd = "fastmcp inspect airbyte/mcp/server.py:app", help = "Inspect MCP tools and resources (supports --tools, --health, etc.)" }
 mcp-tool-test = { cmd = "python -m fastmcp_extensions.utils.test_tool --app airbyte.mcp.server:app", help = "Test MCP tools directly with JSON arguments: poe mcp-tool-test <tool_name> '<json_args>'" }

--- a/tests/unit_tests/test_mcp_telemetry.py
+++ b/tests/unit_tests/test_mcp_telemetry.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+import responses
+from mcp.types import CallToolRequestParams
+
+from airbyte import constants
+from airbyte._util import telemetry
+from airbyte.mcp import _telemetry as mcp_telemetry
+from airbyte.mcp._telemetry import MCPToolCallTelemetryMiddleware
+from fastmcp.server.middleware import MiddlewareContext
+
+
+def _context() -> MiddlewareContext[CallToolRequestParams]:
+    return MiddlewareContext(
+        message=CallToolRequestParams(
+            name="secret_tool",
+            arguments={"api_key": "secret_argument"},
+        ),
+        method="tools/call",
+    )
+
+
+@responses.activate
+def test_mcp_tool_call_telemetry_success_does_not_capture_arguments_or_result(
+    monkeypatch,
+):
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    responses.add(responses.POST, "https://api.segment.io/v1/track", status=200)
+
+    async def call_next(
+        _context: MiddlewareContext[CallToolRequestParams],
+    ) -> dict[str, str]:
+        return {"secret_result": "result_value"}
+
+    result = asyncio.run(
+        MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
+    )
+
+    assert result == {"secret_result": "result_value"}
+    assert len(responses.calls) == 1
+    body = json.loads(responses.calls[0].request.body)
+    properties = body["properties"]
+    assert body["event"] == telemetry.EventType.MCP_TOOL_CALL
+    assert properties["tool_name"] == "secret_tool"
+    assert properties["state"] == telemetry.EventState.SUCCEEDED
+    assert isinstance(properties["duration_ms"], int)
+    assert "secret_argument" not in body["properties"]
+    assert "result_value" not in body["properties"]
+
+
+@responses.activate
+def test_mcp_tool_call_telemetry_failure_reraises_original_exception(monkeypatch):
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    responses.add(responses.POST, "https://api.segment.io/v1/track", status=200)
+    error = RuntimeError("tool failed")
+
+    async def call_next(_context: MiddlewareContext[CallToolRequestParams]) -> object:
+        raise error
+
+    with pytest.raises(RuntimeError) as raised:
+        asyncio.run(
+            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
+        )
+
+    assert raised.value is error
+    body = json.loads(responses.calls[0].request.body)
+    properties = body["properties"]
+    assert properties["state"] == telemetry.EventState.FAILED
+    assert properties["exception"] == {"class": "RuntimeError"}
+
+
+@pytest.mark.parametrize("do_not_track", ["1", "true", "t"])
+@responses.activate
+def test_mcp_tool_call_telemetry_respects_do_not_track(monkeypatch, do_not_track):
+    monkeypatch.setenv("DO_NOT_TRACK", do_not_track)
+    responses.add(responses.POST, "https://api.segment.io/v1/track", status=200)
+
+    async def call_next(_context: MiddlewareContext[CallToolRequestParams]) -> str:
+        return "result"
+
+    assert (
+        asyncio.run(
+            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
+        )
+        == "result"
+    )
+    assert not responses.calls
+
+
+def test_mcp_tool_call_telemetry_swallows_telemetry_errors(monkeypatch):
+    def fail_logging(**kwargs: object) -> None:
+        raise RuntimeError("telemetry failed")
+
+    monkeypatch.setattr(
+        mcp_telemetry,
+        "log_mcp_tool_call",
+        fail_logging,
+    )
+
+    async def call_next(_context: MiddlewareContext[CallToolRequestParams]) -> str:
+        return "result"
+
+    assert (
+        asyncio.run(
+            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
+        )
+        == "result"
+    )
+
+
+def test_mcp_tool_call_telemetry_middleware_is_registered():
+    from airbyte.mcp.server import app
+
+    assert any(
+        isinstance(middleware, MCPToolCallTelemetryMiddleware)
+        for middleware in app.middleware
+    )
+
+
+def test_hosted_mcp_flag_is_evaluated_for_each_event(monkeypatch):
+    monkeypatch.setattr(constants, "_HOSTED_MCP_MODE_ENABLED", False)
+
+    before = telemetry.get_env_flags()
+    constants.set_hosted_mcp_mode()
+    after = telemetry.get_env_flags()
+
+    assert "HOSTED_MCP" not in before
+    assert after["HOSTED_MCP"] is True

--- a/tests/unit_tests/test_mcp_telemetry.py
+++ b/tests/unit_tests/test_mcp_telemetry.py
@@ -49,8 +49,9 @@ def test_mcp_tool_call_telemetry_success_does_not_capture_arguments_or_result(
     assert properties["tool_name"] == "secret_tool"
     assert properties["state"] == telemetry.EventState.SUCCEEDED
     assert isinstance(properties["duration_ms"], int)
-    assert "secret_argument" not in body["properties"]
-    assert "result_value" not in body["properties"]
+    serialized_properties = json.dumps(properties)
+    assert "secret_argument" not in serialized_properties
+    assert "result_value" not in serialized_properties
 
 
 @responses.activate

--- a/tests/unit_tests/test_mcp_telemetry.py
+++ b/tests/unit_tests/test_mcp_telemetry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
+from threading import Event
 
 import pytest
 import responses
@@ -25,6 +27,17 @@ def _context() -> MiddlewareContext[CallToolRequestParams]:
     )
 
 
+async def _call_tool_and_wait(
+    call_next,
+):
+    try:
+        return await MCPToolCallTelemetryMiddleware().on_call_tool(
+            _context(), call_next
+        )
+    finally:
+        await mcp_telemetry._wait_for_pending_telemetry()
+
+
 @responses.activate
 def test_mcp_tool_call_telemetry_success_does_not_capture_arguments_or_result(
     monkeypatch,
@@ -37,9 +50,7 @@ def test_mcp_tool_call_telemetry_success_does_not_capture_arguments_or_result(
     ) -> dict[str, str]:
         return {"secret_result": "result_value"}
 
-    result = asyncio.run(
-        MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
-    )
+    result = asyncio.run(_call_tool_and_wait(call_next))
 
     assert result == {"secret_result": "result_value"}
     assert len(responses.calls) == 1
@@ -64,9 +75,7 @@ def test_mcp_tool_call_telemetry_failure_reraises_original_exception(monkeypatch
         raise error
 
     with pytest.raises(RuntimeError) as raised:
-        asyncio.run(
-            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
-        )
+        asyncio.run(_call_tool_and_wait(call_next))
 
     assert raised.value is error
     body = json.loads(responses.calls[0].request.body)
@@ -84,12 +93,7 @@ def test_mcp_tool_call_telemetry_respects_do_not_track(monkeypatch, do_not_track
     async def call_next(_context: MiddlewareContext[CallToolRequestParams]) -> str:
         return "result"
 
-    assert (
-        asyncio.run(
-            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
-        )
-        == "result"
-    )
+    assert asyncio.run(_call_tool_and_wait(call_next)) == "result"
     assert not responses.calls
 
 
@@ -106,12 +110,43 @@ def test_mcp_tool_call_telemetry_swallows_telemetry_errors(monkeypatch):
     async def call_next(_context: MiddlewareContext[CallToolRequestParams]) -> str:
         return "result"
 
-    assert (
-        asyncio.run(
-            MCPToolCallTelemetryMiddleware().on_call_tool(_context(), call_next)
-        )
-        == "result"
+    assert asyncio.run(_call_tool_and_wait(call_next)) == "result"
+
+
+@responses.activate
+def test_mcp_tool_call_returns_before_slow_telemetry_finishes(monkeypatch):
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    telemetry_started = Event()
+    telemetry_delay_seconds = 0.5
+
+    def slow_telemetry(request):
+        telemetry_started.set()
+        time.sleep(telemetry_delay_seconds)
+        return (200, {}, "")
+
+    responses.add_callback(
+        responses.POST,
+        "https://api.segment.io/v1/track",
+        callback=slow_telemetry,
     )
+
+    async def call_next(
+        _context: MiddlewareContext[CallToolRequestParams],
+    ) -> dict[str, str]:
+        return {"result": "value"}
+
+    async def call_tool():
+        started_at = time.perf_counter()
+        result = await MCPToolCallTelemetryMiddleware().on_call_tool(
+            _context(), call_next
+        )
+        elapsed_seconds = time.perf_counter() - started_at
+        assert await asyncio.to_thread(telemetry_started.wait, 1)
+        assert elapsed_seconds < telemetry_delay_seconds / 2
+        await mcp_telemetry._wait_for_pending_telemetry()
+        return result
+
+    assert asyncio.run(call_tool()) == {"result": "value"}
 
 
 def test_mcp_tool_call_telemetry_middleware_is_registered():


### PR DESCRIPTION
## Summary

Requested by AJ Steers (@aaronsteers) while reviewing the MCP reporting page in airbytehq/internal.airbyte.ai#128, which turned out to be uncharted-able: nothing under `airbyte/mcp/` emitted telemetry at all, so the only MCP-attributed rows in the warehouse are `sync` events — and the MCP server has sync actions disabled in most deployments. The useful MCP actions (checking logs, discovering connectors, cloud operations) were invisible, and hosted Cloud MCP — which powers the Cloud support bot and agent use cases — was indistinguishable downstream from a local stdio server.

Three gaps are closed:

**1. Per-tool-call events.** A new `EventType.MCP_TOOL_CALL` plus a FastMCP middleware that wraps every tool invocation:

```python
class MCPToolCallTelemetryMiddleware(Middleware):
    async def on_call_tool(self, context, call_next):
        started_at = perf_counter()
        try:
            result = await call_next(context)
        except Exception as exception:
            self._log(tool_name=..., state=FAILED, duration_ms=..., exception=exception)
            raise           # original exception, unchanged
        else:
            self._log(tool_name=..., state=SUCCEEDED, duration_ms=...)
            return result
```

Registered once where the app is built in `airbyte/mcp/server.py`, so stdio and HTTP transports both get it. Exactly one terminal event per call — no `started` row, so a downstream aggregate doesn't double-count the way `sync` does.

Deliberately narrow payload: `tool_name`, `state`, `duration_ms`, and the existing `exception` shape (`safe_logging_dict()` for `AirbyteError`, class name otherwise). Tool **arguments and results are never captured** — they routinely carry connector config, secrets, and customer data.

**2. Telemetry can neither slow down nor break a tool call.** Two independent guarantees:

- `send_telemetry` now passes a finite `timeout` to the Segment POST. It previously had none, so a hung endpoint could block indefinitely — that also affected the pre-existing sync/install telemetry path.
- A bounded timeout still means bounded *added latency*, which is unacceptable per call, so the middleware never awaits telemetry: `_log` dispatches via `loop.run_in_executor` and returns immediately. Pending futures are held in a module-level set and their results consumed by a done-callback, so a telemetry failure can't leak as an unretrieved-exception warning. `_log` also suppresses every telemetry-side exception.

**3. Hosted vs. local is now distinguishable.** `is_hosted_mcp_mode()` existed but was only used for exception messages and never reached telemetry, so every hosted Cloud MCP event looked like a local one. It is now emitted as a `HOSTED_MCP` flag.

The subtle part: `get_env_flags()` was `@lru_cache`d, but `set_hosted_mcp_mode()` runs later, at HTTP startup. A cached snapshot would have permanently reported `HOSTED_MCP: false` on exactly the deployment we care about. The mode flags are therefore split out of the cached portion and evaluated per event:

```python
@lru_cache
def _get_static_env_flags() -> dict[str, Any]:   # CI, LANGCHAIN, NOTEBOOK_RUNTIME

def get_env_flags() -> dict[str, Any]:
    return {**_get_static_env_flags(), "MCP": ..., "HOSTED_MCP": ...}  # falsy dropped
```

`test_hosted_mcp_flag_is_evaluated_for_each_event` reads the flags before and after enabling hosted mode and fails under the naive cached implementation.

Relatedly, `poe mcp-serve-http` now invokes the real `airbyte-mcp-http` entry point instead of running `app.run(transport="http", ...)` inline, so local HTTP serving goes through `set_hosted_mcp_mode()` exactly like the deployed server does. `mcp-serve-sse` is unchanged.

### Known follow-ups, not in this PR

- Workspace/organization attribution for hosted callers, so support-bot and agent traffic can be segmented rather than lumped together.
- `anonymous_id` comes from `~/.airbyte/analytics.yml`, so on a containerized hosted server it is per-container and "unique users" is meaningless for hosted traffic.
- The dbt model: `pyairbyte_events` unions only the `install` and `sync` staging models, so `mcp_tool_call` (like the existing `validate` and `check` events) will not land in the warehouse until a staging model is added in `airbytehq/airbyte-warehouse`. airbytehq/internal.airbyte.ai#128 stays blocked until then.

## Test plan

`tests/unit_tests/test_mcp_telemetry.py`, all offline (Segment calls intercepted with `responses`):

- success emits one `mcp_tool_call` event with the tool name, `succeeded`, and an integer duration, and neither the argument nor the result value appears anywhere in the serialized payload;
- failure emits `failed` with `{"class": "RuntimeError"}` and the original exception object propagates unchanged;
- `DO_NOT_TRACK` (`1`/`true`/`t`) suppresses the request entirely;
- a raising `log_mcp_tool_call` does not break the tool call;
- the middleware is present on the built `app`;
- the hosted-flag ordering regression test described above;
- `test_mcp_tool_call_returns_before_slow_telemetry_finishes` stubs a 500ms telemetry endpoint and asserts the tool call returns in under half that. Verified to have teeth: temporarily reverting to synchronous dispatch fails it at ~0.5016s against the 0.25s threshold.

Commands run:

```
uv run ruff format .                 # 226 files unchanged
uv run ruff check .                  # all checks passed
uv run pyrefly check                 # 0 errors (repo uses pyrefly, not mypy)
uv run pytest tests/unit_tests/test_mcp_telemetry.py tests/unit_tests/test_anonymous_usage_stats.py tests/unit_tests/test_mcp_auth.py   # 48 passed
```

Beyond the unit tests, the real `airbyte.mcp.server.app` was driven through an in-memory FastMCP client with Segment intercepted, confirming exactly one `mcp_tool_call` event per call, with `MCP: true`, the expected `tool_name`/`duration_ms`, and no argument or result content in the payload.

Not run: the full matrix suite and any `requires_creds` tests. No live Segment event was sent from a real MCP server, so end-to-end delivery into the warehouse is unverified by design — there is no staging model to receive it yet.


Link to Devin session: https://app.devin.ai/sessions/c6e358d911424ec298aa41df9110ed3b