### PR TITLE
feat(mcp): add Cloud connector check and sync cancellation tools

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -1000,6 +1000,40 @@ def get_job_info(
     )
 
 
+def cancel_job(
+    job_id: int,
+    *,
+    api_root: str,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> models.JobResponse:
+    """Cancel a running job."""
+    airbyte_instance = get_airbyte_server_instance(
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+        api_root=api_root,
+    )
+    response = airbyte_instance.jobs.cancel_job(
+        api.CancelJobRequest(
+            job_id=job_id,
+        ),
+    )
+    if status_ok(response.status_code) and response.job_response:
+        return response.job_response
+
+    raise AirbyteMissingResourceError(
+        resource_name_or_id=str(job_id),
+        resource_type="job",
+        log_text=response.raw_response.text,
+        context={
+            "request_url": response.raw_response.url,
+            "status_code": response.status_code,
+        },
+    )
+
+
 # Create, get, and delete sources
 
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -1020,12 +1020,33 @@ def cancel_job(
             job_id=job_id,
         ),
     )
-    if status_ok(response.status_code) and response.job_response:
-        return response.job_response
+    if status_ok(response.status_code):
+        if response.job_response:
+            return response.job_response
+        raise AirbyteError(
+            message="Job cancellation response payload was empty.",
+            response=response,
+            context={
+                "request_url": response.raw_response.url,
+                "status_code": response.status_code,
+            },
+        )
 
