### PR TITLE
fix(cloud): Drop undocumented AIRBYTE_API_ROOT env var aliases

### DIFF
--- a/airbyte/cloud/_credentials.py
+++ b/airbyte/cloud/_credentials.py
@@ -24,9 +24,7 @@ CLIENT_ID_ENV_VAR = "AIRBYTE_CLIENT_ID"
 CLIENT_SECRET_ENV_VAR = "AIRBYTE_CLIENT_SECRET"
 WORKSPACE_ID_ENV_VAR = "AIRBYTE_WORKSPACE_ID"
 ORGANIZATION_ID_ENV_VAR = "AIRBYTE_ORGANIZATION_ID"
-PUBLIC_API_ROOT_ENV_VAR = "AIRBYTE_API_ROOT"
 BEARER_TOKEN_ENV_VAR = "AIRBYTE_BEARER_TOKEN"
-CONFIG_API_ROOT_ENV_VAR = "AIRBYTE_CONFIG_API_ROOT"
 
 
 @dataclass(frozen=True)
@@ -94,14 +92,12 @@ class _AirbyteCredentials:
             bearer_token=SecretString(resolved_bearer_token) if resolved_bearer_token else None,
             public_api_root=_first_value(
                 public_api_root,
-                _env_value(PUBLIC_API_ROOT_ENV_VAR, CLOUD_API_ROOT_ENV_VAR) if env_vars else None,
+                _env_value(CLOUD_API_ROOT_ENV_VAR) if env_vars else None,
             )
             or CLOUD_API_ROOT,
             config_api_root=_first_value(
                 config_api_root,
-                _env_value(CONFIG_API_ROOT_ENV_VAR, CLOUD_CONFIG_API_ROOT_ENV_VAR)
-                if env_vars
-                else None,
+                _env_value(CLOUD_CONFIG_API_ROOT_ENV_VAR) if env_vars else None,
             ),
             workspace_id=_first_value(
                 workspace_id,

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -71,8 +71,8 @@ def test_airbyte_credentials_from_auth_defaults_to_env_var_lookup(
 def test_airbyte_credentials_from_auth_ignores_legacy_api_root_env_vars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    legacy_public_api_root_env_var = "AIRBYTE_" + "API_ROOT"
-    legacy_config_api_root_env_var = "AIRBYTE_" + "CONFIG_API_ROOT"
+    legacy_public_api_root_env_var = "AIRBYTE_API_ROOT"
+    legacy_config_api_root_env_var = "AIRBYTE_CONFIG_API_ROOT"
     for env_var in (
         constants.CLOUD_API_ROOT_ENV_VAR,
         constants.CLOUD_CONFIG_API_ROOT_ENV_VAR,
@@ -82,11 +82,15 @@ def test_airbyte_credentials_from_auth_ignores_legacy_api_root_env_vars(
         cloud_credentials.BEARER_TOKEN_ENV_VAR,
         cloud_credentials.CLIENT_ID_ENV_VAR,
         cloud_credentials.CLIENT_SECRET_ENV_VAR,
-        legacy_public_api_root_env_var,
-        legacy_config_api_root_env_var,
     ):
         monkeypatch.delenv(env_var, raising=False)
     monkeypatch.setenv(constants.CLOUD_BEARER_TOKEN_ENV_VAR, "test-bearer-token")
+    monkeypatch.setenv(
+        legacy_public_api_root_env_var, "http://legacy.example.com/api/public/v1"
+    )
+    monkeypatch.setenv(
+        legacy_config_api_root_env_var, "http://legacy.example.com/api/v1"
+    )
     credentials = cloud_credentials._AirbyteCredentials.from_auth(env_vars=True)
 
     assert credentials.public_api_root == constants.CLOUD_API_ROOT

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 from __future__ import annotations
 
+import os
+
 import pytest
 from airbyte_api import models
 
@@ -91,6 +93,18 @@ def test_airbyte_credentials_from_auth_ignores_legacy_api_root_env_vars(
     monkeypatch.setenv(
         legacy_config_api_root_env_var, "http://legacy.example.com/api/v1"
     )
+
+    def fake_try_get_secret(
+        secret_name: str,
+        /,
+        *,
+        default: str | SecretString | None = None,
+        **_: object,
+    ) -> SecretString | str | None:
+        return os.environ.get(secret_name, default)
+
+    monkeypatch.setattr(cloud_credentials, "try_get_secret", fake_try_get_secret)
+
     credentials = cloud_credentials._AirbyteCredentials.from_auth(env_vars=True)
 
     assert credentials.public_api_root == constants.CLOUD_API_ROOT

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -68,6 +68,44 @@ def test_airbyte_credentials_from_auth_defaults_to_env_var_lookup(
     assert credentials.bearer_token == "test-bearer-token"
 
 
+def test_airbyte_credentials_from_auth_ignores_legacy_api_root_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_public_api_root_env_var = "AIRBYTE_" + "API_ROOT"
+    legacy_config_api_root_env_var = "AIRBYTE_" + "CONFIG_API_ROOT"
+    for env_var in (
+        constants.CLOUD_API_ROOT_ENV_VAR,
+        constants.CLOUD_CONFIG_API_ROOT_ENV_VAR,
+        constants.CLOUD_BEARER_TOKEN_ENV_VAR,
+        constants.CLOUD_CLIENT_ID_ENV_VAR,
+        constants.CLOUD_CLIENT_SECRET_ENV_VAR,
+        cloud_credentials.BEARER_TOKEN_ENV_VAR,
+        cloud_credentials.CLIENT_ID_ENV_VAR,
+        cloud_credentials.CLIENT_SECRET_ENV_VAR,
+        legacy_public_api_root_env_var,
+        legacy_config_api_root_env_var,
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv(constants.CLOUD_BEARER_TOKEN_ENV_VAR, "test-bearer-token")
+    credentials = cloud_credentials._AirbyteCredentials.from_auth(env_vars=True)
+
+    assert credentials.public_api_root == constants.CLOUD_API_ROOT
+    assert credentials.config_api_root is None
+
+    monkeypatch.setenv(
+        constants.CLOUD_API_ROOT_ENV_VAR,
+        "https://example.airbyte.com/api/public/v1",
+    )
+    monkeypatch.setenv(
+        constants.CLOUD_CONFIG_API_ROOT_ENV_VAR,
+        "https://example.airbyte.com/api/v1",
+    )
+    credentials = cloud_credentials._AirbyteCredentials.from_auth(env_vars=True)
+
+    assert credentials.public_api_root == "https://example.airbyte.com/api/public/v1"
+    assert credentials.config_api_root == "https://example.airbyte.com/api/v1"
+
+
 @pytest.mark.parametrize(
     "env_vars, expected_guidance",
     [


### PR DESCRIPTION
## Summary

`_AirbyteCredentials.from_auth()` resolved the API roots from two undocumented aliases *before* the documented Cloud vars:

```python
public_api_root = _env_value("AIRBYTE_API_ROOT", "AIRBYTE_CLOUD_API_URL")        # alias wins
config_api_root = _env_value("AIRBYTE_CONFIG_API_ROOT", "AIRBYTE_CLOUD_CONFIG_API_URL")
```

The aliases were invisible to the MCP server, because `_get_cloud_client()` builds `CloudClient(...)`, whose `__init__` passes `env_vars=False` — so only the two `AIRBYTE_CLOUD_*` MCP config args resolve. Setting `AIRBYTE_API_ROOT` for a self-managed/OSS deployment therefore silently left the root at `https://api.airbyte.com/v1`, i.e. the OSS client credentials were sent to Airbyte Cloud and every tool call failed with a `401` from the token endpoint. In the non-MCP path (`CloudWorkspace.from_env()`) the aliases worked but shadowed the only vars its own docstring documents.

Both aliases are removed; the roots now resolve solely from `AIRBYTE_CLOUD_API_URL` / `AIRBYTE_CLOUD_CONFIG_API_URL`. The other un-prefixed aliases (`AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, `AIRBYTE_BEARER_TOKEN`, `AIRBYTE_WORKSPACE_ID`, `AIRBYTE_ORGANIZATION_ID`) are untouched.

Requested by AJ Steers after an OSS STDIO integration check.

## Test plan

Verified against a real self-managed Airbyte (abctl, chart 2.2.0) at `http://localhost:8000`, driving `airbyte-mcp` over STDIO with `abctl local credentials` and calling `list_cloud_organizations`, `list_cloud_workspaces`, `check_airbyte_cloud_workspace`, `list_deployed_cloud_source_connectors`, `list_deployed_cloud_connections` (public API) and `list_custom_source_definitions` (Config API):

- `AIRBYTE_CLOUD_API_URL=http://localhost:8000/api/public/v1` alone — all six tools returned live OSS data; the Config API root was correctly inferred as `/api/v1`.
- Adding `AIRBYTE_CLOUD_CONFIG_API_URL=http://localhost:8000/api/v1` — identical results.
- `AIRBYTE_API_ROOT` / `AIRBYTE_CONFIG_API_ROOT` only — all six tools failed with `401` from the token endpoint against Airbyte Cloud, which is the behavior this PR stops advertising.

New unit test `test_airbyte_credentials_from_auth_ignores_legacy_api_root_env_vars` sets both legacy vars with the `AIRBYTE_CLOUD_*` vars unset and asserts the roots fall back to the Cloud defaults, then asserts the documented vars still resolve.

Run: `uv run pytest tests/unit_tests/test_cloud_credentials.py tests/unit_tests/test_cloud_api_roots.py tests/unit_tests/test_exceptions.py` (54 passed), plus `uv run ruff format .` and `uv run ruff check .`. Full-repo `mypy` is blocked by a preexisting duplicate `setup` module error in the test fixture sources, unrelated to this branch.


Link to Devin session: https://app.devin.ai/sessions/1f5ac01724924c1ba53ab381fe4a241d
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud API configuration now uses only the current supported environment variables.
  * Legacy API-root environment variable names are no longer recognized.
  * Default cloud API endpoints are used when only a bearer token is provided.

* **Tests**
  * Added coverage for legacy variable handling, default endpoints, and explicit current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._