### PR TITLE
fix(mcp): validate Host and Origin headers on the HTTP transport

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -212,7 +212,9 @@ set; the interactive path activates once the OIDC client credentials are set.
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.
 - `AIRBYTE_MCP_ALLOWED_HOSTS` — comma-separated allowed hostnames or `fnmatch`
-  patterns for HTTP `Host` and `Origin` validation; entries may include ports.
+  patterns for HTTP `Host` and `Origin` validation. Ports are ignored: an entry
+  may carry one for readability, but matching is on hostname only, so
+  `example.com:8443` also allows `example.com` on any port.
 - `AIRBYTE_MCP_HTTP_HOST` — host interface to bind for the HTTP server (defaults
   to `0.0.0.0`).
 - `AIRBYTE_MCP_OIDC_CLIENT_ID`, `AIRBYTE_MCP_OIDC_CLIENT_SECRET` — enable

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -211,6 +211,10 @@ set; the interactive path activates once the OIDC client credentials are set.
 
 - `MCP_SERVER_URL` — public base URL of the server (also used for OIDC redirect
   callbacks); defaults to `http://localhost:8080`.
+- `AIRBYTE_MCP_ALLOWED_HOSTS` — comma-separated allowed hostnames or `fnmatch`
+  patterns for HTTP `Host` and `Origin` validation; entries may include ports.
+- `AIRBYTE_MCP_HTTP_HOST` — host interface to bind for the HTTP server (defaults
+  to `0.0.0.0`).
 - `AIRBYTE_MCP_OIDC_CLIENT_ID`, `AIRBYTE_MCP_OIDC_CLIENT_SECRET` — enable
   interactive OIDC (both required).
 - `AIRBYTE_MCP_OIDC_CONFIG_URL` — OIDC discovery URL (required when the client

--- a/airbyte/mcp/_transport_security.py
+++ b/airbyte/mcp/_transport_security.py
@@ -71,10 +71,14 @@ def resolve_allowed_hosts(server_url: str) -> tuple[str, ...]:
 
 
 def _request_host(scope: Scope) -> str | None:
-    for name, value in scope.get("headers", []):
-        if name.lower() == b"host":
-            return _strip_host_port(value.decode("latin-1")) or None
-    return None
+    hosts = [
+        value.decode("latin-1")
+        for name, value in scope.get("headers", [])
+        if name.lower() == b"host"
+    ]
+    if len(hosts) != 1:
+        return None
+    return _strip_host_port(hosts[0]) or None
 
 
 def _origin_hosts(scope: Scope) -> tuple[str | None, ...]:

--- a/airbyte/mcp/_transport_security.py
+++ b/airbyte/mcp/_transport_security.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""ASGI transport security for the HTTP MCP server."""
+
+from __future__ import annotations
+
+import fnmatch
+import ipaddress
+import os
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from starlette.responses import Response
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+ALLOWED_HOSTS_ENV = "AIRBYTE_MCP_ALLOWED_HOSTS"
+HTTP_HOST_ENV = "AIRBYTE_MCP_HTTP_HOST"
+
+_DEFAULT_ALLOWED_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def _strip_host_port(value: str) -> str:
+    """Normalize a host or host pattern for comparison."""
+    normalized = value.strip().lower()
+    if normalized.startswith("["):
+        closing_bracket = normalized.find("]")
+        if closing_bracket != -1:
+            return normalized[1:closing_bracket]
+    if normalized.count(":") == 1:
+        return normalized.rsplit(":", 1)[0]
+    return normalized
+
+
+def _is_unspecified_address(hostname: str) -> bool:
+    try:
+        return ipaddress.ip_address(hostname).is_unspecified
+    except ValueError:
+        return False
+
+
+def resolve_allowed_hosts(server_url: str) -> tuple[str, ...]:
+    """Resolve allowed hostnames from defaults, the server URL, and the environment."""
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    def add(host: str) -> None:
+        cleaned = host.strip()
+        if not cleaned:
+            return
+        key = _strip_host_port(cleaned)
+        if key and key not in seen:
+            resolved.append(cleaned)
+            seen.add(key)
+
+    for host in _DEFAULT_ALLOWED_HOSTS:
+        add(host)
+
+    hostname = urlparse(server_url).hostname
+    if hostname and not _is_unspecified_address(hostname):
+        add(hostname)
+
+    for host in os.getenv(ALLOWED_HOSTS_ENV, "").split(","):
+        add(host)
+
+    return tuple(resolved)
+
+
+def _request_host(scope: Scope) -> str | None:
+    for name, value in scope.get("headers", []):
+        if name.lower() == b"host":
+            return _strip_host_port(value.decode("latin-1")) or None
+    return None
+
+
+def _origin_hosts(scope: Scope) -> tuple[str | None, ...]:
+    origins: list[str | None] = []
+    for name, value in scope.get("headers", []):
+        if name.lower() == b"origin":
+            origin = value.decode("latin-1").strip()
+            try:
+                hostname = urlparse(origin).hostname
+            except ValueError:
+                origins.append(None)
+            else:
+                origins.append(_strip_host_port(hostname) if hostname else None)
+    return tuple(origins)
+
+
+class HostOriginGuardMiddleware:
+    """Reject HTTP requests whose host or origin is outside the allowlist."""
+
+    def __init__(self, app: ASGIApp, allowed_hosts: Sequence[str]) -> None:
+        self.app = app
+        self.allowed_hosts = tuple(
+            normalized
+            for normalized in (_strip_host_port(host) for host in allowed_hosts)
+            if normalized
+        )
+
+    def _is_allowed(self, hostname: str | None) -> bool:
+        return hostname is not None and any(
+            fnmatch.fnmatchcase(hostname, allowed_host) for allowed_host in self.allowed_hosts
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if not self._is_allowed(_request_host(scope)):
+            await Response("Misdirected Request", status_code=421)(scope, receive, send)
+            return
+
+        origin_hosts = _origin_hosts(scope)
+        # Both headers are attacker-controlled; do not fall back to request Host.
+        if any(not self._is_allowed(origin_host) for origin_host in origin_hosts):
+            await Response("Forbidden Origin", status_code=403)(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -34,7 +34,9 @@ Environment variables:
   derive the MCP endpoint mount path (serves at `/` when the URL has a path
   prefix, otherwise defaults to `/mcp`).
 - `AIRBYTE_MCP_ALLOWED_HOSTS`: Comma-separated allowed hostnames or `fnmatch`
-  patterns for HTTP `Host` and `Origin` validation. Entries may include ports.
+  patterns for HTTP `Host` and `Origin` validation. Ports are ignored: an entry
+  may carry one for readability, but matching is on hostname only, so
+  `example.com:8443` also allows `example.com` on any port.
 - `AIRBYTE_MCP_HTTP_HOST`: Host interface to bind for the HTTP server. Defaults
   to `0.0.0.0`.
 

--- a/airbyte/mcp/http_main.py
+++ b/airbyte/mcp/http_main.py
@@ -33,6 +33,10 @@ Environment variables:
 - `MCP_SERVER_URL`: Public base URL. Used for OIDC redirect callbacks and to
   derive the MCP endpoint mount path (serves at `/` when the URL has a path
   prefix, otherwise defaults to `/mcp`).
+- `AIRBYTE_MCP_ALLOWED_HOSTS`: Comma-separated allowed hostnames or `fnmatch`
+  patterns for HTTP `Host` and `Origin` validation. Entries may include ports.
+- `AIRBYTE_MCP_HTTP_HOST`: Host interface to bind for the HTTP server. Defaults
+  to `0.0.0.0`.
 
 Interactive OIDC (Keycloak Authorization Code + PKCE), enabled when the client
 credentials are set:
@@ -86,6 +90,11 @@ from airbyte.mcp._client_credentials import (
     client_credentials_enabled,
     wrap_if_enabled,
 )
+from airbyte.mcp._transport_security import (
+    HTTP_HOST_ENV,
+    HostOriginGuardMiddleware,
+    resolve_allowed_hosts,
+)
 from airbyte.mcp.server import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
@@ -99,6 +108,7 @@ from airbyte.version import get_version
 
 if TYPE_CHECKING:
     from fastmcp.server.auth import AuthProvider
+    from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
 
@@ -234,9 +244,13 @@ def main() -> None:
 
     _log_auth_status()
 
+    http_host = _env_or_default(HTTP_HOST_ENV, DEFAULT_HTTP_HOST)
+    allowed_hosts = resolve_allowed_hosts(server_url)
+    logger.info("Resolved HTTP transport allowed hosts: %s", allowed_hosts)
+
     logger.info(
         "Starting Airbyte MCP HTTP server on %s:%d (mcp_path=%r)",
-        DEFAULT_HTTP_HOST,
+        http_host,
         DEFAULT_HTTP_PORT,
         mcp_path,
     )
@@ -247,14 +261,20 @@ def main() -> None:
     # entrypoint (a permanent gate; the per-request filter also forces it off).
     assert_http_trusted_execution_disabled(app)
 
+    def wrap_http_app(http_app: ASGIApp) -> ASGIApp:
+        return HostOriginGuardMiddleware(
+            wrap_if_enabled(http_app),
+            allowed_hosts,
+        )
+
     try:
         run_mcp_http_server(
             app,
             path=mcp_path,
             transport="streamable-http",
             stateless_http=True,
-            wrapper=wrap_if_enabled,
-            host=DEFAULT_HTTP_HOST,
+            wrapper=wrap_http_app,
+            host=http_host,
             port=DEFAULT_HTTP_PORT,
         )
     except KeyboardInterrupt:

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -167,14 +167,13 @@ def test_http_main_delegates_http_serving_to_fastmcp_extensions(
 
     http_main.main()
 
-    assert config == {
-        "path": "/mcp",
-        "transport": "streamable-http",
-        "stateless_http": True,
-        "wrapper": http_main.wrap_if_enabled,
-        "host": http_main.DEFAULT_HTTP_HOST,
-        "port": http_main.DEFAULT_HTTP_PORT,
-    }
+    assert config["path"] == "/mcp"
+    assert config["transport"] == "streamable-http"
+    assert config["stateless_http"] is True
+    assert config["host"] == http_main.DEFAULT_HTTP_HOST
+    assert config["port"] == http_main.DEFAULT_HTTP_PORT
+    assert callable(config["wrapper"])
+    assert config["wrapper"] is not http_main.wrap_if_enabled
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_auth.py
+++ b/tests/unit_tests/test_mcp_auth.py
@@ -23,6 +23,7 @@ from fastmcp_extensions import JWTAuthConfig, OIDCAuthConfig
 from airbyte.mcp import _client_credentials as client_credentials
 from airbyte.mcp import http_main
 from airbyte.mcp import server
+from airbyte.mcp._transport_security import HostOriginGuardMiddleware
 
 
 if TYPE_CHECKING:
@@ -172,8 +173,7 @@ def test_http_main_delegates_http_serving_to_fastmcp_extensions(
     assert config["stateless_http"] is True
     assert config["host"] == http_main.DEFAULT_HTTP_HOST
     assert config["port"] == http_main.DEFAULT_HTTP_PORT
-    assert callable(config["wrapper"])
-    assert config["wrapper"] is not http_main.wrap_if_enabled
+    assert isinstance(config["wrapper"](object()), HostOriginGuardMiddleware)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_transport_security.py
+++ b/tests/unit_tests/test_mcp_transport_security.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
@@ -74,6 +76,35 @@ def test_missing_host_is_rejected() -> None:
         response = client.get("/", headers={"host": ""})
 
     assert response.status_code == 421
+
+
+def test_duplicate_hosts_are_rejected() -> None:
+    messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [
+            (b"host", b"localhost"),
+            (b"host", b"attacker.example"),
+        ],
+    }
+
+    async def call_middleware() -> None:
+        await HostOriginGuardMiddleware(_app, ("localhost",))(scope, receive, send)
+
+    asyncio.run(call_middleware())
+
+    assert messages[0]["status"] == 421
 
 
 def test_configured_hosts_are_allowed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_mcp_transport_security.py
+++ b/tests/unit_tests/test_mcp_transport_security.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+"""Unit tests for HTTP MCP host and origin validation."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+
+from airbyte.mcp._transport_security import (
+    ALLOWED_HOSTS_ENV,
+    HostOriginGuardMiddleware,
+    resolve_allowed_hosts,
+)
+
+
+async def _app(scope: Scope, receive: Receive, send: Send) -> None:
+    if scope["type"] == "lifespan":
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+        return
+    await PlainTextResponse("ok")(scope, receive, send)
+
+
+def _client(allowed_hosts: tuple[str, ...]) -> TestClient:
+    return TestClient(HostOriginGuardMiddleware(_app, allowed_hosts))
+
+
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1"])
+def test_allowed_loopback_hosts_pass_through(host: str) -> None:
+    with _client(("localhost", "127.0.0.1")) as client:
+        response = client.get("/", headers={"host": host})
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_unallowed_host_is_rejected() -> None:
+    with _client(("localhost",)) as client:
+        response = client.get("/", headers={"host": "attacker.example:8080"})
+
+    assert response.status_code == 421
+    assert response.text == "Misdirected Request"
+
+
+def test_unallowed_origin_is_rejected_even_with_allowed_host() -> None:
+    with _client(("localhost",)) as client:
+        response = client.get(
+            "/",
+            headers={
+                "host": "localhost",
+                "origin": "http://attacker.example:8080",
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.text == "Forbidden Origin"
+
+
+def test_missing_origin_is_allowed() -> None:
+    with _client(("localhost",)) as client:
+        response = client.get("/", headers={"host": "localhost"})
+
+    assert response.status_code == 200
+
+
+def test_missing_host_is_rejected() -> None:
+    with _client(("localhost",)) as client:
+        response = client.get("/", headers={"host": ""})
+
+    assert response.status_code == 421
+
+
+def test_configured_hosts_are_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ALLOWED_HOSTS_ENV, "custom.example:8443,*.run.app")
+
+    with _client(resolve_allowed_hosts("")) as client:
+        custom_response = client.get("/", headers={"host": "custom.example"})
+        pattern_response = client.get("/", headers={"host": "service.run.app"})
+
+    assert custom_response.status_code == 200
+    assert pattern_response.status_code == 200
+
+
+def test_server_url_hostname_is_allowed() -> None:
+    allowed_hosts = resolve_allowed_hosts("https://mcp.example.com:443/mcp")
+
+    assert "mcp.example.com" in allowed_hosts

--- a/tests/unit_tests/test_mcp_transport_security.py
+++ b/tests/unit_tests/test_mcp_transport_security.py
@@ -90,4 +90,4 @@ def test_configured_hosts_are_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_server_url_hostname_is_allowed() -> None:
     allowed_hosts = resolve_allowed_hosts("https://mcp.example.com:443/mcp")
 
-    assert "mcp.example.com" in allowed_hosts
+    assert allowed_hosts[-1:] == ("mcp.example.com",)

--- a/tests/unit_tests/test_mcp_transport_security.py
+++ b/tests/unit_tests/test_mcp_transport_security.py
@@ -24,7 +24,6 @@ async def _app(scope: Scope, receive: Receive, send: Send) -> None:
             elif message["type"] == "lifespan.shutdown":
                 await send({"type": "lifespan.shutdown.complete"})
                 return
-        return
     await PlainTextResponse("ok")(scope, receive, send)
 
 


### PR DESCRIPTION
## Summary

The HTTP MCP entrypoint accepts any `Host` and `Origin` header, so a browser page can drive a locally or privately run `airbyte-mcp-http` server (CWE-346, reported externally by a third party researcher; requested by Pablo Vega). The pinned `fastmcp` 3.2.0 constructs `StreamableHTTPSessionManager` without `TransportSecuritySettings` and ships no host/origin guard, so there is no flag to flip; this adds the check as an ASGI middleware in PyAirbyte instead of bumping a public dependency.

`HostOriginGuardMiddleware` in `airbyte/mcp/_transport_security.py` wraps the whole app, outside the existing client-credentials wrapper:

```python
wrapper = lambda http_app: HostOriginGuardMiddleware(wrap_if_enabled(http_app), allowed_hosts)
```

- missing or non-allowlisted `Host` -> `421`
- present but non-allowlisted `Origin` -> `403`; absent `Origin` is allowed (non-browser clients)
- comparison is `fnmatch` on the hostname only, port-stripped, bracket-stripped, lowercased

There is deliberately **no** same-origin fallback (accepting `Origin == scheme://<request Host>`, as upstream fastmcp's newer guard does). Both headers are attacker-controlled in the rebinding scenario, so that fallback makes the Origin check bypassable whenever the Host allowlist is permissive.

The allowlist resolves from three sources, none of them request-derived: loopback defaults (`127.0.0.1`, `localhost`, `::1`), the hostname parsed from `MCP_SERVER_URL` (already injected with the public URL by the hosted deployment, so hosted traffic keeps working with no new config), and the new `AIRBYTE_MCP_ALLOWED_HOSTS` (comma-separated, patterns like `*.run.app` allowed) for ingress hostnames, in-cluster Service DNS names, or anything else the process cannot infer about itself.

`AIRBYTE_MCP_HTTP_HOST` now overrides the previously hard-coded bind address. The default stays `0.0.0.0` so hosted deployments are unaffected; the guard, not the bind address, is what closes LAN and browser access here.

**Before rolling this out to a deployment**, confirm every legitimate `Host` value is covered. Load-balancer or kubelet health probes that send an IP-literal `Host`, and direct `*.run.app` hits where ingress still permits them, will get a `421` unless they are added to `AIRBYTE_MCP_ALLOWED_HOSTS` or pointed at an unguarded path with an explicit `Host`.

## Test plan

`tests/unit_tests/test_mcp_transport_security.py` drives the middleware through `starlette.testclient.TestClient`: allowed loopback hosts pass; `Host: attacker.example:8080` gets `421`; `Origin: http://attacker.example:8080` with an allowed `Host` gets `403` (the regression test for the reported vector); missing `Origin` passes; missing `Host` gets `421`; `AIRBYTE_MCP_ALLOWED_HOSTS` entries and pattern entries pass; `resolve_allowed_hosts` includes the `MCP_SERVER_URL` hostname. The existing `http_main` delegation test now asserts the wrapper produces the guard.

Run: `pytest tests/unit_tests/test_mcp_transport_security.py tests/unit_tests/test_mcp_auth.py` (38 passed locally), plus `ruff format --check .`, `ruff check .`, and `mypy` on the changed modules. Full-repo `mypy` is blocked by a preexisting duplicate `setup` module error in the test fixture sources, unrelated to this branch.


Link to Devin session: https://app.devin.ai/sessions/d15a969d92424c7990d399577f916d89
Requested by: @pablo-airbyte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP server bind host settings.
  * Added allowed-host configuration through `AIRBYTE_MCP_ALLOWED_HOSTS`.
  * Added host and origin validation, including wildcard support.
  * Rejected invalid, missing, duplicate, or disallowed host headers and origins with appropriate responses.

* **Documentation**
  * Documented the HTTP server host and allowed-host environment variables.

* **Tests**
  * Added coverage for accepted and rejected hosts, origins, missing and duplicate headers, wildcard configuration, and server URL host detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->