-    raise AirbyteMissingResourceError(
-        resource_name_or_id=str(job_id),
-        resource_type="job",
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        raise AirbyteMissingResourceError(
+            resource_name_or_id=str(job_id),
+            resource_type="job",
+            response=response,
+            log_text=response.raw_response.text,
+            context={
+                "request_url": response.raw_response.url,
+                "status_code": response.status_code,
+            },
+        )
+
+    raise AirbyteError(
+        message="Could not cancel job.",
+        response=response,
         log_text=response.raw_response.text,
         context={
             "request_url": response.raw_response.url,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -23,6 +23,7 @@ from airbyte.cloud._connection_state import (
     _normalize_state_to_protocol,
 )
 from airbyte.cloud.connectors import CloudDestination, CloudSource
+from airbyte.cloud.constants import FINAL_STATUSES
 from airbyte.cloud.models import (
     CloudConnectionInfo,
     CloudJobInfo,
@@ -301,9 +302,17 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
         return sync_result
 
     def cancel_sync(self, job_id: int | None = None) -> SyncResult:
-        """Cancel a running sync job. Defaults to the connection's most recent job."""
+        """Cancel a running sync job.
+
+        Defaults to the connection's most recent sync job. Other job types must be
+        targeted with an explicit `job_id`.
+        """
         if job_id is None:
-            sync_result = self.get_sync_result()
+            sync_results = self.get_previous_sync_logs(
+                limit=1,
+                job_type=JobTypeEnum.SYNC,
+            )
+            sync_result = sync_results[0] if sync_results else None
             if sync_result is None:
                 raise PyAirbyteInputError(
                     message="No sync jobs found for this connection.",
@@ -317,6 +326,28 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
                     ),
                 )
             job_id = sync_result.job_id
+        else:
+            job_info = api_util.get_job_info(
+                job_id=job_id,
+                api_root=self.workspace.api_root,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
+            if job_info.connection_id != self.connection_id:
+                raise PyAirbyteInputError(
+                    message=(
+                        f"Job {job_id} belongs to connection '{job_info.connection_id}', "
+                        f"not '{self.connection_id}'."
+                    ),
+                )
+            job_status = CloudJobInfo.from_api_response(job_info).status
+            if job_status in FINAL_STATUSES:
+                raise PyAirbyteInputError(
+                    message=(
+                        f"Job {job_id} is already finished with status " f"'{job_status.value}'."
+                    ),
+                )
 
         job_response = api_util.cancel_job(
             job_id=job_id,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -301,56 +301,64 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
 
         return sync_result
 
+    def _get_latest_cancellable_sync_job_id(self) -> int:
+        """Get the latest cancellable sync job ID."""
+        sync_results = self.get_previous_sync_logs(
+            limit=1,
+            job_type=JobTypeEnum.SYNC,
+        )
+        sync_result = sync_results[0] if sync_results else None
+        if sync_result is None:
+            raise PyAirbyteInputError(
+                message="No sync jobs found for this connection.",
+            )
+        if sync_result.is_job_complete():
+            raise PyAirbyteInputError(
+                message=(
+                    f"The latest sync job is already finished with status "
+                    f"'{sync_result.get_job_status().value}'. "
+                    "Pass an explicit job_id to target a different job."
+                ),
+            )
+        return sync_result.job_id
+
+    def _validated_cancellable_job_id(self, job_id: int) -> int:
+        """Validate an explicit cancellable job ID."""
+        job_info = api_util.get_job_info(
+            job_id=job_id,
+            api_root=self.workspace.api_root,
+            client_id=self.workspace.client_id,
+            client_secret=self.workspace.client_secret,
+            bearer_token=self.workspace.bearer_token,
+        )
+        if job_info.connection_id != self.connection_id:
+            raise PyAirbyteInputError(
+                message=(
+                    f"Job {job_id} belongs to connection '{job_info.connection_id}', "
+                    f"not '{self.connection_id}'."
+                ),
+            )
+        job_status = CloudJobInfo.from_api_response(job_info).status
+        if job_status in FINAL_STATUSES:
+            raise PyAirbyteInputError(
+                message=f"Job {job_id} is already finished with status " f"'{job_status.value}'.",
+            )
+        return job_id
+
     def cancel_sync(self, job_id: int | None = None) -> SyncResult:
         """Cancel a running sync job.
 
         Defaults to the connection's most recent sync job. Other job types must be
         targeted with an explicit `job_id`.
         """
-        if job_id is None:
-            sync_results = self.get_previous_sync_logs(
-                limit=1,
-                job_type=JobTypeEnum.SYNC,
-            )
-            sync_result = sync_results[0] if sync_results else None
-            if sync_result is None:
-                raise PyAirbyteInputError(
-                    message="No sync jobs found for this connection.",
-                )
-            if sync_result.is_job_complete():
-                raise PyAirbyteInputError(
-                    message=(
-                        f"The latest sync job is already finished with status "
-                        f"'{sync_result.get_job_status().value}'. "
-                        "Pass an explicit job_id to target a different job."
-                    ),
-                )
-            job_id = sync_result.job_id
-        else:
-            job_info = api_util.get_job_info(
-                job_id=job_id,
-                api_root=self.workspace.api_root,
-                client_id=self.workspace.client_id,
-                client_secret=self.workspace.client_secret,
-                bearer_token=self.workspace.bearer_token,
-            )
-            if job_info.connection_id != self.connection_id:
-                raise PyAirbyteInputError(
-                    message=(
-                        f"Job {job_id} belongs to connection '{job_info.connection_id}', "
-                        f"not '{self.connection_id}'."
-                    ),
-                )
-            job_status = CloudJobInfo.from_api_response(job_info).status
-            if job_status in FINAL_STATUSES:
-                raise PyAirbyteInputError(
-                    message=(
-                        f"Job {job_id} is already finished with status " f"'{job_status.value}'."
-                    ),
-                )
+        target_job_id: int = (
+            self._get_latest_cancellable_sync_job_id()
+            if job_id is None
+            else self._validated_cancellable_job_id(job_id)
+        )
 
         job_response = api_util.cancel_job(
-            job_id=job_id,
+            job_id=target_job_id,
             api_root=self.workspace.api_root,
             client_id=self.workspace.client_id,
             client_secret=self.workspace.client_secret,

--- a/airbyte/cloud/connections.py
+++ b/airbyte/cloud/connections.py
@@ -300,6 +300,38 @@ class CloudConnection:  # noqa: PLR0904  # Too many public methods
 
         return sync_result
 
+    def cancel_sync(self, job_id: int | None = None) -> SyncResult:
+        """Cancel a running sync job. Defaults to the connection's most recent job."""
+        if job_id is None:
+            sync_result = self.get_sync_result()
+            if sync_result is None:
+                raise PyAirbyteInputError(
+                    message="No sync jobs found for this connection.",
+                )
+            if sync_result.is_job_complete():
+                raise PyAirbyteInputError(
+                    message=(
+                        f"The latest sync job is already finished with status "
+                        f"'{sync_result.get_job_status().value}'. "
+                        "Pass an explicit job_id to target a different job."
+                    ),
+                )
+            job_id = sync_result.job_id
+
+        job_response = api_util.cancel_job(
+            job_id=job_id,
+            api_root=self.workspace.api_root,
+            client_id=self.workspace.client_id,
+            client_secret=self.workspace.client_secret,
+            bearer_token=self.workspace.bearer_token,
+        )
+        return SyncResult(
+            workspace=self.workspace,
+            connection=self,
+            job_id=job_response.job_id,
+            _latest_job_info=CloudJobInfo.from_api_response(job_response),
+        )
+
     def __repr__(self) -> str:
         """String representation of the connection."""
         return (

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -293,6 +293,19 @@ class SyncJobResult(BaseModel):
     """URL to view the job in Airbyte Cloud."""
 
 
+class ConnectorCheckResult(BaseModel):
+    """Result of a connection check against a deployed Cloud connector."""
+
+    connector_id: str
+    """The deployed connector ID."""
+    connector_type: str
+    """The connector type: 'source' or 'destination'."""
+    succeeded: bool
+    """Whether the connector check succeeded."""
+    message: str | None
+    """The failure message when the check failed, otherwise None."""
+
+
 class SyncJobListResult(BaseModel):
     """Result of listing sync jobs with limit support."""
 
@@ -857,6 +870,51 @@ def list_cloud_sync_jobs(
 
 
 @mcp_tool(
+    destructive=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
+def cancel_cloud_sync(
+    ctx: Context,
+    connection_id: Annotated[
+        str,
+        Field(description="The ID of the Airbyte Cloud connection."),
+    ],
+    job_id: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Optional job ID to cancel. If not provided, the connection's most recent "
+                "job will be cancelled."
+            ),
+            default=None,
+        ),
+    ],
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+) -> SyncJobResult:
+    """Cancel a running sync job on an Airbyte Cloud connection."""
+    workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
+    connection = workspace.get_connection(connection_id=connection_id)
+    # Deliberately omit check_guid_created_in_session: cancelling a sync is reversible.
+    sync_result = connection.cancel_sync(job_id=job_id)
+    return SyncJobResult(
+        job_id=sync_result.job_id,
+        status=sync_result.get_job_status().value,
+        bytes_synced=sync_result.bytes_synced,
+        records_synced=sync_result.records_synced,
+        start_time=sync_result.start_time.isoformat(),
+        job_url=sync_result.job_url,
+    )
+
+
+@mcp_tool(
     read_only=True,
     idempotent=True,
     open_world=True,
@@ -1029,6 +1087,80 @@ def describe_cloud_destination(
         destination_name=destination_name,
         destination_url=destination.connector_url,
         connector_definition_id=destination.definition_id,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
+def check_cloud_source(
+    ctx: Context,
+    source_id: Annotated[
+        str,
+        Field(description="The ID of the deployed source connector to check."),
+    ],
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+) -> ConnectorCheckResult:
+    """Check the configuration and credentials of a deployed source connector."""
+    workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
+    source = workspace.get_source(source_id=source_id)
+    check_result = source.check(raise_on_error=False)
+    return ConnectorCheckResult(
+        connector_id=source_id,
+        connector_type=source.connector_type,
+        succeeded=check_result.success,
+        message=(
+            None
+            if check_result.success
+            else check_result.error_message or check_result.internal_error
+        ),
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
+def check_cloud_destination(
+    ctx: Context,
+    destination_id: Annotated[
+        str,
+        Field(description="The ID of the deployed destination connector to check."),
+    ],
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+) -> ConnectorCheckResult:
+    """Check the configuration and credentials of a deployed destination connector."""
+    workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
+    destination = workspace.get_destination(destination_id=destination_id)
+    check_result = destination.check(raise_on_error=False)
+    return ConnectorCheckResult(
+        connector_id=destination_id,
+        connector_type=destination.connector_type,
+        succeeded=check_result.success,
+        message=(
+            None
+            if check_result.success
+            else check_result.error_message or check_result.internal_error
+        ),
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
 from airbyte.cloud.client import CloudClient
-from airbyte.cloud.connectors import CustomCloudSourceDefinition
+from airbyte.cloud.connectors import CheckResult, CustomCloudSourceDefinition
 from airbyte.cloud.constants import FAILED_STATUSES
 from airbyte.cloud.models import JobTypeEnum
 from airbyte.cloud.workspaces import CloudWorkspace
@@ -71,6 +71,7 @@ WORKSPACE_ID_TIP_TEXT = (
     f"`{MCP_WORKSPACE_ID_HEADER}` header; local or stdio connections use the "
     f"`{CLOUD_WORKSPACE_ID_ENV_VAR}` environment variable."
 )
+CONNECTOR_CHECK_FAILURE_FALLBACK = "Connector check failed without a failure message."
 
 _DiscoveryResult = TypeVar("_DiscoveryResult")
 
@@ -88,6 +89,17 @@ def _handle_discovery_permission_error(
         "Organization or workspace discovery is unavailable because these credentials "
         "do not have the required permission or access. Provide an organization or "
         "workspace ID, or use credentials with the needed access."
+    )
+
+
+def _get_connector_check_message(check_result: CheckResult) -> str | None:
+    """Return the check failure message, if applicable."""
+    if check_result.success:
+        return None
+    return (
+        check_result.error_message
+        or check_result.internal_error
+        or CONNECTOR_CHECK_FAILURE_FALLBACK
     )
 
 
@@ -885,7 +897,7 @@ def cancel_cloud_sync(
         Field(
             description=(
                 "Optional job ID to cancel. If not provided, the connection's most recent "
-                "job will be cancelled."
+                "sync job will be cancelled. Other job types require an explicit job ID."
             ),
             default=None,
         ),
@@ -1119,11 +1131,7 @@ def check_cloud_source(
         connector_id=source_id,
         connector_type=source.connector_type,
         succeeded=check_result.success,
-        message=(
-            None
-            if check_result.success
-            else check_result.error_message or check_result.internal_error
-        ),
+        message=_get_connector_check_message(check_result),
     )
 
 
@@ -1156,11 +1164,7 @@ def check_cloud_destination(
         connector_id=destination_id,
         connector_type=destination.connector_type,
         succeeded=check_result.success,
-        message=(
-            None
-            if check_result.success
-            else check_result.error_message or check_result.internal_error
-        ),
+        message=_get_connector_check_message(check_result),
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -298,7 +298,7 @@ class ConnectorCheckResult(BaseModel):
 
     connector_id: str
     """The deployed connector ID."""
-    connector_type: str
+    connector_type: Literal["source", "destination"]
     """The connector type: 'source' or 'destination'."""
     succeeded: bool
     """Whether the connector check succeeded."""

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -8,7 +8,11 @@ from types import SimpleNamespace
 import pytest
 import requests
 from airbyte._util import api_util
-from airbyte.exceptions import AirbyteWorkspaceNotEmptyError, PyAirbyteInputError
+from airbyte.exceptions import (
+    AirbyteMissingResourceError,
+    AirbyteWorkspaceNotEmptyError,
+    PyAirbyteInputError,
+)
 from airbyte.secrets.base import SecretString
 from airbyte_api import api, models
 
@@ -688,3 +692,77 @@ def test_get_job_logs_uses_offset_and_allows_unbounded_limit(
         (100, 10),
         (100, 110),
     ]
+
+
+def test_cancel_job_forwards_request_and_returns_job_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify cancelling a job forwards its ID and returns the API job response."""
+    captured_request: api.CancelJobRequest | None = None
+    job_response = _job_response(42)
+    raw_response = requests.Response()
+    raw_response.url = "https://api.airbyte.com/v1/jobs/42"
+
+    def cancel_job(request: api.CancelJobRequest) -> api.CancelJobResponse:
+        """Capture the cancellation request."""
+        nonlocal captured_request
+        captured_request = request
+        return api.CancelJobResponse(
+            content_type="application/json",
+            status_code=200,
+            raw_response=raw_response,
+            job_response=job_response,
+        )
+
+    airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(cancel_job=cancel_job))
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.cancel_job(
+        job_id=42,
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+    )
+
+    assert result is job_response
+    assert captured_request is not None
+    assert captured_request.job_id == 42
+
+
+def test_cancel_job_raises_for_non_ok_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify cancelling a job raises when the API response is not successful."""
+    raw_response = requests.Response()
+    raw_response.status_code = 404
+    raw_response.url = "https://api.airbyte.com/v1/jobs/42"
+
+    def cancel_job(request: api.CancelJobRequest) -> api.CancelJobResponse:
+        """Return a not-found cancellation response."""
+        _ = request
+        return api.CancelJobResponse(
+            content_type="application/json",
+            status_code=404,
+            raw_response=raw_response,
+        )
+
+    airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(cancel_job=cancel_job))
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    with pytest.raises(AirbyteMissingResourceError):
+        api_util.cancel_job(
+            job_id=42,
+            api_root="https://api.airbyte.com/v1/",
+            client_id=SecretString("client-id"),
+            client_secret=SecretString("client-secret"),
+            bearer_token=None,
+        )

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from airbyte._util import api_util
 from airbyte.exceptions import (
+    AirbyteError,
     AirbyteMissingResourceError,
     AirbyteWorkspaceNotEmptyError,
     PyAirbyteInputError,
@@ -766,3 +767,39 @@ def test_cancel_job_raises_for_non_ok_response(
             client_secret=SecretString("client-secret"),
             bearer_token=None,
         )
+
+
+def test_cancel_job_raises_airbyte_error_for_non_not_found_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify non-not-found cancellation failures use a general API error."""
+    raw_response = requests.Response()
+    raw_response.status_code = 409
+    raw_response.url = "https://api.airbyte.com/v1/jobs/42"
+
+    def cancel_job(request: api.CancelJobRequest) -> api.CancelJobResponse:
+        """Return a conflict cancellation response."""
+        _ = request
+        return api.CancelJobResponse(
+            content_type="application/json",
+            status_code=409,
+            raw_response=raw_response,
+        )
+
+    airbyte_instance = SimpleNamespace(jobs=SimpleNamespace(cancel_job=cancel_job))
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    with pytest.raises(AirbyteError) as error:
+        api_util.cancel_job(
+            job_id=42,
+            api_root="https://api.airbyte.com/v1/",
+            client_id=SecretString("client-id"),
+            client_secret=SecretString("client-secret"),
+            bearer_token=None,
+        )
+
+    assert not isinstance(error.value, AirbyteMissingResourceError)

--- a/tests/unit_tests/test_cloud_connections.py
+++ b/tests/unit_tests/test_cloud_connections.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for Airbyte Cloud connections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from airbyte._util import api_util
+from airbyte.cloud.connections import CloudConnection
+from airbyte.cloud.models import JobStatusEnum
+from airbyte.cloud.workspaces import CloudWorkspace
+from airbyte.exceptions import PyAirbyteInputError
+from airbyte_api import models
+
+
+def _job_response(job_id: int, status: models.JobStatusEnum) -> models.JobResponse:
+    """Create a minimal job response."""
+    return models.JobResponse(
+        connection_id="connection-id",
+        job_id=job_id,
+        job_type=models.JobTypeEnum.SYNC,
+        start_time="2026-01-01T00:00:00Z",
+        status=status,
+    )
+
+
+@dataclass
+class _SyncResultDouble:
+    """Subset of `SyncResult` needed by cancellation tests."""
+
+    job_id: int
+    status: JobStatusEnum
+    complete: bool
+
+    def is_job_complete(self) -> bool:
+        """Return whether the job is complete."""
+        return self.complete
+
+    def get_job_status(self) -> JobStatusEnum:
+        """Return the job status."""
+        return self.status
+
+
+def _connection() -> CloudConnection:
+    """Create a CloudConnection with local credentials."""
+    workspace = CloudWorkspace(
+        workspace_id="workspace-id",
+        bearer_token="token",
+        api_root="https://api.airbyte.com/v1",
+    )
+    return CloudConnection(workspace=workspace, connection_id="connection-id")
+
+
+def _patch_cancel_job(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_job_ids: list[int],
+    response: models.JobResponse,
+) -> None:
+    """Patch the API utility cancellation call and capture its job IDs."""
+
+    def cancel_job(
+        *,
+        job_id: int,
+        api_root: str,
+        client_id: object,
+        client_secret: object,
+        bearer_token: object,
+    ) -> models.JobResponse:
+        """Capture cancellation arguments and return the configured response."""
+        _ = (api_root, client_id, client_secret, bearer_token)
+        captured_job_ids.append(job_id)
+        return response
+
+    monkeypatch.setattr(api_util, "cancel_job", cancel_job)
+
+
+def test_cancel_sync_resolves_latest_incomplete_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify cancellation without an ID uses the latest incomplete job."""
+    connection = _connection()
+    latest = _SyncResultDouble(
+        job_id=17,
+        status=JobStatusEnum.RUNNING,
+        complete=False,
+    )
+    captured_job_ids: list[int] = []
+    _patch_cancel_job(
+        monkeypatch,
+        captured_job_ids,
+        _job_response(17, models.JobStatusEnum.CANCELLED),
+    )
+
+    def get_sync_result(job_id: int | None = None) -> _SyncResultDouble:
+        """Return the configured latest job."""
+        assert job_id is None
+        return latest
+
+    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+
+    result = connection.cancel_sync()
+
+    assert captured_job_ids == [17]
+    assert result.job_id == 17
+
+
+def test_cancel_sync_rejects_latest_completed_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify cancellation without an ID rejects an already completed latest job."""
+    connection = _connection()
+    latest = _SyncResultDouble(
+        job_id=17,
+        status=JobStatusEnum.SUCCEEDED,
+        complete=True,
+    )
+
+    def get_sync_result(job_id: int | None = None) -> _SyncResultDouble:
+        """Return the configured latest job."""
+        assert job_id is None
+        return latest
+
+    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+
+    with pytest.raises(PyAirbyteInputError, match="succeeded"):
+        connection.cancel_sync()
+
+
+def test_cancel_sync_rejects_connection_without_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify cancellation without an ID rejects a connection with no jobs."""
+    connection = _connection()
+
+    def get_sync_result(job_id: int | None = None) -> None:
+        """Return no jobs."""
+        assert job_id is None
+        return None
+
+    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+
+    with pytest.raises(PyAirbyteInputError, match="No sync jobs found"):
+        connection.cancel_sync()
+
+
+def test_cancel_sync_with_explicit_job_id_skips_latest_job_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify explicit cancellation IDs bypass latest-job resolution."""
+    connection = _connection()
+    captured_job_ids: list[int] = []
+    _patch_cancel_job(
+        monkeypatch,
+        captured_job_ids,
+        _job_response(99, models.JobStatusEnum.CANCELLED),
+    )
+
+    def get_sync_result(job_id: int | None = None) -> None:
+        """Fail if latest-job resolution is attempted."""
+        _ = job_id
+        pytest.fail("get_sync_result should not be called for an explicit job ID")
+
+    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+
+    result = connection.cancel_sync(job_id=123)
+
+    assert captured_job_ids == [123]
+    assert result.job_id == 99

--- a/tests/unit_tests/test_cloud_connections.py
+++ b/tests/unit_tests/test_cloud_connections.py
@@ -8,16 +8,21 @@ from dataclasses import dataclass
 import pytest
 from airbyte._util import api_util
 from airbyte.cloud.connections import CloudConnection
-from airbyte.cloud.models import JobStatusEnum
+from airbyte.cloud.models import JobStatusEnum, JobTypeEnum
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import PyAirbyteInputError
 from airbyte_api import models
 
 
-def _job_response(job_id: int, status: models.JobStatusEnum) -> models.JobResponse:
+def _job_response(
+    job_id: int,
+    status: models.JobStatusEnum,
+    *,
+    connection_id: str = "connection-id",
+) -> models.JobResponse:
     """Create a minimal job response."""
     return models.JobResponse(
-        connection_id="connection-id",
+        connection_id=connection_id,
         job_id=job_id,
         job_type=models.JobTypeEnum.SYNC,
         start_time="2026-01-01T00:00:00Z",
@@ -75,6 +80,29 @@ def _patch_cancel_job(
     monkeypatch.setattr(api_util, "cancel_job", cancel_job)
 
 
+def _patch_get_job_info(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_job_ids: list[int],
+    response: models.JobResponse,
+) -> None:
+    """Patch the API utility job lookup and capture its job IDs."""
+
+    def get_job_info(
+        job_id: int,
+        *,
+        api_root: str,
+        client_id: object,
+        client_secret: object,
+        bearer_token: object,
+    ) -> models.JobResponse:
+        """Capture lookup arguments and return the configured response."""
+        _ = (api_root, client_id, client_secret, bearer_token)
+        captured_job_ids.append(job_id)
+        return response
+
+    monkeypatch.setattr(api_util, "get_job_info", get_job_info)
+
+
 def test_cancel_sync_resolves_latest_incomplete_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,12 +120,17 @@ def test_cancel_sync_resolves_latest_incomplete_job(
         _job_response(17, models.JobStatusEnum.CANCELLED),
     )
 
-    def get_sync_result(job_id: int | None = None) -> _SyncResultDouble:
-        """Return the configured latest job."""
-        assert job_id is None
-        return latest
+    def get_previous_sync_logs(
+        *,
+        limit: int,
+        job_type: JobTypeEnum,
+    ) -> list[_SyncResultDouble]:
+        """Return the configured latest sync job."""
+        assert limit == 1
+        assert job_type == JobTypeEnum.SYNC
+        return [latest]
 
-    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+    monkeypatch.setattr(connection, "get_previous_sync_logs", get_previous_sync_logs)
 
     result = connection.cancel_sync()
 
@@ -116,12 +149,17 @@ def test_cancel_sync_rejects_latest_completed_job(
         complete=True,
     )
 
-    def get_sync_result(job_id: int | None = None) -> _SyncResultDouble:
-        """Return the configured latest job."""
-        assert job_id is None
-        return latest
+    def get_previous_sync_logs(
+        *,
+        limit: int,
+        job_type: JobTypeEnum,
+    ) -> list[_SyncResultDouble]:
+        """Return the configured latest sync job."""
+        assert limit == 1
+        assert job_type == JobTypeEnum.SYNC
+        return [latest]
 
-    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+    monkeypatch.setattr(connection, "get_previous_sync_logs", get_previous_sync_logs)
 
     with pytest.raises(PyAirbyteInputError, match="succeeded"):
         connection.cancel_sync()
@@ -133,31 +171,42 @@ def test_cancel_sync_rejects_connection_without_jobs(
     """Verify cancellation without an ID rejects a connection with no jobs."""
     connection = _connection()
 
-    def get_sync_result(job_id: int | None = None) -> None:
+    def get_previous_sync_logs(
+        *,
+        limit: int,
+        job_type: JobTypeEnum,
+    ) -> list[_SyncResultDouble]:
         """Return no jobs."""
-        assert job_id is None
-        return None
+        assert limit == 1
+        assert job_type == JobTypeEnum.SYNC
+        return []
 
-    monkeypatch.setattr(connection, "get_sync_result", get_sync_result)
+    monkeypatch.setattr(connection, "get_previous_sync_logs", get_previous_sync_logs)
 
     with pytest.raises(PyAirbyteInputError, match="No sync jobs found"):
         connection.cancel_sync()
 
 
-def test_cancel_sync_with_explicit_job_id_skips_latest_job_lookup(
+def test_cancel_sync_with_explicit_running_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify explicit cancellation IDs bypass latest-job resolution."""
+    """Verify an explicit running job ID is validated and cancelled."""
     connection = _connection()
+    captured_lookup_job_ids: list[int] = []
+    _patch_get_job_info(
+        monkeypatch,
+        captured_lookup_job_ids,
+        _job_response(123, models.JobStatusEnum.RUNNING),
+    )
     captured_job_ids: list[int] = []
     _patch_cancel_job(
         monkeypatch,
         captured_job_ids,
-        _job_response(99, models.JobStatusEnum.CANCELLED),
+        _job_response(123, models.JobStatusEnum.CANCELLED),
     )
 
     def get_sync_result(job_id: int | None = None) -> None:
-        """Fail if latest-job resolution is attempted."""
+        """Fail if latest-job resolution is attempted for an explicit ID."""
         _ = job_id
         pytest.fail("get_sync_result should not be called for an explicit job ID")
 
@@ -165,5 +214,63 @@ def test_cancel_sync_with_explicit_job_id_skips_latest_job_lookup(
 
     result = connection.cancel_sync(job_id=123)
 
+    assert captured_lookup_job_ids == [123]
     assert captured_job_ids == [123]
-    assert result.job_id == 99
+    assert result.job_id == 123
+
+
+def test_cancel_sync_rejects_explicit_job_from_different_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify an explicit job ID from another connection cannot be cancelled."""
+    connection = _connection()
+    captured_lookup_job_ids: list[int] = []
+    _patch_get_job_info(
+        monkeypatch,
+        captured_lookup_job_ids,
+        _job_response(
+            123,
+            models.JobStatusEnum.RUNNING,
+            connection_id="different-connection-id",
+        ),
+    )
+    captured_job_ids: list[int] = []
+    _patch_cancel_job(
+        monkeypatch,
+        captured_job_ids,
+        _job_response(123, models.JobStatusEnum.CANCELLED),
+    )
+
+    with pytest.raises(
+        PyAirbyteInputError,
+        match="different-connection-id.*connection-id",
+    ):
+        connection.cancel_sync(job_id=123)
+
+    assert captured_lookup_job_ids == [123]
+    assert captured_job_ids == []
+
+
+def test_cancel_sync_rejects_explicit_completed_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify an explicit completed job cannot be cancelled."""
+    connection = _connection()
+    captured_lookup_job_ids: list[int] = []
+    _patch_get_job_info(
+        monkeypatch,
+        captured_lookup_job_ids,
+        _job_response(123, models.JobStatusEnum.SUCCEEDED),
+    )
+    captured_job_ids: list[int] = []
+    _patch_cancel_job(
+        monkeypatch,
+        captured_job_ids,
+        _job_response(123, models.JobStatusEnum.CANCELLED),
+    )
+
+    with pytest.raises(PyAirbyteInputError, match="succeeded"):
+        connection.cancel_sync(job_id=123)
+
+    assert captured_lookup_job_ids == [123]
+    assert captured_job_ids == []

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -8,12 +8,15 @@ from datetime import datetime, timezone
 from typing import Callable, cast
 
 import pytest
+from airbyte.cloud.connectors import CheckResult
 from airbyte.cloud.models import JobStatusEnum
 from airbyte.mcp import cloud as cloud_mcp
 from airbyte.mcp.cloud import (
     CloudConnectionResult,
     CloudDestinationResult,
     CloudSourceResult,
+    ConnectorCheckResult,
+    SyncJobResult,
 )
 from fastmcp import Context
 
@@ -25,6 +28,9 @@ class _SyncResultLike:
     job_id: int
     status: JobStatusEnum
     start_time: datetime
+    bytes_synced: int = 0
+    records_synced: int = 0
+    job_url: str = "https://cloud.airbyte.com/jobs"
 
     def get_job_status(self) -> JobStatusEnum:
         """Return the configured job status."""
@@ -54,6 +60,48 @@ class _CloudDestinationLike:
 
 
 @dataclass
+class _CheckableConnectorLike:
+    """Subset of `CloudConnector` used by connector check tests."""
+
+    connector_id: str
+    connector_type: str
+    result: CheckResult
+    received_raise_on_error: bool | None = None
+
+    def check(self, *, raise_on_error: bool = True) -> CheckResult:
+        """Capture the error handling option and return the configured result."""
+        self.received_raise_on_error = raise_on_error
+        return self.result
+
+
+class _ConnectorCheckWorkspace:
+    """Return checkable source and destination test doubles."""
+
+    def __init__(self, result: CheckResult) -> None:
+        """Create source and destination test doubles."""
+        self.source = _CheckableConnectorLike(
+            connector_id="source-id",
+            connector_type="source",
+            result=result,
+        )
+        self.destination = _CheckableConnectorLike(
+            connector_id="destination-id",
+            connector_type="destination",
+            result=result,
+        )
+
+    def get_source(self, *, source_id: str) -> _CheckableConnectorLike:
+        """Return the source test double."""
+        assert source_id == self.source.connector_id
+        return self.source
+
+    def get_destination(self, *, destination_id: str) -> _CheckableConnectorLike:
+        """Return the destination test double."""
+        assert destination_id == self.destination.connector_id
+        return self.destination
+
+
+@dataclass
 class _CloudConnectionLike:
     """Subset of `CloudConnection` used by tested MCP list tools."""
 
@@ -75,6 +123,32 @@ class _CloudConnectionLike:
                 start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
             )
         ]
+
+
+@dataclass
+class _CancelableConnectionLike:
+    """Subset of `CloudConnection` used by sync cancellation tests."""
+
+    sync_result: _SyncResultLike
+    received_job_id: int | None = None
+
+    def cancel_sync(self, *, job_id: int | None = None) -> _SyncResultLike:
+        """Capture the job ID and return the cancelled sync result."""
+        self.received_job_id = job_id
+        return self.sync_result
+
+
+class _CancellationWorkspace:
+    """Return a connection test double for sync cancellation tests."""
+
+    def __init__(self, connection: _CancelableConnectionLike) -> None:
+        """Create a workspace test double."""
+        self.connection = connection
+
+    def get_connection(self, *, connection_id: str) -> _CancelableConnectionLike:
+        """Return the configured connection."""
+        assert connection_id == "connection-id"
+        return self.connection
 
 
 class _CloudWorkspace:
@@ -258,3 +332,149 @@ def test_mcp_cloud_connections_apply_limit_after_status_filter(
     assert workspace.limits["connections"] is None
     assert len(results) == 1
     assert results[0].id == "connection-2"
+
+
+@pytest.mark.parametrize(
+    ("tool", "connector_id_parameter", "connector_id", "connector_type"),
+    [
+        pytest.param(
+            cloud_mcp.check_cloud_source,
+            "source_id",
+            "source-id",
+            "source",
+            id="source",
+        ),
+        pytest.param(
+            cloud_mcp.check_cloud_destination,
+            "destination_id",
+            "destination-id",
+            "destination",
+            id="destination",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("check_result", "expected_success", "expected_message"),
+    [
+        pytest.param(
+            CheckResult(success=True),
+            True,
+            None,
+            id="success",
+        ),
+        pytest.param(
+            CheckResult(success=False, error_message="Invalid credentials"),
+            False,
+            "Invalid credentials",
+            id="error-message",
+        ),
+        pytest.param(
+            CheckResult(success=False, internal_error="Check service unavailable"),
+            False,
+            "Check service unavailable",
+            id="internal-error",
+        ),
+    ],
+)
+def test_mcp_cloud_connector_checks_map_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tool: Callable[..., object],
+    connector_id_parameter: str,
+    connector_id: str,
+    connector_type: str,
+    check_result: CheckResult,
+    expected_success: bool,
+    expected_message: str | None,
+) -> None:
+    """Verify Cloud MCP connector checks map result fields and disable raising."""
+    workspace = _ConnectorCheckWorkspace(check_result)
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    result = cast(
+        ConnectorCheckResult,
+        tool(
+            ctx=cast(Context, object()),
+            workspace_id="workspace-id",
+            **{connector_id_parameter: connector_id},
+        ),
+    )
+
+    connector = (
+        workspace.source if connector_type == "source" else workspace.destination
+    )
+    assert result.connector_id == connector_id
+    assert result.connector_type == connector_type
+    assert result.succeeded is expected_success
+    assert result.message == expected_message
+    assert connector.received_raise_on_error is False
+
+
+def test_cancel_cloud_sync_returns_cancelled_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the Cloud MCP cancellation tool maps the cancelled sync result."""
+    sync_result = _SyncResultLike(
+        job_id=42,
+        status=JobStatusEnum.CANCELLED,
+        bytes_synced=123,
+        records_synced=456,
+        start_time=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        job_url="https://cloud.airbyte.com/jobs/42",
+    )
+    connection = _CancelableConnectionLike(sync_result=sync_result)
+    workspace = _CancellationWorkspace(connection)
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    result = cast(
+        SyncJobResult,
+        cloud_mcp.cancel_cloud_sync(
+            ctx=cast(Context, object()),
+            connection_id="connection-id",
+            job_id=42,
+            workspace_id="workspace-id",
+        ),
+    )
+
+    assert connection.received_job_id == 42
+    assert result.job_id == 42
+    assert result.status == "cancelled"
+    assert result.bytes_synced == 123
+    assert result.records_synced == 456
+    assert result.start_time == "2026-01-02T03:04:05+00:00"
+    assert result.job_url == "https://cloud.airbyte.com/jobs/42"
+
+
+def test_cancel_cloud_sync_forwards_missing_job_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the Cloud MCP cancellation tool forwards a missing job ID."""
+    connection = _CancelableConnectionLike(
+        sync_result=_SyncResultLike(
+            job_id=42,
+            status=JobStatusEnum.CANCELLED,
+            start_time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        )
+    )
+    workspace = _CancellationWorkspace(connection)
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: workspace,
+    )
+
+    cloud_mcp.cancel_cloud_sync(
+        ctx=cast(Context, object()),
+        connection_id="connection-id",
+        job_id=None,
+        workspace_id="workspace-id",
+    )
+
+    assert connection.received_job_id is None

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -374,6 +374,12 @@ def test_mcp_cloud_connections_apply_limit_after_status_filter(
             "Check service unavailable",
             id="internal-error",
         ),
+        pytest.param(
+            CheckResult(success=False),
+            False,
+            "Connector check failed without a failure message.",
+            id="missing-message",
+        ),
     ],
 )
 def test_mcp_cloud_connector_checks_map_results(


### PR DESCRIPTION
## Summary

Closes #1118. Adds the two Cloud MCP capabilities requested by AJ Steers (@aaronsteers): checking a *deployed* Cloud actor, and cancelling an in-flight sync job.

**1. `check_cloud_source` / `check_cloud_destination`** — pure presentation wrappers over the existing `CloudConnector.check()`, called with `raise_on_error=False` so a failed check comes back as data rather than an exception:

```python
ConnectorCheckResult(
    connector_id=source_id,
    connector_type=source.connector_type,   # Literal["source", "destination"]
    succeeded=check_result.success,
    message=None if check_result.success else (check_result.error_message or check_result.internal_error),
)
```

Annotated `read_only=True, idempotent=True` — a check runs a connector-side check job but mutates no Airbyte config, so it stays available in read-only/hosted sessions (where `validate_connector_config` is unavailable behind trusted execution).

**2. `cancel_cloud_sync`** — needed new core support, added bottom-up:

- `api_util.cancel_job(job_id, ...)` over the public API's `DELETE /v1/jobs/{jobId}`, via the pinned SDK's `jobs.cancel_job(api.CancelJobRequest(job_id=...))`. Unlike `get_job_info`, a non-2xx here is frequently *not* a missing job — 409/422 means "exists but not cancellable" and 401/403 means auth — so only 404 raises `AirbyteMissingResourceError` and everything else (including a 2xx with an empty payload) raises `AirbyteError`.
- `CloudConnection.cancel_sync(job_id=None)` resolves the target job and then cancels it:

```python
if job_id is None:
    # latest *sync* job only: the API's default job-type filter also matches resets
    latest = get_previous_sync_logs(limit=1, job_type=JobTypeEnum.SYNC)
    -> PyAirbyteInputError if absent, or already in FINAL_STATUSES
else:
    job = api_util.get_job_info(job_id)
    -> PyAirbyteInputError if job.connection_id != self.connection_id
    -> PyAirbyteInputError if job status in FINAL_STATUSES
```

  The explicit-`job_id` ownership check matters because `cancel_job` is addressed purely by job ID: without it, a job ID from *another* connection in an accessible workspace would be cancelled even though the caller named this connection. Returns a `SyncResult` seeded with the cancel response, so the caller sees the post-cancel status without a second fetch.
- The MCP tool is `destructive=True` (not `read_only`, not `idempotent`) and returns the existing `SyncJobResult`.

**Safe mode decision: `cancel_cloud_sync` is deliberately *not* gated by `check_guid_created_in_session`.** Safe mode exists to stop an agent from destroying pre-existing resources; cancelling a job destroys nothing and is reversible — the sync can simply be re-run. Gating it would also break the primary use case, since the runaway sync an agent or user most wants stopped is typically on a connection the current session did not create. The omission is noted in a code comment so it doesn't read as an oversight.

## Test plan

Mock-based unit tests at the three seams — `api_util` (SDK request shape; 404 vs 409 error types), `CloudConnection.cancel_sync` (sync-only default selection, no-jobs, already-finished, foreign-connection job, successful cancel), and the MCP mapping (both check tools including `error_message` → `internal_error` fallback, plus `cancel_cloud_sync` → `SyncJobResult`).

Locally: `ruff format`, `ruff check .`, `mypy airbyte/` clean, and the repo's fast suite — `628 passed, 1 skipped, 85 deselected`. The full-repo `mypy .` run hits a duplicate-`run`-module error in `tests/integration_tests/fixtures/source-broken`, confirmed pre-existing on a clean `origin/main` worktree.

Neither new code path is exercised against live Cloud in CI: `check_*` needs a deployed actor and `cancel_cloud_sync` needs a running job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to cancel cloud sync jobs, including the latest sync when no job is specified.
  - Added connector checks for cloud sources and destinations.
  - Connector checks report success or provide an actionable failure message.
- **Bug Fixes**
  - Added validation for missing, completed, or unrelated sync jobs before cancellation.
  - Improved error handling when a requested job cannot be found or cancellation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Link to Devin session: https://app.devin.ai/sessions/fe45a6bd8ca74a459e02c8f3b09a840e

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._