### PR TITLE
fix(docs): document every MCP module (agents, local, interactive) and fail on unresolved includes

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -312,17 +312,15 @@ For issues and questions:
 
 """  # noqa: D415
 
-from airbyte.mcp import cloud, http_main, interactive, local, prompts, registry, server
+from airbyte.mcp import cloud, interactive, local, prompts, registry
 
 
 __all__: list[str] = [
     "cloud",
-    "http_main",
     "interactive",
     "local",
     "prompts",
     "registry",
-    "server",
 ]
 
 __docformat__ = "google"

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -312,11 +312,12 @@ For issues and questions:
 
 """  # noqa: D415
 
-from airbyte.mcp import cloud, interactive, local, prompts, registry, server
+from airbyte.mcp import cloud, http_main, interactive, local, prompts, registry, server
 
 
 __all__: list[str] = [
     "cloud",
+    "http_main",
     "interactive",
     "local",
     "prompts",

--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -312,12 +312,14 @@ For issues and questions:
 
 """  # noqa: D415
 
-from airbyte.mcp import cloud, local, registry, server
+from airbyte.mcp import cloud, interactive, local, prompts, registry, server
 
 
 __all__: list[str] = [
     "cloud",
+    "interactive",
     "local",
+    "prompts",
     "registry",
     "server",
 ]

--- a/airbyte/mcp/interactive/__init__.py
+++ b/airbyte/mcp/interactive/__init__.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
-"""Interactive MCP tools for UI-capable clients."""
+"""Interactive MCP tools for UI-capable clients.
+
+.. include:: ../../../docs/mcp-generated/interactive.md
+"""
 
 from __future__ import annotations
 

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -85,7 +85,7 @@ def run() -> None:
     # MCP module docstrings resolve on a clean checkout (docs/mcp-generated/
     # is git-ignored).
     _regenerate_mcp_markdown()
-    _validate_includes(pathlib.Path.cwd())
+    _validate_includes(pathlib.Path(__file__).parent.parent)
 
     # recursively delete the docs/generated folder if it exists
     if pathlib.Path("docs/generated").exists():

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -22,7 +22,7 @@ import pdoc.render_helpers
 def _regenerate_mcp_markdown() -> None:
     """Regenerate `docs/mcp-generated/` before pdoc runs.
 
-    The `airbyte.mcp.{cloud,local,interactive,registry,prompts}` modules pull the
+    The `airbyte.mcp.{agents,cloud,local,interactive,registry,prompts}` modules pull the
     per-module Markdown files from `docs/mcp-generated/` via pdoc's
     `.. include::` directive. That directory is git-ignored, so on a clean
     checkout pdoc would fail to resolve the include unless we regenerate it

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import re
 import shutil
-import sys
 
 import pdoc
 import pdoc.render_helpers
@@ -22,17 +22,13 @@ import pdoc.render_helpers
 def _regenerate_mcp_markdown() -> None:
     """Regenerate `docs/mcp-generated/` before pdoc runs.
 
-    The `airbyte.mcp.{cloud,local,registry,prompts}` modules pull the
+    The `airbyte.mcp.{cloud,local,interactive,registry,prompts}` modules pull the
     per-module Markdown files from `docs/mcp-generated/` via pdoc's
     `.. include::` directive. That directory is git-ignored, so on a clean
     checkout pdoc would fail to resolve the include unless we regenerate it
     here. Running the generator from inside `docs-generate` makes the full
     docs build reproducible from a fresh clone (and matches the standalone
     `poe mcp-docs-md` task).
-
-    If generation fails (e.g. `fastmcp` is not installed, or the MCP server
-    import fails), we print a warning and continue: pdoc will still build,
-    and the include directive will just surface the missing file.
 
     We load the generator via `importlib.util` from its on-disk path rather
     than a plain `from generate_mcp_markdown import ...`: the generator
@@ -42,26 +38,35 @@ def _regenerate_mcp_markdown() -> None:
     """
     script = pathlib.Path(__file__).parent.parent / "scripts" / "generate_mcp_markdown.py"
     if not script.exists():
-        print(f"[docs-generate] MCP markdown generator not found at {script}; skipping.")
-        return
-    try:
-        spec = importlib.util.spec_from_file_location("_mcp_markdown_gen", script)
-        if spec is None or spec.loader is None:
-            msg = f"Could not load spec for {script}"
-            raise RuntimeError(msg)  # noqa: TRY301
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        print("[docs-generate] Regenerating docs/mcp-generated/ ...")
-        module.generate(
-            server_spec=module.DEFAULT_SERVER_SPEC,
-            output=module.DEFAULT_OUTPUT,
-        )
-    except Exception as ex:
-        print(
-            f"[docs-generate] WARNING: failed to regenerate MCP Markdown docs: {ex}. "
-            "pdoc will continue, but module pages may show missing include warnings.",
-            file=sys.stderr,
-        )
+        raise RuntimeError(f"MCP markdown generator not found at {script}")
+    spec = importlib.util.spec_from_file_location("_mcp_markdown_gen", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load spec for {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    print("[docs-generate] Regenerating docs/mcp-generated/ ...")
+    module.generate(
+        server_spec=module.DEFAULT_SERVER_SPEC,
+        output=module.DEFAULT_OUTPUT,
+    )
+
+
+_INCLUDE_DIRECTIVE = re.compile(r"^\s*\.\.\s+include::\s+(\S+)\s*$", re.MULTILINE)
+
+
+def _validate_includes(root: pathlib.Path) -> None:
+    """Raise if a reStructuredText include in an Airbyte source is missing."""
+    missing: list[str] = []
+    airbyte_root = root / "airbyte"
+    for source in sorted(airbyte_root.rglob("*.py")):
+        for match in _INCLUDE_DIRECTIVE.finditer(source.read_text(encoding="utf-8")):
+            target = (source.parent / match.group(1)).resolve()
+            if not target.exists():
+                missing.append(
+                    f"{source.relative_to(root)} includes missing {target.relative_to(root)}"
+                )
+    if missing:
+        raise RuntimeError("Unresolved documentation includes:\n" + "\n".join(missing))
 
 
 def run() -> None:
@@ -72,6 +77,7 @@ def run() -> None:
     # MCP module docstrings resolve on a clean checkout (docs/mcp-generated/
     # is git-ignored).
     _regenerate_mcp_markdown()
+    _validate_includes(pathlib.Path.cwd())
 
     # recursively delete the docs/generated folder if it exists
     if pathlib.Path("docs/generated").exists():

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -54,16 +54,24 @@ def _regenerate_mcp_markdown() -> None:
 _INCLUDE_DIRECTIVE = re.compile(r"^\s*\.\.\s+include::\s+(\S+)\s*$", re.MULTILINE)
 
 
+def _display_path(path: pathlib.Path, root: pathlib.Path) -> str:
+    """Return `path` relative to `root`, or absolute if it falls outside `root`."""
+    if path.is_relative_to(root):
+        return str(path.relative_to(root))
+    return str(path)
+
+
 def _validate_includes(root: pathlib.Path) -> None:
     """Raise if a reStructuredText include in an Airbyte source is missing."""
+    resolved_root = root.resolve()
     missing: list[str] = []
-    airbyte_root = root / "airbyte"
-    for source in sorted(airbyte_root.rglob("*.py")):
+    for source in sorted((resolved_root / "airbyte").rglob("*.py")):
         for match in _INCLUDE_DIRECTIVE.finditer(source.read_text(encoding="utf-8")):
             target = (source.parent / match.group(1)).resolve()
             if not target.exists():
                 missing.append(
-                    f"{source.relative_to(root)} includes missing {target.relative_to(root)}"
+                    f"{_display_path(source, resolved_root)} includes missing "
+                    f"{_display_path(target, resolved_root)}"
                 )
     if missing:
         raise RuntimeError("Unresolved documentation includes:\n" + "\n".join(missing))

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -412,7 +412,7 @@ def _render_parameters_table(input_schema: dict[str, Any]) -> str:
     """Render a GFM parameters table for a tool's `input_schema`."""
     properties = input_schema.get("properties") or {}
     if not properties:
-        return "_No parameters._\n\n"
+        return "*No parameters.*\n\n"
     required = set(input_schema.get("required") or [])
     lines = [
         "| Name | Type | Required | Default | Description |",

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -2,11 +2,13 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 """Generate Markdown documentation for the Airbyte Replication MCP server.
 
-Runs `fastmcp inspect` against the default `airbyte/mcp/server.py:app` spec
+Runs a two-pass inspect against the default `airbyte/mcp/server.py:app` spec
 (override with `--server-spec`) to obtain the full FastMCP protocol surface
-(tools, resources, resource templates, prompts) as a JSON report, then
-renders it into one Markdown file **per MCP module** under
-`docs/mcp-generated/`, plus an `index.md` overview.
+(tools, resources, resource templates, prompts) as a JSON report, then renders
+it into one Markdown file **per MCP module** under `docs/mcp-generated/`, plus
+an `index.md` overview. The trusted-execution and interactive-UI gates cannot
+both be open in one request, so the passes are merged to document every
+registered tool.
 
 The per-module grouping uses the `mcp_module` annotation that
 `fastmcp_extensions.mcp_tool` attaches to every registered tool (derived from
@@ -71,15 +73,26 @@ poe mcp-docs-md
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib
 import json
+import os
 import shutil
 import subprocess
 import sys
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+from fastmcp import FastMCP
+from fastmcp.apps import UI_EXTENSION_ID
+from fastmcp.server.http import _current_http_request  # noqa: PLC2701
+from fastmcp.utilities.inspect import format_fastmcp_info, inspect_fastmcp
+from fastmcp_extensions.capability_tokens import DEFAULT_EXTENSIONS_HEADER
+from starlette.requests import Request
+
+from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
 
 
 DEFAULT_OUTPUT = Path("docs/mcp-generated")
@@ -101,39 +114,70 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _run_fastmcp_inspect(server_spec: str, report_path: Path) -> dict[str, Any]:
-    """Invoke `fastmcp inspect` and return the parsed JSON report."""
-    fastmcp_bin = shutil.which("fastmcp")
-    if fastmcp_bin is None:
-        raise RuntimeError(
-            "`fastmcp` CLI not found on PATH. Install project dev deps first "
-            "(e.g. `uv sync --group dev`) and re-run from the repo root."
-        )
+    """Run the two-pass inspect in a child process and parse its report."""
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--server-spec",
+        server_spec,
+        "--emit-inspect-json",
+        str(report_path),
+    ]
+    env = {**os.environ, MCP_TRUSTED_EXECUTION_ENV_VAR: "1"}
     try:
         subprocess.run(
-            [
-                fastmcp_bin,
-                "inspect",
-                server_spec,
-                "--format",
-                "fastmcp",
-                "--output",
-                str(report_path),
-            ],
+            command,
             check=True,
             timeout=_FASTMCP_INSPECT_TIMEOUT_SEC,
+            capture_output=True,
+            text=True,
+            env=env,
         )
     except subprocess.TimeoutExpired as ex:
         msg = (
-            f"`fastmcp inspect {server_spec}` timed out after "
+            f"Two-pass `fastmcp inspect {server_spec}` timed out after "
             f"{_FASTMCP_INSPECT_TIMEOUT_SEC}s. The server module likely hangs "
-            "on import (blocking network I/O during tool registration?). "
-            "Re-run with the server imported manually to investigate."
+            "on import (blocking network I/O during tool registration?)."
         )
+        for label, output in (("stderr", ex.stderr), ("stdout", ex.stdout)):
+            if output:
+                msg += f"\n\n{label}:\n{output.strip()}"
         raise RuntimeError(msg) from ex
+    except subprocess.CalledProcessError as ex:
+        stderr = (ex.stderr or "").strip()
+        stdout = (ex.stdout or "").strip()
+        parts = [
+            f"Two-pass `fastmcp inspect {server_spec}` failed with exit code " f"{ex.returncode}."
+        ]
+        if stderr:
+            parts.append(f"stderr:\n{stderr}")
+        if stdout:
+            parts.append(f"stdout:\n{stdout}")
+        raise RuntimeError("\n\n".join(parts)) from ex
     return json.loads(report_path.read_text(encoding="utf-8"))
 
 
-def _resolve_extra_module_map(server_spec: str) -> dict[str, str]:
+def _spec_to_module_name(server_spec: str) -> str:
+    """Normalize a file-path server spec to an importable module name."""
+    file_part = server_spec.split(":", 1)[0]
+    dotted = file_part.removesuffix(".py").replace("/", ".").replace("\\", ".")
+    if dotted.startswith("src."):
+        dotted = dotted.removeprefix("src.")
+    return dotted
+
+
+def _import_server(server_spec: str) -> FastMCP[Any]:
+    """Import and return the server object named by a FastMCP server spec."""
+    module_name, _, object_path = server_spec.partition(":")
+    if not object_path:
+        raise ValueError(f"Server spec must include an object name: {server_spec}")
+    server: object = importlib.import_module(_spec_to_module_name(module_name))
+    for component in object_path.split("."):
+        server = getattr(server, component)
+    return cast(FastMCP[Any], server)
+
+
+def _build_extra_module_map() -> dict[str, str]:
     """Best-effort import-based lookup of `mcp_module` for prompts/resources.
 
     `fastmcp_extensions`'s `mcp_tool` decorator embeds `mcp_module` in the MCP
@@ -150,8 +194,6 @@ def _resolve_extra_module_map(server_spec: str) -> dict[str, str]:
     Returns a map of `name/uri -> mcp_module` covering both prompts and
     resources.
     """
-    file_part = server_spec.split(":", 1)[0]
-    module_name = file_part.removesuffix(".py").replace("/", ".")
     mapping: dict[str, str] = {}
     # The iteration sits inside the same `try` as the import so any shape
     # drift in the private `_REGISTERED_*` tuples (e.g. an added third element,
@@ -159,7 +201,6 @@ def _resolve_extra_module_map(server_spec: str) -> dict[str, str]:
     # mapping — preserving this helper's documented best-effort semantics —
     # rather than aborting doc generation.
     try:
-        importlib.import_module(module_name)
         # Import private lists from fastmcp_extensions: these are the only
         # place `mcp_module` is recorded for prompts/resources, so we accept
         # the private-name coupling.
@@ -182,6 +223,63 @@ def _resolve_extra_module_map(server_spec: str) -> dict[str, str]:
     except Exception:
         return {}
     return mapping
+
+
+def _annotate_modules(report: dict[str, Any], module_map: dict[str, str]) -> None:
+    """Preserve prompt/resource module metadata in the inspect report."""
+    for section in ("prompts", "resources", "templates"):
+        for item in report.get(section) or []:
+            key = item.get("name") or item.get("uri") or item.get("uri_template")
+            if key in module_map:
+                item["meta"] = {**(item.get("meta") or {}), "mcp_module": module_map[key]}
+
+
+def _merge_reports(report_a: dict[str, Any], report_b: dict[str, Any]) -> dict[str, Any]:
+    """Merge unique protocol primitives from two inspect passes."""
+    merged = {**report_a}
+    for section in ("tools", "prompts", "resources", "templates"):
+        entries = list(report_a.get(section) or [])
+        seen = {item.get("name") or item.get("uri") or item.get("uri_template") for item in entries}
+        for item in report_b.get(section) or []:
+            key = item.get("name") or item.get("uri") or item.get("uri_template")
+            if key not in seen:
+                entries.append(item)
+                seen.add(key)
+        merged[section] = entries
+    return merged
+
+
+def _emit_inspect_json(server_spec: str, report_path: Path) -> None:
+    """Inspect a server with trusted and UI-capable request contexts."""
+    server = _import_server(server_spec)
+
+    async def inspect() -> dict[str, Any]:
+        report_a = json.loads(format_fastmcp_info(await inspect_fastmcp(server)))
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp",
+            "headers": [
+                (
+                    DEFAULT_EXTENSIONS_HEADER.lower().encode(),
+                    UI_EXTENSION_ID.encode(),
+                )
+            ],
+            "query_string": b"",
+        }
+        token = _current_http_request.set(Request(scope))
+        try:
+            report_b = json.loads(format_fastmcp_info(await inspect_fastmcp(server)))
+        finally:
+            _current_http_request.reset(token)
+        report = _merge_reports(report_a, report_b)
+        _annotate_modules(report, _build_extra_module_map())
+        return report
+
+    report_path.write_text(
+        json.dumps(asyncio.run(inspect()), indent=2),
+        encoding="utf-8",
+    )
 
 
 def _get_module(item: dict[str, Any], fallback_map: dict[str, str]) -> str:
@@ -281,6 +379,17 @@ def _render_hint_badges(annotations: dict[str, Any] | None) -> str:
     badges = [f"`{label}`" for key, label in _HINT_LABELS.items() if annotations.get(key) is True]
     if badges:
         lines.append("**Hints:** " + " · ".join(badges))
+    if annotations.get("requiresClientFilesystem") is True:
+        lines.append(
+            "**Availability:** requires trusted execution "
+            f"(`{MCP_TRUSTED_EXECUTION_ENV_VAR}=1`, stdio transport only); "
+            "never available over HTTP."
+        )
+    if annotations.get("interactive-ui") is True:
+        lines.append(
+            "**Availability:** requires an MCP Apps UI-capable client "
+            f"(declares the `{UI_EXTENSION_ID}` extension)."
+        )
     if title := annotations.get("title"):
         lines.append(f"**Title:** {title}")
     return ("\n\n".join(lines) + "\n\n") if lines else ""
@@ -570,14 +679,13 @@ def _prepare_output_dir(output: Path) -> Path:
 
 
 def generate(server_spec: str, output: Path) -> None:
-    """Run `fastmcp inspect`, render Markdown, and write files to `output/`."""
+    """Run a two-pass inspect, render Markdown, and write files to `output/`."""
     with tempfile.TemporaryDirectory() as tmp:
         report_path = Path(tmp) / "mcp-inspect.json"
-        print(f"Running `fastmcp inspect {server_spec}`...")
+        print(f"Running two-pass `fastmcp inspect {server_spec}`...")
         report = _run_fastmcp_inspect(server_spec, report_path)
 
-    fallback_map = _resolve_extra_module_map(server_spec)
-    buckets = _bucket_by_module(report, fallback_map)
+    buckets = _bucket_by_module(report, {})
 
     # Use the resolved path returned by `_prepare_output_dir` for subsequent
     # writes: when called from a subdirectory, the raw `output` is
@@ -615,9 +723,17 @@ def main() -> int:
         default=DEFAULT_OUTPUT,
         help=f"Output directory for generated Markdown (default: {DEFAULT_OUTPUT}).",
     )
+    parser.add_argument(
+        "--emit-inspect-json",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     args = parser.parse_args()
     try:
-        generate(server_spec=args.server_spec, output=args.output)
+        if args.emit_inspect_json:
+            _emit_inspect_json(args.server_spec, args.emit_inspect_json)
+        else:
+            generate(server_spec=args.server_spec, output=args.output)
     except (subprocess.CalledProcessError, RuntimeError) as ex:
         print(f"MCP docs generation failed: {ex}", file=sys.stderr)
         return 1

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -89,7 +89,9 @@ from fastmcp import FastMCP
 from fastmcp.apps import UI_EXTENSION_ID
 from fastmcp.server.http import _current_http_request  # noqa: PLC2701
 from fastmcp.utilities.inspect import format_fastmcp_info, inspect_fastmcp
+from fastmcp_extensions import ANNOTATION_INTERACTIVE_UI
 from fastmcp_extensions.capability_tokens import DEFAULT_EXTENSIONS_HEADER
+from fastmcp_extensions.tool_filters import ANNOTATION_REQUIRES_CLIENT_FILESYSTEM
 from starlette.requests import Request
 
 from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
@@ -379,13 +381,13 @@ def _render_hint_badges(annotations: dict[str, Any] | None) -> str:
     badges = [f"`{label}`" for key, label in _HINT_LABELS.items() if annotations.get(key) is True]
     if badges:
         lines.append("**Hints:** " + " · ".join(badges))
-    if annotations.get("requiresClientFilesystem") is True:
+    if annotations.get(ANNOTATION_REQUIRES_CLIENT_FILESYSTEM) is True:
         lines.append(
             "**Availability:** requires trusted execution "
             f"(`{MCP_TRUSTED_EXECUTION_ENV_VAR}=1`, stdio transport only); "
             "never available over HTTP."
         )
-    if annotations.get("interactive-ui") is True:
+    if annotations.get(ANNOTATION_INTERACTIVE_UI) is True:
         lines.append(
             "**Availability:** requires an MCP Apps UI-capable client "
             f"(declares the `{UI_EXTENSION_ID}` extension)."
@@ -685,6 +687,7 @@ def generate(server_spec: str, output: Path) -> None:
         print(f"Running two-pass `fastmcp inspect {server_spec}`...")
         report = _run_fastmcp_inspect(server_spec, report_path)
 
+    # Child metadata removes the need for a parent fallback map or server import.
     buckets = _bucket_by_module(report, {})
 
     # Use the resolved path returned by `_prepare_output_dir` for subsequent

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -159,10 +159,9 @@ def _run_fastmcp_inspect(server_spec: str, report_path: Path) -> dict[str, Any]:
     return json.loads(report_path.read_text(encoding="utf-8"))
 
 
-def _spec_to_module_name(server_spec: str) -> str:
-    """Normalize a file-path server spec to an importable module name."""
-    file_part = server_spec.split(":", 1)[0]
-    dotted = file_part.removesuffix(".py").replace("/", ".").replace("\\", ".")
+def _spec_to_module_name(module_path: str) -> str:
+    """Normalize a file path to an importable module name."""
+    dotted = module_path.removesuffix(".py").replace("/", ".").replace("\\", ".")
     if dotted.startswith("src."):
         dotted = dotted.removeprefix("src.")
     return dotted
@@ -170,10 +169,10 @@ def _spec_to_module_name(server_spec: str) -> str:
 
 def _import_server(server_spec: str) -> FastMCP[Any]:
     """Import and return the server object named by a FastMCP server spec."""
-    module_name, _, object_path = server_spec.partition(":")
-    if not object_path:
+    module_path, separator, object_path = server_spec.rpartition(":")
+    if not separator or not object_path:
         raise ValueError(f"Server spec must include an object name: {server_spec}")
-    server: object = importlib.import_module(_spec_to_module_name(module_name))
+    server: object = importlib.import_module(_spec_to_module_name(module_path))
     for component in object_path.split("."):
         server = getattr(server, component)
     return cast(FastMCP[Any], server)
@@ -188,10 +187,10 @@ def _build_extra_module_map() -> dict[str, str]:
     internal `_REGISTERED_*` lists only — it is not re-emitted as an MCP
     annotation, so it doesn't appear in the inspect JSON.
 
-    To still recover that information, we import the server module and read
-    those internal lists. If that fails (not a `fastmcp_extensions`-based
-    server, import errors, etc.), we silently return an empty map and the
-    caller falls back to `MISC_MODULE`.
+    To still recover that information, the caller must import the server module
+    before calling this helper, then this helper reads those internal lists. If
+    that fails (not a `fastmcp_extensions`-based server, import errors, etc.),
+    we silently return an empty map and the caller falls back to `MISC_MODULE`.
 
     Returns a map of `name/uri -> mcp_module` covering both prompts and
     resources.

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -401,7 +401,8 @@ def _render_hint_badges(annotations: dict[str, Any] | None) -> str:
         lines.append(
             "**Availability:** experimental, insiders only "
             f"(`{MCP_INSIDERS_ENV_VAR}=1` for stdio, `{MCP_INSIDERS_HEADER}: 1` for hosted "
-            "servers, or name the module in the include-modules setting)."
+            "servers, or name the module in the include-modules setting; "
+            f"`{MCP_INSIDERS_ENV_VAR}=0` disables it regardless)."
         )
     if title := annotations.get("title"):
         lines.append(f"**Title:** {title}")

--- a/scripts/generate_mcp_markdown.py
+++ b/scripts/generate_mcp_markdown.py
@@ -6,7 +6,8 @@ Runs a two-pass inspect against the default `airbyte/mcp/server.py:app` spec
 (override with `--server-spec`) to obtain the full FastMCP protocol surface
 (tools, resources, resource templates, prompts) as a JSON report, then renders
 it into one Markdown file **per MCP module** under `docs/mcp-generated/`, plus
-an `index.md` overview. The trusted-execution and interactive-UI gates cannot
+an `index.md` overview. The child inspect process enables trusted execution and
+insiders mode via env vars; the trusted-execution and interactive-UI gates cannot
 both be open in one request, so the passes are merged to document every
 registered tool.
 
@@ -94,7 +95,12 @@ from fastmcp_extensions.capability_tokens import DEFAULT_EXTENSIONS_HEADER
 from fastmcp_extensions.tool_filters import ANNOTATION_REQUIRES_CLIENT_FILESYSTEM
 from starlette.requests import Request
 
-from airbyte.constants import MCP_TRUSTED_EXECUTION_ENV_VAR
+from airbyte.constants import (
+    MCP_INSIDERS_ENV_VAR,
+    MCP_INSIDERS_HEADER,
+    MCP_INSIDERS_MODULES,
+    MCP_TRUSTED_EXECUTION_ENV_VAR,
+)
 
 
 DEFAULT_OUTPUT = Path("docs/mcp-generated")
@@ -125,7 +131,7 @@ def _run_fastmcp_inspect(server_spec: str, report_path: Path) -> dict[str, Any]:
         "--emit-inspect-json",
         str(report_path),
     ]
-    env = {**os.environ, MCP_TRUSTED_EXECUTION_ENV_VAR: "1"}
+    env = {**os.environ, MCP_TRUSTED_EXECUTION_ENV_VAR: "1", MCP_INSIDERS_ENV_VAR: "1"}
     try:
         subprocess.run(
             command,
@@ -390,6 +396,12 @@ def _render_hint_badges(annotations: dict[str, Any] | None) -> str:
         lines.append(
             "**Availability:** requires an MCP Apps UI-capable client "
             f"(declares the `{UI_EXTENSION_ID}` extension)."
+        )
+    if annotations.get("mcp_module") in MCP_INSIDERS_MODULES:
+        lines.append(
+            "**Availability:** experimental, insiders only "
+            f"(`{MCP_INSIDERS_ENV_VAR}=1` for stdio, `{MCP_INSIDERS_HEADER}: 1` for hosted "
+            "servers, or name the module in the include-modules setting)."
         )
     if title := annotations.get("title"):
         lines.append(f"**Title:** {title}")

--- a/tests/unit_tests/test_mcp_docs_includes.py
+++ b/tests/unit_tests/test_mcp_docs_includes.py
@@ -25,6 +25,15 @@ def test_validate_includes_raises_for_missing_target(tmp_path: Path) -> None:
         _validate_includes(tmp_path)
 
 
+def test_validate_includes_handles_target_outside_root(tmp_path: Path) -> None:
+    source = tmp_path / "airbyte" / "mcp" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(".. include:: ../../../../../outside.md\n")
+
+    with pytest.raises(RuntimeError, match="Unresolved documentation includes"):
+        _validate_includes(tmp_path)
+
+
 def test_validate_includes_passes_for_existing_target(tmp_path: Path) -> None:
     source = tmp_path / "airbyte" / "mcp" / "module.py"
     target = tmp_path / "docs" / "mcp-generated" / "module.md"

--- a/tests/unit_tests/test_mcp_docs_includes.py
+++ b/tests/unit_tests/test_mcp_docs_includes.py
@@ -12,6 +12,10 @@ import airbyte.mcp
 from docs.generate import _validate_includes
 
 
+# These process entry points have connectivity docs in `airbyte.mcp`'s docstring.
+DOCS_EXCLUDED_MODULES = frozenset({"http_main", "server"})
+
+
 def test_validate_includes_raises_for_missing_target(tmp_path: Path) -> None:
     source = tmp_path / "airbyte" / "mcp" / "module.py"
     source.parent.mkdir(parents=True)
@@ -51,4 +55,6 @@ def test_mcp_all_covers_public_submodules() -> None:
         for module in pkgutil.iter_modules(airbyte.mcp.__path__)
         if not module.name.startswith("_")
     }
-    assert public_modules <= set(airbyte.mcp.__all__)
+    exported_modules = set(airbyte.mcp.__all__)
+    assert public_modules - DOCS_EXCLUDED_MODULES <= exported_modules
+    assert DOCS_EXCLUDED_MODULES.isdisjoint(exported_modules)

--- a/tests/unit_tests/test_mcp_docs_includes.py
+++ b/tests/unit_tests/test_mcp_docs_includes.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Validate generated MCP documentation includes and public module exports."""
+
+from __future__ import annotations
+
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+import airbyte.mcp
+from docs.generate import _validate_includes
+
+
+def test_validate_includes_raises_for_missing_target(tmp_path: Path) -> None:
+    source = tmp_path / "airbyte" / "mcp" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(".. include:: ../../docs/mcp-generated/missing.md\n")
+
+    with pytest.raises(RuntimeError, match="missing.md"):
+        _validate_includes(tmp_path)
+
+
+def test_validate_includes_passes_for_existing_target(tmp_path: Path) -> None:
+    source = tmp_path / "airbyte" / "mcp" / "module.py"
+    target = tmp_path / "docs" / "mcp-generated" / "module.md"
+    source.parent.mkdir(parents=True)
+    target.parent.mkdir(parents=True)
+    source.write_text(".. include:: ../../docs/mcp-generated/module.md\n")
+    target.write_text("# module\n")
+
+    _validate_includes(tmp_path)
+
+
+def test_existing_includes_name_generated_mcp_modules() -> None:
+    repo_root = Path(__file__).parents[2]
+    generated_modules = {"cloud", "local", "interactive", "registry", "prompts"}
+    for source in (repo_root / "airbyte").rglob("*.py"):
+        for line in source.read_text(encoding="utf-8").splitlines():
+            if ".. include::" not in line:
+                continue
+            target = line.split(".. include::", 1)[1].strip()
+            target_path = Path(target)
+            assert target_path.parts[-2] == "mcp-generated"
+            assert target_path.stem in generated_modules
+
+
+def test_mcp_all_covers_public_submodules() -> None:
+    public_modules = {
+        module.name
+        for module in pkgutil.iter_modules(airbyte.mcp.__path__)
+        if not module.name.startswith("_")
+    }
+    assert public_modules <= set(airbyte.mcp.__all__)

--- a/tests/unit_tests/test_mcp_docs_includes.py
+++ b/tests/unit_tests/test_mcp_docs_includes.py
@@ -47,7 +47,14 @@ def test_validate_includes_passes_for_existing_target(tmp_path: Path) -> None:
 
 def test_existing_includes_name_generated_mcp_modules() -> None:
     repo_root = Path(__file__).parents[2]
-    generated_modules = {"cloud", "local", "interactive", "registry", "prompts"}
+    generated_modules = {
+        "agents",
+        "cloud",
+        "local",
+        "interactive",
+        "registry",
+        "prompts",
+    }
     for source in (repo_root / "airbyte").rglob("*.py"):
         for line in source.read_text(encoding="utf-8").splitlines():
             if ".. include::" not in line:


### PR DESCRIPTION
## Summary

Closes #1119. Requested by @aaronsteers.

The published pdoc pages for `airbyte.mcp.agents`, `airbyte.mcp.local`, and `airbyte.mcp.interactive` rendered only a heading because `scripts/generate_mcp_markdown.py` inspected the server through the same runtime tool filters the server applies, so gated tools were dropped and their `docs/mcp-generated/*.md` includes were never written (pdoc silently ignores a missing `.. include::`).

**Why two passes and not one env-only pass:** the three gates cannot all be opened in a single request.
- `agents` (insiders) and `local` (trusted execution) open via env vars, so the child inspect process now sets both: `env = {**os.environ, AIRBYTE_MCP_TRUSTED_EXECUTION: "1", AIRBYTE_MCP_INSIDERS: "1"}`.
- `interactive` opens only from a client capability (`interactive_ui_filter` in fastmcp-extensions checks session capabilities / `X-MCP-Extensions` header; no env override), and `trusted_execution_filter` forces itself *off* whenever an HTTP request context is present. So pass A (no request context: agents + local + everything else) and pass B (synthetic HTTP request declaring the UI extension: interactive) are merged.

Other changes:
- `docs/generate.py` no longer swallows generator failures; after regenerating it validates every `.. include::` under `airbyte/**/*.py` and fails the build if a target is missing.
- Generated Markdown adds an **Availability** line per gate (insiders / trusted execution / UI-capable client).
- `airbyte/mcp/__init__.py` exports `agents, cloud, interactive, local, prompts, registry` so pdoc renders every documented module (`server`/`http_main` remain excluded as process entry points). Merge conflict with `main` resolved here.
- `tests/unit_tests/test_mcp_docs_includes.py` covers include validation and the generated-module set (now including `agents`).

## Test plan
- `uv run poe docs-generate` → `7 module(s) documented — 63 tool(s), 2 resource(s), 1 prompt(s)`; `agents.html`, `local.html`, `interactive.html` now contain full tool docs.
- `uv run pytest tests/unit_tests/test_mcp_docs_includes.py -q` → 5 passed.
- `uv run ruff format --check` / `ruff check` on changed files → clean.


Link to Devin session: https://app.devin.ai/sessions/5880b5ea6d4744bdaf4acf65a49e4b57
Open in Devin Desktop: https://app.devin.ai/desktop/session/5880b5ea6d4744bdaf4acf65a49e4b57?variant=devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved interactive MCP documentation generation and validation.
  * Added documentation for the Agents MCP module.
  * Added checks to detect missing or invalid documentation includes before publishing generated docs.
  * Added availability badges showing activation requirements for supported tools, including insiders-only tools.

* **Bug Fixes**
  * MCP documentation generation now reports missing or failed generators instead of silently continuing.

* **Tests**
  * Added coverage for valid, missing, and out-of-scope documentation includes.
  * Added checks for approved public MCP modules and generated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**