### PR TITLE
fix(mcp): scale organization discovery and resolve default org

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2483,7 +2483,17 @@ def list_organizations_for_user_id(
             bearer_token=bearer_token,
         )
 
+        if not isinstance(json_result, dict):
+            raise AirbyteError(
+                message="The organizations API returned an unexpected response.",
+                context={"response": json_result},
+            )
         organizations = json_result.get("organizations", [])
+        if not isinstance(organizations, list):
+            raise AirbyteError(
+                message="The organizations API returned an unexpected response.",
+                context={"response": json_result},
+            )
 
         if not organizations:
             break
@@ -2885,7 +2895,7 @@ def get_user_by_auth_id(
     bearer_token: SecretString | None,
 ) -> dict[str, Any]:
     """Get an Airbyte user by the authentication provider user ID."""
-    return _make_config_api_request(
+    result = _make_config_api_request(
         path="/users/get_by_auth_id",
         json={
             "authUserId": auth_user_id,
@@ -2896,6 +2906,13 @@ def get_user_by_auth_id(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
+    )
+    if isinstance(result, dict):
+        return result
+
+    raise AirbyteError(
+        message="The user API returned an unexpected response.",
+        context={"response": result},
     )
 
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -13,6 +13,7 @@ directly. This will ensure a single source of truth when mapping between the `ai
 
 from __future__ import annotations
 
+import base64
 import json
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 JOB_WAIT_INTERVAL_SECS = 2.0
 JOB_WAIT_TIMEOUT_SECS_DEFAULT = 60 * 60  # 1 hour
 PAGE_SIZE = 100
+JWT_PART_COUNT = 3
 
 # Job ordering constants for list_jobs API
 JOB_ORDER_BY_CREATED_AT_DESC = "createdAt|DESC"
@@ -2763,6 +2765,92 @@ def get_organization_info(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
+    )
+
+
+def get_user_id_from_bearer_token(bearer_token: SecretString) -> str:
+    """Extract the authentication user ID from a bearer token."""
+    token_parts = str(bearer_token).split(".")
+    if len(token_parts) != JWT_PART_COUNT:
+        raise PyAirbyteInputError(
+            message="The bearer token is not a valid JWT.",
+            guidance="Provide a valid bearer token.",
+        )
+
+    try:
+        payload = json.loads(
+            base64.urlsafe_b64decode(
+                token_parts[1] + "=" * (-len(token_parts[1]) % 4),
+            ).decode("utf-8")
+        )
+    except (UnicodeDecodeError, ValueError) as error:
+        raise PyAirbyteInputError(
+            message="The bearer token payload could not be decoded.",
+            guidance="Provide a valid bearer token.",
+        ) from error
+
+    user_id = payload.get("user_id") if isinstance(payload, dict) else None
+    if not isinstance(user_id, str) or not user_id:
+        raise PyAirbyteInputError(
+            message="The bearer token does not contain a user ID.",
+            guidance="Provide a bearer token issued for an Airbyte user.",
+        )
+    return user_id
+
+
+def get_user_by_auth_id(
+    auth_user_id: str,
+    *,
+    api_root: str,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> dict[str, Any]:
+    """Get an Airbyte user by the authentication provider user ID."""
+    return _make_config_api_request(
+        path="/users/get_by_auth_id",
+        json={
+            "authUserId": auth_user_id,
+            "authProvider": "keycloak",
+        },
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+
+
+def list_permissions_for_user(
+    user_id: str,
+    *,
+    api_root: str,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> list[dict[str, Any]]:
+    """List permissions granted to an Airbyte user."""
+    result = _make_config_api_request(
+        path="/permissions/list_by_user",
+        json={"userId": user_id},
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+    if isinstance(result, list):
+        return result
+
+    permissions = result.get("permissions")
+    if isinstance(permissions, list):
+        return permissions
+
+    raise AirbyteError(
+        message="The permissions API returned an unexpected response.",
+        context={"response": result},
     )
 
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2424,6 +2424,83 @@ def list_organizations_for_user(
     )
 
 
+def list_organizations_for_user_id(
+    user_id: str,
+    *,
+    api_root: str,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+    config_api_root: str | None = None,
+    name_contains: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """List organizations the given user is a member of.
+
+    Uses the Config API endpoint: POST /v1/organizations/list_by_user_id
+
+    Unlike the public `GET /organizations` endpoint, this endpoint supports
+    server-side name filtering and pagination.
+
+    Args:
+        user_id: The Airbyte user ID to list organizations for
+        api_root: The API root URL
+        client_id: OAuth client ID
+        client_secret: OAuth client secret
+        bearer_token: Bearer token for authentication (alternative to client credentials).
+        config_api_root: Optional explicit Config API root URL.
+        name_contains: Optional substring filter for organization names (server-side)
+        limit: Optional maximum number of organizations to return
+
+    Returns:
+        List of organization dictionaries containing organizationId, organizationName, email, etc.
+    """
+    _validate_pagination_params(limit=limit)
+    result: list[dict[str, Any]] = []
+    page_size = PAGE_SIZE
+
+    payload: dict[str, Any] = {
+        "userId": user_id,
+        "pagination": {
+            "pageSize": page_size,
+            "rowOffset": 0,
+        },
+    }
+    if name_contains is not None:
+        payload["nameContains"] = name_contains
+
+    while True:
+        json_result = _make_config_api_request(
+            path="/organizations/list_by_user_id",
+            json={
+                **payload,
+                "pagination": payload["pagination"].copy(),
+            },
+            api_root=api_root,
+            config_api_root=config_api_root,
+            client_id=client_id,
+            client_secret=client_secret,
+            bearer_token=bearer_token,
+        )
+
+        organizations = json_result.get("organizations", [])
+
+        if not organizations:
+            break
+
+        result.extend(organizations)
+
+        if limit is not None and len(result) >= limit:
+            return result[:limit]
+
+        if len(organizations) < page_size:
+            break
+
+        payload["pagination"]["rowOffset"] += page_size
+
+    return result
+
+
 def list_workspaces_in_organization(
     organization_id: str,
     *,

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2619,7 +2619,7 @@ def get_workspace_organization_info(
         - sso: Whether SSO is enabled
         - billing: Billing information (optional)
     """
-    return _make_config_api_request(
+    result = _make_config_api_request(
         path="/workspaces/get_organization_info",
         json={"workspaceId": workspace_id},
         api_root=api_root,
@@ -2627,6 +2627,12 @@ def get_workspace_organization_info(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
+    )
+    if isinstance(result, dict):
+        return result
+    raise AirbyteError(
+        message="The workspace API returned an unexpected response.",
+        context={"response": result},
     )
 
 
@@ -2844,7 +2850,7 @@ def get_organization_info(
         - sso: Whether SSO is enabled
         - billing: Billing information (optional, contains paymentStatus, subscriptionStatus, etc.)
     """
-    return _make_config_api_request(
+    result = _make_config_api_request(
         path="/organizations/get_organization_info",
         json={"organizationId": organization_id},
         api_root=api_root,
@@ -2852,6 +2858,12 @@ def get_organization_info(
         client_id=client_id,
         client_secret=client_secret,
         bearer_token=bearer_token,
+    )
+    if isinstance(result, dict):
+        return result
+    raise AirbyteError(
+        message="The organization API returned an unexpected response.",
+        context={"response": result},
     )
 
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -544,7 +544,7 @@ def list_connections(
     return result
 
 
-def list_workspaces(
+def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for pagination controls
     workspace_id: str,
     *,
     api_root: str,
@@ -554,11 +554,27 @@ def list_workspaces(
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
+    max_pages: int | None = None,
 ) -> list[models.WorkspaceResponse]:
-    """List workspaces."""
+    """List workspaces, optionally bounded to a maximum number of API pages.
+
+    Args:
+        workspace_id: Workspace context for the request.
+        api_root: The API root URL.
+        client_id: OAuth client ID.
+        client_secret: OAuth client secret.
+        bearer_token: Bearer token for authentication.
+        name: Optional exact workspace name to match.
+        name_filter: Optional predicate to match workspace names.
+        limit: Optional maximum number of matching workspaces to return.
+        max_pages: Optional maximum number of API pages to scan. This is useful
+            when applying a client-side filter to a broad workspace listing.
+    """
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit)
+    if max_pages is not None and max_pages <= 0:
+        raise PyAirbyteInputError(message="`max_pages` must be greater than 0.")
     has_name_filter = name is not None or name_filter is not None
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
@@ -571,6 +587,7 @@ def list_workspaces(
     result: list[models.WorkspaceResponse] = []
     current_offset = 0
     remaining = limit
+    pages_fetched = 0
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
         page_limit = PAGE_SIZE if has_name_filter else _get_page_limit(remaining)
@@ -595,6 +612,7 @@ def list_workspaces(
 
         assert response.workspaces_response is not None
         page_data = response.workspaces_response.data
+        pages_fetched += 1
         if not page_data:
             break
 
@@ -603,6 +621,9 @@ def list_workspaces(
         result += page_results
         if remaining is not None:
             remaining -= len(page_results)
+
+        if max_pages is not None and pages_fetched >= max_pages:
+            break
 
         if not response.workspaces_response.next:
             break

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2844,7 +2844,7 @@ def list_permissions_for_user(
     if isinstance(result, list):
         return result
 
-    permissions = result.get("permissions")
+    permissions = result.get("permissions") if isinstance(result, dict) else None
     if isinstance(permissions, list):
         return permissions
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -544,7 +544,7 @@ def list_connections(
     return result
 
 
-def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for pagination controls
+def list_workspaces(
     workspace_id: str,
     *,
     api_root: str,
@@ -554,9 +554,8 @@ def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for paginat
     name: str | None = None,
     name_filter: Callable[[str], bool] | None = None,
     limit: int | None = None,
-    max_pages: int | None = None,
 ) -> list[models.WorkspaceResponse]:
-    """List workspaces, optionally bounded to a maximum number of API pages.
+    """List workspaces.
 
     Args:
         workspace_id: Workspace context for the request.
@@ -567,14 +566,10 @@ def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for paginat
         name: Optional exact workspace name to match.
         name_filter: Optional predicate to match workspace names.
         limit: Optional maximum number of matching workspaces to return.
-        max_pages: Optional maximum number of API pages to scan. This is useful
-            when applying a client-side filter to a broad workspace listing.
     """
     if name is not None and name_filter:
         raise PyAirbyteInputError(message="You can provide name or name_filter, but not both.")
     _validate_pagination_params(limit=limit)
-    if max_pages is not None and max_pages <= 0:
-        raise PyAirbyteInputError(message="`max_pages` must be greater than 0.")
     has_name_filter = name is not None or name_filter is not None
     name_filter = (lambda n: n == name) if name is not None else name_filter or (lambda _: True)
 
@@ -587,7 +582,6 @@ def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for paginat
     result: list[models.WorkspaceResponse] = []
     current_offset = 0
     remaining = limit
-    pages_fetched = 0
     base_context = {"workspace_id": workspace_id, "api_root": api_root}
     while remaining is None or remaining > 0:
         page_limit = PAGE_SIZE if has_name_filter else _get_page_limit(remaining)
@@ -612,7 +606,6 @@ def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for paginat
 
         assert response.workspaces_response is not None
         page_data = response.workspaces_response.data
-        pages_fetched += 1
         if not page_data:
             break
 
@@ -621,9 +614,6 @@ def list_workspaces(  # noqa: PLR0913  # Too many arguments - needed for paginat
         result += page_results
         if remaining is not None:
             remaining -= len(page_results)
-
-        if max_pages is not None and pages_fetched >= max_pages:
-            break
 
         if not response.workspaces_response.next:
             break

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -400,7 +400,7 @@ class CloudClient:
             config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            bearer_token=self.bearer_token,
+            bearer_token=self._get_config_api_bearer_token(),
             name_contains=name_contains or name,
             limit=None if name is not None or name_filter is not None else limit,
         )
@@ -445,6 +445,20 @@ class CloudClient:
             self._raise_ambiguous_organization_error(organization_ids)
         return organization_ids[0] if organization_ids else None
 
+    def _get_config_api_bearer_token(self) -> SecretString | None:
+        """Get and cache a bearer token for Config API requests."""
+        if self._authenticated_bearer_token is not None:
+            return self._authenticated_bearer_token
+        if self.bearer_token is not None:
+            self._authenticated_bearer_token = self.bearer_token
+        elif self.client_id is not None and self.client_secret is not None:
+            self._authenticated_bearer_token = api_util.get_bearer_token(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                api_root=self.public_api_root,
+            )
+        return self._authenticated_bearer_token
+
     def _get_workspace_parent_organization_id(self, workspace_id: str) -> str:
         """Resolve a workspace's parent organization ID."""
         organization = api_util.get_workspace_organization_info(
@@ -453,7 +467,7 @@ class CloudClient:
             config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            bearer_token=self.bearer_token,
+            bearer_token=self._get_config_api_bearer_token(),
         )
         resolved_organization_id = organization.get("organizationId")
         if isinstance(resolved_organization_id, str) and resolved_organization_id:
@@ -468,19 +482,12 @@ class CloudClient:
         if self._authenticated_user_id is not None:
             return self._authenticated_user_id
 
-        bearer_token = self.bearer_token
+        bearer_token = self._get_config_api_bearer_token()
         if bearer_token is None:
-            if self.client_id is None or self.client_secret is None:
-                raise exc.PyAirbyteInputError(
-                    message="No authentication credentials provided.",
-                    guidance="Provide either client credentials or a bearer token.",
-                )
-            bearer_token = api_util.get_bearer_token(
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                api_root=self.public_api_root,
+            raise exc.PyAirbyteInputError(
+                message="No authentication credentials provided.",
+                guidance="Provide either client credentials or a bearer token.",
             )
-        self._authenticated_bearer_token = bearer_token
         auth_user_id = api_util.get_user_id_from_bearer_token(bearer_token)
         user = api_util.get_user_by_auth_id(
             auth_user_id,
@@ -510,7 +517,7 @@ class CloudClient:
             config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            bearer_token=self._authenticated_bearer_token,
+            bearer_token=self._get_config_api_bearer_token(),
         )
         organization_ids: list[str] = []
         for permission in permissions:
@@ -539,7 +546,7 @@ class CloudClient:
                     config_api_root=self.config_api_root,
                     client_id=self.client_id,
                     client_secret=self.client_secret,
-                    bearer_token=self.bearer_token,
+                    bearer_token=self._get_config_api_bearer_token(),
                 )
             except AirbyteError:
                 pass
@@ -695,7 +702,7 @@ class CloudClient:
                 config_api_root=self.config_api_root,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
+                bearer_token=self._get_config_api_bearer_token(),
             )
         except AirbyteError:
             return None

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -272,10 +272,10 @@ class CloudClient:
                     message="You can provide name_contains or name_filter, but not both."
                 )
             if name_contains is not None:
-                name_substring = name_contains
+                name_substring = name_contains.casefold()
 
                 def matches_name(workspace_name: str) -> bool:
-                    return name_substring in workspace_name
+                    return name_substring in workspace_name.casefold()
 
                 name_filter = matches_name
                 name = None
@@ -300,6 +300,7 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="You can provide name_contains or name_filter, but not both."
             )
+        # The organization-scoped path delegates `name_contains` casing to the server.
         workspaces = api_util.list_workspaces_in_organization(
             organization_id=resolved_organization_id,
             api_root=self.public_api_root,
@@ -308,15 +309,17 @@ class CloudClient:
             client_secret=self.client_secret,
             bearer_token=self.bearer_token,
             name_contains=name_contains or name,
-            limit=None if name_filter is not None else limit,
+            limit=None if name is not None or name_filter is not None else limit,
         )
         workspace_infos = [CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces]
+        if name is not None:
+            workspace_infos = [workspace for workspace in workspace_infos if workspace.name == name]
         if name_filter is not None:
             workspace_infos = [
                 workspace for workspace in workspace_infos if name_filter(workspace.name)
             ]
-            if limit is not None:
-                workspace_infos = workspace_infos[:limit]
+        if limit is not None and (name is not None or name_filter is not None):
+            workspace_infos = workspace_infos[:limit]
         return workspace_infos
 
     def _resolve_workspace_organization_id(

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -83,7 +83,7 @@ class CloudClient:
         return self._credentials.organization_id
 
     @property
-    def workspace_id(self) -> str | None:
+    def default_workspace_id(self) -> str | None:
         """Default workspace ID for workspace-scoped operations."""
         return self._credentials.workspace_id
 
@@ -340,9 +340,9 @@ class CloudClient:
             return self._get_workspace_parent_organization_id(workspace_id)
 
         configured_organization_id = self.organization_id
-        if configured_organization_id is None and self.workspace_id is not None:
+        if configured_organization_id is None and self.default_workspace_id is not None:
             configured_organization_id = self._get_workspace_parent_organization_id(
-                self.workspace_id
+                self.default_workspace_id
             )
         if configured_organization_id is not None:
             return configured_organization_id

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -21,16 +21,12 @@ if TYPE_CHECKING:
     from airbyte.secrets.base import SecretString
 
 
-CROSS_ORG_WORKSPACE_DEFAULT_LIMIT = 100
-CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = 100
-CLOUD_ORGANIZATION_DEFAULT_LIMIT = 100
-
-
 @dataclass(init=False, kw_only=True)
 class CloudClient:
     """Authenticated client for Airbyte Cloud and self-managed Airbyte APIs."""
 
     _credentials: _AirbyteCredentials
+    _membership_organization_ids: tuple[str, ...] | None
 
     def __init__(
         self,
@@ -54,6 +50,7 @@ class CloudClient:
             organization_id=organization_id,
             env_vars=False,
         )
+        self._membership_organization_ids = None
 
     @property
     def client_id(self) -> SecretString | None:
@@ -84,6 +81,11 @@ class CloudClient:
     def organization_id(self) -> str | None:
         """Default organization ID for organization-scoped operations."""
         return self._credentials.organization_id
+
+    @property
+    def workspace_id(self) -> str | None:
+        """Default workspace ID for workspace-scoped operations."""
+        return self._credentials.workspace_id
 
     @classmethod
     def from_auth(
@@ -211,9 +213,12 @@ class CloudClient:
         name: str | None = None,
         *,
         organization_id: None = None,
+        organization_name: str | None = None,
+        workspace_id: str | None = None,
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        all_organizations: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
@@ -223,9 +228,12 @@ class CloudClient:
         name: str | None = None,
         *,
         organization_id: str,
+        organization_name: str | None = None,
+        workspace_id: str | None = None,
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        all_organizations: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
@@ -234,68 +242,68 @@ class CloudClient:
         name: str | None = None,
         *,
         organization_id: str | None = None,
+        organization_name: str | None = None,
+        workspace_id: str | None = None,
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        all_organizations: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         """List workspaces available to this client."""
-        if organization_id is not None or self.organization_id is not None:
-            resolved_organization_id = organization_id or self.organization_id
-            if not resolved_organization_id:
-                raise exc.PyAirbyteInputError(
-                    message="Organization ID is required.",
-                    guidance="Provide an organization ID.",
-                )
-            workspaces = api_util.list_workspaces_in_organization(
-                organization_id=resolved_organization_id,
-                api_root=self.public_api_root,
-                config_api_root=self.config_api_root,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
-                name_contains=name_contains or name,
-                limit=None if name_filter is not None else limit,
+        if limit is not None and limit <= 0:
+            raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
+        if organization_id is not None and organization_name is not None:
+            raise exc.PyAirbyteInputError(
+                message="Provide either organization ID or organization name."
             )
-            workspace_infos = [
-                CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces
-            ]
-            if name_filter is not None:
-                workspace_infos = [
-                    workspace for workspace in workspace_infos if name_filter(workspace.name)
-                ]
-                if limit is not None:
-                    workspace_infos = workspace_infos[:limit]
-            return workspace_infos
-        if name_contains is not None:
-            if name_filter is not None:
+        is_explicit_lookup = name is not None or name_filter is not None
+        has_explicit_organization = organization_id is not None or organization_name is not None
+        has_explicit_workspace = workspace_id is not None
+
+        if all_organizations:
+            if has_explicit_organization or has_explicit_workspace:
+                raise exc.PyAirbyteInputError(
+                    message=(
+                        "The all_organizations option cannot be combined with an "
+                        "organization or workspace ID."
+                    )
+                )
+            if name_contains is not None and name_filter is not None:
                 raise exc.PyAirbyteInputError(
                     message="You can provide name_contains or name_filter, but not both."
                 )
-            name_substring = name_contains
-            if limit is not None and limit <= 0:
-                raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
+            if name_contains is not None:
+                name_substring = name_contains
+
+                def matches_name(workspace_name: str) -> bool:
+                    return name_substring in workspace_name
+
+                name_filter = matches_name
+                name = None
             workspaces = api_util.list_workspaces(
                 workspace_id="",
                 api_root=self.public_api_root,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 bearer_token=self.bearer_token,
-                limit=CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS,
+                name_filter=name_filter,
+                name=name,
+                limit=limit,
             )
-            matching_workspaces = [
-                CloudWorkspaceInfo.from_api_response(workspace)
-                for workspace in workspaces
-                if name_substring in workspace.name
-            ]
-            return matching_workspaces[: limit or CROSS_ORG_WORKSPACE_DEFAULT_LIMIT]
+            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
 
-        is_explicit_lookup = name is not None or name_filter is not None
-        effective_limit = (
-            limit if limit is not None or is_explicit_lookup else CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
-        )
-        return [
-            CloudWorkspaceInfo.from_api_response(workspace)
-            for workspace in api_util.list_workspaces(
+        if (
+            is_explicit_lookup
+            and not has_explicit_organization
+            and not has_explicit_workspace
+            and self.organization_id is None
+            and self.workspace_id is None
+        ):
+            if name_contains is not None:
+                raise exc.PyAirbyteInputError(
+                    message="You can provide name or name_contains, but not both."
+                )
+            workspaces = api_util.list_workspaces(
                 workspace_id="",
                 api_root=self.public_api_root,
                 name=name,
@@ -303,9 +311,160 @@ class CloudClient:
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 bearer_token=self.bearer_token,
-                limit=effective_limit,
+                limit=limit,
             )
-        ]
+            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
+
+        resolved_organization_id = self._resolve_workspace_organization_id(
+            organization_id=organization_id,
+            organization_name=organization_name,
+            workspace_id=workspace_id,
+        )
+        if name_contains is not None and name_filter is not None:
+            raise exc.PyAirbyteInputError(
+                message="You can provide name_contains or name_filter, but not both."
+            )
+        workspaces = api_util.list_workspaces_in_organization(
+            organization_id=resolved_organization_id,
+            api_root=self.public_api_root,
+            config_api_root=self.config_api_root,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=self.bearer_token,
+            name_contains=name_contains or name,
+            limit=None if name_filter is not None else limit,
+        )
+        workspace_infos = [CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces]
+        if name_filter is not None:
+            workspace_infos = [
+                workspace for workspace in workspace_infos if name_filter(workspace.name)
+            ]
+            if limit is not None:
+                workspace_infos = workspace_infos[:limit]
+        return workspace_infos
+
+    def _resolve_workspace_organization_id(
+        self,
+        *,
+        organization_id: str | None,
+        organization_name: str | None,
+        workspace_id: str | None,
+    ) -> str:
+        """Resolve the organization for a workspace listing."""
+        if organization_id is not None:
+            return organization_id
+        if organization_name is not None:
+            return self.get_organization(organization_name=organization_name).organization_id
+
+        if workspace_id is not None:
+            return self._get_workspace_parent_organization_id(workspace_id)
+
+        if self.organization_id is not None:
+            return self.organization_id
+
+        if self.workspace_id is not None:
+            return self._get_workspace_parent_organization_id(self.workspace_id)
+
+        organization_ids = self._get_membership_organization_ids()
+        if len(organization_ids) == 1:
+            return organization_ids[0]
+        if not organization_ids:
+            raise exc.PyAirbyteInputError(
+                message=(
+                    "No organization membership was found for these credentials. "
+                    "Pass an organization_id to list workspaces."
+                ),
+                context={
+                    "organization_ids": [],
+                    "organization_candidates": [],
+                },
+            )
+        raise exc.PyAirbyteInputError(
+            message=(
+                "Multiple organization memberships were found for these credentials. "
+                "Pass one of the candidate organization IDs to list workspaces."
+            ),
+            context={
+                "organization_ids": list(organization_ids),
+                "organization_candidates": [
+                    {
+                        "organization_id": candidate_id,
+                        "organization_name": None,
+                    }
+                    for candidate_id in organization_ids
+                ],
+            },
+        )
+
+    def _get_workspace_parent_organization_id(self, workspace_id: str) -> str:
+        """Resolve a workspace's parent organization ID."""
+        organization = api_util.get_workspace_organization_info(
+            workspace_id=workspace_id,
+            api_root=self.public_api_root,
+            config_api_root=self.config_api_root,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=self.bearer_token,
+        )
+        resolved_organization_id = organization.get("organizationId")
+        if isinstance(resolved_organization_id, str) and resolved_organization_id:
+            return resolved_organization_id
+        raise exc.PyAirbyteInputError(
+            message="The workspace response did not include an organization ID.",
+            context={"workspace_id": workspace_id, "response": organization},
+        )
+
+    def _get_membership_organization_ids(self) -> tuple[str, ...]:
+        """Get and cache organization IDs from the caller's permissions."""
+        if self._membership_organization_ids is not None:
+            return self._membership_organization_ids
+
+        bearer_token = self.bearer_token
+        if bearer_token is None:
+            if self.client_id is None or self.client_secret is None:
+                raise exc.PyAirbyteInputError(
+                    message="No authentication credentials provided.",
+                    guidance="Provide either client credentials or a bearer token.",
+                )
+            bearer_token = api_util.get_bearer_token(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                api_root=self.public_api_root,
+            )
+        auth_user_id = api_util.get_user_id_from_bearer_token(bearer_token)
+        user = api_util.get_user_by_auth_id(
+            auth_user_id,
+            api_root=self.public_api_root,
+            config_api_root=self.config_api_root,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=bearer_token,
+        )
+        user_id = user.get("userId")
+        if not isinstance(user_id, str) or not user_id:
+            raise exc.PyAirbyteInputError(
+                message="The Airbyte user response did not include a user ID.",
+                context={"response": user},
+            )
+        permissions = api_util.list_permissions_for_user(
+            user_id,
+            api_root=self.public_api_root,
+            config_api_root=self.config_api_root,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=bearer_token,
+        )
+        organization_ids: list[str] = []
+        for permission in permissions:
+            permission_organization_id = permission.get("organizationId")
+            if (
+                isinstance(permission_organization_id, str)
+                and permission_organization_id
+                and permission_organization_id not in organization_ids
+            ):
+                organization_ids.append(permission_organization_id)
+        self._membership_organization_ids = tuple(organization_ids)
+        return self._membership_organization_ids
 
     def list_organizations(
         self,
@@ -317,7 +476,6 @@ class CloudClient:
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
 
-        effective_limit = limit if limit is not None else CLOUD_ORGANIZATION_DEFAULT_LIMIT
         organizations = self._fetch_organizations()
         if name_contains is not None:
             name_substring = name_contains.casefold()
@@ -326,7 +484,7 @@ class CloudClient:
                 for organization in organizations
                 if name_substring in (organization.organization_name or "").casefold()
             ]
-        return organizations[:effective_limit]
+        return organizations if limit is None else organizations[:limit]
 
     def _fetch_organizations(self) -> list[CloudOrganization]:
         """Fetch all organizations available to this client."""
@@ -356,11 +514,13 @@ class CloudClient:
         organization_name: str | None = None,
     ) -> CloudOrganization:
         """Resolve an organization by ID or exact name."""
-        resolved_organization_id = organization_id or self.organization_id
+        resolved_organization_id = organization_id
         if resolved_organization_id and organization_name:
             raise exc.PyAirbyteInputError(
                 message="Provide either organization ID or organization name."
             )
+        if resolved_organization_id is None and organization_name is None:
+            resolved_organization_id = self.organization_id
         if not resolved_organization_id and not organization_name:
             raise exc.PyAirbyteInputError(
                 message="Organization ID or organization name is required."

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
 
 CROSS_ORG_WORKSPACE_DEFAULT_LIMIT = 100
 CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES = 1
-CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = 100
+CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = api_util.PAGE_SIZE * CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES
+CLOUD_ORGANIZATION_DEFAULT_LIMIT = 100
 
 
 @dataclass(init=False, kw_only=True)
@@ -295,15 +296,28 @@ class CloudClient:
 
     def list_organizations(
         self,
-        name_contains: str | None = None,
         *,
+        name_contains: str | None = None,
         limit: int | None = None,
     ) -> list[CloudOrganization]:
         """List organizations available to this client."""
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
 
-        organizations = [
+        effective_limit = limit if limit is not None else CLOUD_ORGANIZATION_DEFAULT_LIMIT
+        organizations = self._fetch_organizations()
+        if name_contains is not None:
+            name_substring = name_contains.casefold()
+            organizations = [
+                organization
+                for organization in organizations
+                if name_substring in (organization.organization_name or "").casefold()
+            ]
+        return organizations[:effective_limit]
+
+    def _fetch_organizations(self) -> list[CloudOrganization]:
+        """Fetch all organizations available to this client."""
+        return [
             CloudOrganization(
                 organization_id=organization.organization_id,
                 organization_name=organization.organization_name,
@@ -321,14 +335,6 @@ class CloudClient:
                 bearer_token=self.bearer_token,
             )
         ]
-        if name_contains is not None:
-            name_substring = name_contains.casefold()
-            organizations = [
-                organization
-                for organization in organizations
-                if name_substring in (organization.organization_name or "").casefold()
-            ]
-        return organizations if limit is None else organizations[:limit]
 
     def get_organization(
         self,
@@ -347,7 +353,7 @@ class CloudClient:
                 message="Organization ID or organization name is required."
             )
 
-        organizations = self.list_organizations()
+        organizations = self._fetch_organizations()
         if resolved_organization_id:
             matching_organizations = [
                 organization

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -267,6 +267,7 @@ class CloudClient:
                 if limit is not None:
                     workspace_infos = workspace_infos[:limit]
             return workspace_infos
+        is_explicit_lookup = name is not None or name_filter is not None
         if name_contains is not None:
             if name_filter is not None:
                 raise exc.PyAirbyteInputError(
@@ -277,7 +278,9 @@ class CloudClient:
             def name_filter(workspace_name: str) -> bool:
                 return name_substring in workspace_name
 
-        effective_limit = limit if limit is not None else CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
+        effective_limit = (
+            limit if limit is not None or is_explicit_lookup else CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
+        )
         max_pages = CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES if name_contains is not None else None
         return [
             CloudWorkspaceInfo.from_api_response(workspace)

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -259,18 +259,27 @@ class CloudClient:
         has_explicit_organization = organization_id is not None or organization_name is not None
         has_explicit_workspace = workspace_id is not None
 
-        if all_organizations:
-            if has_explicit_organization or has_explicit_workspace:
-                raise exc.PyAirbyteInputError(
-                    message=(
-                        "The all_organizations option cannot be combined with an "
-                        "organization or workspace ID."
-                    )
+        if all_organizations and (has_explicit_organization or has_explicit_workspace):
+            raise exc.PyAirbyteInputError(
+                message=(
+                    "The all_organizations option cannot be combined with an "
+                    "organization or workspace ID."
                 )
-            if name_contains is not None and name_filter is not None:
-                raise exc.PyAirbyteInputError(
-                    message="You can provide name_contains or name_filter, but not both."
-                )
+            )
+        if name_contains is not None and name_filter is not None:
+            raise exc.PyAirbyteInputError(
+                message="You can provide name_contains or name_filter, but not both."
+            )
+        resolved_organization_id = (
+            None
+            if all_organizations
+            else self._resolve_workspace_organization_id(
+                organization_id=organization_id,
+                organization_name=organization_name,
+                workspace_id=workspace_id,
+            )
+        )
+        if resolved_organization_id is None:
             if name_contains is not None:
                 name_substring = name_contains.casefold()
 
@@ -291,15 +300,6 @@ class CloudClient:
             )
             return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
 
-        resolved_organization_id = self._resolve_workspace_organization_id(
-            organization_id=organization_id,
-            organization_name=organization_name,
-            workspace_id=workspace_id,
-        )
-        if name_contains is not None and name_filter is not None:
-            raise exc.PyAirbyteInputError(
-                message="You can provide name_contains or name_filter, but not both."
-            )
         # The organization-scoped path delegates `name_contains` casing to the server.
         workspaces = api_util.list_workspaces_in_organization(
             organization_id=resolved_organization_id,
@@ -328,7 +328,7 @@ class CloudClient:
         organization_id: str | None,
         organization_name: str | None,
         workspace_id: str | None,
-    ) -> str:
+    ) -> str | None:
         """Resolve the organization for a workspace listing."""
         if organization_id is not None:
             return organization_id
@@ -339,26 +339,19 @@ class CloudClient:
         if workspace_id is not None:
             return self._get_workspace_parent_organization_id(workspace_id)
 
-        if self.organization_id is not None:
-            return self.organization_id
-
-        if self.workspace_id is not None:
-            return self._get_workspace_parent_organization_id(self.workspace_id)
+        configured_organization_id = self.organization_id
+        if configured_organization_id is None and self.workspace_id is not None:
+            configured_organization_id = self._get_workspace_parent_organization_id(
+                self.workspace_id
+            )
+        if configured_organization_id is not None:
+            return configured_organization_id
 
         organization_ids = self._get_membership_organization_ids()
         if len(organization_ids) == 1:
             return organization_ids[0]
         if not organization_ids:
-            raise exc.PyAirbyteInputError(
-                message=(
-                    "No organization membership was found for these credentials. "
-                    "Pass an organization_id to list workspaces."
-                ),
-                context={
-                    "organization_ids": [],
-                    "organization_candidates": [],
-                },
-            )
+            return None
         raise exc.PyAirbyteInputError(
             message=(
                 "Multiple organization memberships were found for these credentials. "

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -620,15 +620,16 @@ class CloudClient:
         limit: int | None = None,
     ) -> list[CloudOrganization]:
         """List organizations via the Config API, with server-side search and paging."""
+        user_id = self._get_authenticated_user_id()
         return [
             self._organization_from_mapping(organization)
             for organization in api_util.list_organizations_for_user_id(
-                user_id=self._get_authenticated_user_id(),
+                user_id=user_id,
                 api_root=self.public_api_root,
                 config_api_root=self.config_api_root,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
+                bearer_token=self._authenticated_bearer_token,
                 name_contains=name_contains,
                 limit=limit,
             )

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -1,5 +1,57 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
-"""PyAirbyte Cloud client."""
+"""PyAirbyte Cloud client.
+
+## Organization and workspace resolution
+
+Most discovery operations need an organization context. `CloudClient` derives that
+context from whatever the caller supplies, falling back to the credentials' own
+configuration and finally to the authenticated user's memberships.
+
+### Resolving the organization
+
+`CloudClient.list_workspaces` resolves an organization in this order, stopping at the
+first step that yields one:
+
+1. The explicit `organization_id` argument.
+2. The explicit `organization_name` argument, resolved by exact name via
+   `CloudClient.get_organization`. This scans every visible organization, so it is
+   never used to infer a default.
+3. The parent organization of an explicit `workspace_id` argument.
+4. The organization configured on the credentials (`CloudClient.organization_id`, from
+   the constructor or `AIRBYTE_CLOUD_ORGANIZATION_ID`).
+5. The parent organization of the configured default workspace
+   (`CloudClient.default_workspace_id`, from the constructor or
+   `AIRBYTE_CLOUD_WORKSPACE_ID`).
+6. The sole organization the authenticated user belongs to, read from that user's
+   permissions and cached for the life of the client.
+
+If step 6 finds several memberships, discovery stops with a `PyAirbyteInputError`
+carrying the candidate organization IDs and names, so the caller can retry with one of
+them instead of having to list organizations first. If it finds none — which happens
+for credentials whose grants are not organization-scoped — resolution yields no
+organization and listing falls back to the cross-organization path below. Passing
+`all_organizations=True` selects that path deliberately and cannot be combined with an
+organization or workspace argument.
+
+### Resolving the workspace
+
+`CloudClient.get_workspace` takes the explicit `workspace_id` argument if given, and
+otherwise the configured `CloudClient.default_workspace_id`. It raises when neither is
+available; it never guesses a workspace from the organization, since an organization
+can hold many.
+
+### Why the path matters
+
+The two listing paths differ in completeness, not just speed:
+
+- **Organization-scoped** (an organization resolved above) uses the Config API, which
+  filters by name server-side and paginates, so results are complete and each workspace
+  carries its organization attribution.
+- **Cross-organization** (no organization resolved, or `all_organizations=True`) uses
+  the public API, which has neither an organization filter nor a name filter. Name
+  matching happens client-side over every visible workspace, and the responses carry no
+  organization attribution.
+"""
 
 from __future__ import annotations
 
@@ -129,7 +181,10 @@ class CloudClient:
         )
 
     def get_workspace(self, workspace_id: str | None = None) -> CloudWorkspace:
-        """Create a `CloudWorkspace` using this client's credentials."""
+        """Create a `CloudWorkspace` using this client's credentials.
+
+        See the module docstring for how the workspace is resolved.
+        """
         resolved_workspace_id = workspace_id or self._credentials.workspace_id
         if not resolved_workspace_id:
             raise exc.PyAirbyteInputError(
@@ -249,7 +304,10 @@ class CloudClient:
         limit: int | None = None,
         all_organizations: bool = False,
     ) -> list[CloudWorkspaceInfo]:
-        """List workspaces available to this client."""
+        """List workspaces available to this client.
+
+        See the module docstring for how the organization context is resolved.
+        """
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
         if organization_id is not None and organization_name is not None:

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -363,6 +363,10 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="You can provide name_contains or name_filter, but not both."
             )
+        if name is not None and name_contains is not None:
+            raise exc.PyAirbyteInputError(
+                message="You can provide name or name_contains, but not both."
+            )
         resolved_organization_id = (
             None
             if all_organizations

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -12,7 +12,7 @@ from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud.models import CloudWorkspaceInfo
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
-from airbyte.exceptions import AirbyteMissingResourceError
+from airbyte.exceptions import AirbyteError, AirbyteMissingResourceError
 
 
 if TYPE_CHECKING:
@@ -256,7 +256,6 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="Provide either organization ID or organization name."
             )
-        is_explicit_lookup = name is not None or name_filter is not None
         has_explicit_organization = organization_id is not None or organization_name is not None
         has_explicit_workspace = workspace_id is not None
 
@@ -288,29 +287,6 @@ class CloudClient:
                 bearer_token=self.bearer_token,
                 name_filter=name_filter,
                 name=name,
-                limit=limit,
-            )
-            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
-
-        if (
-            is_explicit_lookup
-            and not has_explicit_organization
-            and not has_explicit_workspace
-            and self.organization_id is None
-            and self.workspace_id is None
-        ):
-            if name_contains is not None:
-                raise exc.PyAirbyteInputError(
-                    message="You can provide name or name_contains, but not both."
-                )
-            workspaces = api_util.list_workspaces(
-                workspace_id="",
-                api_root=self.public_api_root,
-                name=name,
-                name_filter=name_filter,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
                 limit=limit,
             )
             return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
@@ -354,6 +330,7 @@ class CloudClient:
         if organization_id is not None:
             return organization_id
         if organization_name is not None:
+            # Explicit name lookup scans all visible organizations; do not use it for defaults.
             return self.get_organization(organization_name=organization_name).organization_id
 
         if workspace_id is not None:
@@ -386,13 +363,7 @@ class CloudClient:
             ),
             context={
                 "organization_ids": list(organization_ids),
-                "organization_candidates": [
-                    {
-                        "organization_id": candidate_id,
-                        "organization_name": None,
-                    }
-                    for candidate_id in organization_ids
-                ],
+                "organization_candidates": self._get_organization_candidates(organization_ids),
             },
         )
 
@@ -465,6 +436,37 @@ class CloudClient:
                 organization_ids.append(permission_organization_id)
         self._membership_organization_ids = tuple(organization_ids)
         return self._membership_organization_ids
+
+    def _get_organization_candidates(
+        self,
+        organization_ids: tuple[str, ...],
+    ) -> list[dict[str, str | None]]:
+        """Get names for membership-derived organization candidates."""
+        candidates: list[dict[str, str | None]] = []
+        for organization_id in organization_ids:
+            organization_name = None
+            try:
+                organization_info = api_util.get_organization_info(
+                    organization_id=organization_id,
+                    api_root=self.public_api_root,
+                    config_api_root=self.config_api_root,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                    bearer_token=self.bearer_token,
+                )
+            except AirbyteError:
+                pass
+            else:
+                candidate_name = organization_info.get("organizationName")
+                if isinstance(candidate_name, str):
+                    organization_name = candidate_name
+            candidates.append(
+                {
+                    "organization_id": organization_id,
+                    "organization_name": organization_name,
+                }
+            )
+        return candidates
 
     def list_organizations(
         self,

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -436,15 +436,22 @@ class CloudClient:
         if workspace_id is not None:
             return self._get_workspace_parent_organization_id(workspace_id)
 
-        configured_organization_id = self.organization_id
-        if configured_organization_id is None and self.default_workspace_id is not None:
-            configured_organization_id = self._get_workspace_parent_organization_id(
-                self.default_workspace_id
-            )
-        if configured_organization_id is not None:
-            return configured_organization_id
+        return self._resolve_ambient_organization_id()
 
-        organization_ids = self._get_membership_organization_ids()
+    def _resolve_ambient_organization_id(self) -> str | None:
+        """Resolve an organization from configured client context or memberships."""
+        if self.organization_id is not None:
+            return self.organization_id
+        if self.default_workspace_id is not None:
+            try:
+                return self._get_workspace_parent_organization_id(self.default_workspace_id)
+            except (exc.AirbyteError, exc.PyAirbyteInputError):
+                pass
+
+        try:
+            organization_ids = self._get_membership_organization_ids()
+        except (exc.AirbyteError, exc.PyAirbyteInputError):
+            return None
         if len(organization_ids) > 1:
             self._raise_ambiguous_organization_error(organization_ids)
         return organization_ids[0] if organization_ids else None
@@ -640,7 +647,7 @@ class CloudClient:
                 config_api_root=self.config_api_root,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
-                bearer_token=self._authenticated_bearer_token,
+                bearer_token=self._get_config_api_bearer_token(),
                 name_contains=name_contains,
                 limit=limit,
             )
@@ -685,17 +692,7 @@ class CloudClient:
 
     def _resolve_default_organization_id(self) -> str | None:
         """Resolve the organization to use when no organization argument is given."""
-        if self.organization_id is not None:
-            return self.organization_id
-        if self.default_workspace_id is not None:
-            return self._get_workspace_parent_organization_id(self.default_workspace_id)
-
-        organization_ids = self._get_membership_organization_ids()
-        if len(organization_ids) == 1:
-            return organization_ids[0]
-        if len(organization_ids) > 1:
-            self._raise_ambiguous_organization_error(organization_ids)
-        return None
+        return self._resolve_ambient_organization_id()
 
     def _get_organization_by_id(self, organization_id: str) -> CloudOrganization | None:
         """Look up a single organization via the Config API, if available."""

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
     from airbyte.secrets.base import SecretString
 
 
+CROSS_ORG_WORKSPACE_DEFAULT_LIMIT = 100
+CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES = 1
+CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = 100
+
+
 @dataclass(init=False, kw_only=True)
 class CloudClient:
     """Authenticated client for Airbyte Cloud and self-managed Airbyte APIs."""
@@ -271,6 +276,8 @@ class CloudClient:
             def name_filter(workspace_name: str) -> bool:
                 return name_substring in workspace_name
 
+        effective_limit = limit if limit is not None else CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
+        max_pages = CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES if name_contains is not None else None
         return [
             CloudWorkspaceInfo.from_api_response(workspace)
             for workspace in api_util.list_workspaces(
@@ -281,13 +288,22 @@ class CloudClient:
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 bearer_token=self.bearer_token,
-                limit=limit,
+                limit=effective_limit,
+                max_pages=max_pages,
             )
         ]
 
-    def list_organizations(self) -> list[CloudOrganization]:
-        """List all organizations available to this client."""
-        return [
+    def list_organizations(
+        self,
+        name_contains: str | None = None,
+        *,
+        limit: int | None = None,
+    ) -> list[CloudOrganization]:
+        """List organizations available to this client."""
+        if limit is not None and limit <= 0:
+            raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
+
+        organizations = [
             CloudOrganization(
                 organization_id=organization.organization_id,
                 organization_name=organization.organization_name,
@@ -305,6 +321,14 @@ class CloudClient:
                 bearer_token=self.bearer_token,
             )
         ]
+        if name_contains is not None:
+            name_substring = name_contains.casefold()
+            organizations = [
+                organization
+                for organization in organizations
+                if name_substring in (organization.organization_name or "").casefold()
+            ]
+        return organizations if limit is None else organizations[:limit]
 
     def get_organization(
         self,
@@ -343,9 +367,29 @@ class CloudClient:
                 resource_name_or_id=resolved_organization_id or organization_name,
             )
         if len(matching_organizations) > 1:
+            total_matches = len(matching_organizations)
+            shown_matches = matching_organizations[:10]
+            match_details = ", ".join(
+                f"{organization.organization_id} ({organization.email or 'email unavailable'})"
+                for organization in shown_matches
+            )
             raise exc.PyAirbyteInputError(
-                message="Organization name matches multiple organizations.",
-                context={"organization_name": organization_name},
+                message=(
+                    "Organization name matches multiple organizations. Provide an "
+                    f"organization ID to disambiguate. Matching organizations "
+                    f"(showing {len(shown_matches)} of {total_matches}): {match_details}"
+                ),
+                context={
+                    "organization_name": organization_name,
+                    "matching_organizations": [
+                        {
+                            "organization_id": organization.organization_id,
+                            "email": organization.email,
+                        }
+                        for organization in shown_matches
+                    ],
+                    "total_matches": total_matches,
+                },
             )
 
         return matching_organizations[0]

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -37,20 +37,21 @@ which always wins over a workspace-derived organization — as does a configured
 ### If an organization ID is known but no workspace ID
 
 The organization is used as-is, whether it came from the `organization_id` argument,
-from `organization_name` (an exact-name lookup that scans every visible organization,
-so it is never used to infer a default), or from the credentials as
-`CloudClient.organization_id`.
+from `organization_name` (an exact-name lookup, so it is never used to infer a
+default), or from the credentials as `CloudClient.organization_id`.
 
 ### If neither is known
 
 `CloudClient.list_workspaces` falls back to the authenticated user's memberships: the
 organizations that user holds permissions on, read once and cached for the life of the
-client.
+client. `CloudClient.get_organization` called with no arguments resolves the same way:
+configured `CloudClient.organization_id` first, then the parent organization of
+`CloudClient.default_workspace_id`, then the memberships below.
 
 - Exactly one membership — that organization is the context.
-- Several memberships — discovery stops with a `PyAirbyteInputError` carrying the
-  candidate organization IDs and names, so the caller can retry with one of them
-  instead of having to list organizations first.
+- Several memberships — discovery stops with a `PyAirbyteInputError` that both carries
+  and enumerates in its message the first ten candidate organization IDs and names, so
+  the caller can retry with one of them instead of having to list organizations first.
 - No memberships — which happens for credentials whose grants are not
   organization-scoped — listing falls back to the cross-organization path below.
 
@@ -68,12 +69,22 @@ The two listing paths differ in completeness, not just speed:
   the public API, which has neither an organization filter nor a name filter. Name
   matching happens client-side over every visible workspace, and the responses carry no
   organization attribution.
+
+### Searching organizations
+
+Organization search and limits are also server-side. `CloudClient.list_organizations`
+uses the Config API whenever `name_contains` or `limit` is passed, which filters and
+paginates on the server; with neither argument it uses the public API, which returns
+every visible organization in a single request. `CloudClient.get_organization` fetches
+one organization by ID directly, and searches by name through the Config API. These
+organization lookup paths fall back to the public listing when the Config API is
+unavailable, so self-managed deployments keep working.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, NoReturn, overload
 
 from airbyte import exceptions as exc
 from airbyte._util import api_util
@@ -85,9 +96,12 @@ from airbyte.exceptions import AirbyteError, AirbyteMissingResourceError
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from airbyte.secrets.base import SecretString
+
+
+MAX_ORGANIZATION_CANDIDATES = 10
 
 
 @dataclass(init=False, kw_only=True)
@@ -96,6 +110,8 @@ class CloudClient:
 
     _credentials: _AirbyteCredentials
     _membership_organization_ids: tuple[str, ...] | None
+    _authenticated_user_id: str | None
+    _authenticated_bearer_token: SecretString | None
 
     def __init__(
         self,
@@ -120,6 +136,8 @@ class CloudClient:
             env_vars=False,
         )
         self._membership_organization_ids = None
+        self._authenticated_user_id = None
+        self._authenticated_bearer_token = None
 
     @property
     def client_id(self) -> SecretString | None:
@@ -405,10 +423,10 @@ class CloudClient:
         workspace_id: str | None,
     ) -> str | None:
         """Resolve the organization for a workspace listing."""
-        if organization_id is not None:
-            return organization_id
-        if organization_name is not None:
-            # Explicit name lookup scans all visible organizations; do not use it for defaults.
+        if organization_id is not None or organization_name is not None:
+            if organization_id is not None:
+                return organization_id
+            # Do not use explicit name lookup to infer a default organization.
             return self.get_organization(organization_name=organization_name).organization_id
 
         if workspace_id is not None:
@@ -423,20 +441,9 @@ class CloudClient:
             return configured_organization_id
 
         organization_ids = self._get_membership_organization_ids()
-        if len(organization_ids) == 1:
-            return organization_ids[0]
-        if not organization_ids:
-            return None
-        raise exc.PyAirbyteInputError(
-            message=(
-                "Multiple organization memberships were found for these credentials. "
-                "Pass one of the candidate organization IDs to list workspaces."
-            ),
-            context={
-                "organization_ids": list(organization_ids),
-                "organization_candidates": self._get_organization_candidates(organization_ids),
-            },
-        )
+        if len(organization_ids) > 1:
+            self._raise_ambiguous_organization_error(organization_ids)
+        return organization_ids[0] if organization_ids else None
 
     def _get_workspace_parent_organization_id(self, workspace_id: str) -> str:
         """Resolve a workspace's parent organization ID."""
@@ -456,10 +463,10 @@ class CloudClient:
             context={"workspace_id": workspace_id, "response": organization},
         )
 
-    def _get_membership_organization_ids(self) -> tuple[str, ...]:
-        """Get and cache organization IDs from the caller's permissions."""
-        if self._membership_organization_ids is not None:
-            return self._membership_organization_ids
+    def _get_authenticated_user_id(self) -> str:
+        """Get and cache the Airbyte user ID for the current credentials."""
+        if self._authenticated_user_id is not None:
+            return self._authenticated_user_id
 
         bearer_token = self.bearer_token
         if bearer_token is None:
@@ -473,6 +480,7 @@ class CloudClient:
                 client_secret=self.client_secret,
                 api_root=self.public_api_root,
             )
+        self._authenticated_bearer_token = bearer_token
         auth_user_id = api_util.get_user_id_from_bearer_token(bearer_token)
         user = api_util.get_user_by_auth_id(
             auth_user_id,
@@ -488,13 +496,21 @@ class CloudClient:
                 message="The Airbyte user response did not include a user ID.",
                 context={"response": user},
             )
+        self._authenticated_user_id = user_id
+        return self._authenticated_user_id
+
+    def _get_membership_organization_ids(self) -> tuple[str, ...]:
+        """Get and cache organization IDs from the caller's permissions."""
+        if self._membership_organization_ids is not None:
+            return self._membership_organization_ids
+
         permissions = api_util.list_permissions_for_user(
-            user_id,
+            self._get_authenticated_user_id(),
             api_root=self.public_api_root,
             config_api_root=self.config_api_root,
             client_id=self.client_id,
             client_secret=self.client_secret,
-            bearer_token=bearer_token,
+            bearer_token=self._authenticated_bearer_token,
         )
         organization_ids: list[str] = []
         for permission in permissions:
@@ -539,15 +555,53 @@ class CloudClient:
             )
         return candidates
 
+    def _raise_ambiguous_organization_error(
+        self,
+        organization_ids: tuple[str, ...],
+    ) -> NoReturn:
+        """Raise an error enumerating the caller's candidate organizations."""
+        candidates = self._get_organization_candidates(
+            organization_ids[:MAX_ORGANIZATION_CANDIDATES]
+        )
+        candidate_details = ", ".join(
+            f"{candidate['organization_id']} "
+            f"({candidate['organization_name'] or 'name unavailable'})"
+            for candidate in candidates
+        )
+        raise exc.PyAirbyteInputError(
+            message=(
+                "Multiple organization memberships were found for these credentials. "
+                "Retry with one of these organization IDs "
+                f"(showing {len(candidates)} of {len(organization_ids)}): {candidate_details}"
+            ),
+            context={
+                "organization_ids": list(organization_ids),
+                "organization_candidates": candidates,
+                "total_candidates": len(organization_ids),
+            },
+        )
+
     def list_organizations(
         self,
         *,
         name_contains: str | None = None,
         limit: int | None = None,
     ) -> list[CloudOrganization]:
-        """List organizations available to this client."""
+        """List organizations available to this client.
+
+        See the module docstring for how organization search and limits are resolved.
+        """
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
+
+        if name_contains is not None or limit is not None:
+            try:
+                return self._list_organizations_by_user_id(
+                    name_contains=name_contains,
+                    limit=limit,
+                )
+            except AirbyteError:
+                pass
 
         organizations = self._fetch_organizations()
         if name_contains is not None:
@@ -558,6 +612,43 @@ class CloudClient:
                 if name_substring in (organization.organization_name or "").casefold()
             ]
         return organizations if limit is None else organizations[:limit]
+
+    def _list_organizations_by_user_id(
+        self,
+        *,
+        name_contains: str | None = None,
+        limit: int | None = None,
+    ) -> list[CloudOrganization]:
+        """List organizations via the Config API, with server-side search and paging."""
+        return [
+            self._organization_from_mapping(organization)
+            for organization in api_util.list_organizations_for_user_id(
+                user_id=self._get_authenticated_user_id(),
+                api_root=self.public_api_root,
+                config_api_root=self.config_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+                name_contains=name_contains,
+                limit=limit,
+            )
+        ]
+
+    def _organization_from_mapping(
+        self,
+        organization: Mapping[str, Any],
+    ) -> CloudOrganization:
+        """Build a `CloudOrganization` from a Config API organization mapping."""
+        return CloudOrganization(
+            organization_id=organization["organizationId"],
+            organization_name=organization.get("organizationName"),
+            email=organization.get("email"),
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=self.bearer_token,
+            public_api_root=self.public_api_root,
+            config_api_root=self.config_api_root,
+        )
 
     def _fetch_organizations(self) -> list[CloudOrganization]:
         """Fetch all organizations available to this client."""
@@ -580,37 +671,86 @@ class CloudClient:
             )
         ]
 
+    def _resolve_default_organization_id(self) -> str | None:
+        """Resolve the organization to use when no organization argument is given."""
+        if self.organization_id is not None:
+            return self.organization_id
+        if self.default_workspace_id is not None:
+            return self._get_workspace_parent_organization_id(self.default_workspace_id)
+
+        organization_ids = self._get_membership_organization_ids()
+        if len(organization_ids) == 1:
+            return organization_ids[0]
+        if len(organization_ids) > 1:
+            self._raise_ambiguous_organization_error(organization_ids)
+        return None
+
+    def _get_organization_by_id(self, organization_id: str) -> CloudOrganization | None:
+        """Look up a single organization via the Config API, if available."""
+        try:
+            organization_info = api_util.get_organization_info(
+                organization_id=organization_id,
+                api_root=self.public_api_root,
+                config_api_root=self.config_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+            )
+        except AirbyteError:
+            return None
+        if not isinstance(organization_info.get("organizationId"), str):
+            return None
+        return self._organization_from_mapping(organization_info)
+
+    def _search_organizations_by_name(
+        self,
+        organization_name: str | None,
+    ) -> list[CloudOrganization]:
+        """Get organizations whose names contain `organization_name`, if available."""
+        if organization_name is not None:
+            try:
+                return self._list_organizations_by_user_id(name_contains=organization_name)
+            except AirbyteError:
+                pass
+        return self._fetch_organizations()
+
     def get_organization(
         self,
         organization_id: str | None = None,
         *,
         organization_name: str | None = None,
     ) -> CloudOrganization:
-        """Resolve an organization by ID or exact name."""
+        """Resolve an organization by ID or exact name.
+
+        See the module docstring for how the organization is resolved when no
+        argument is given.
+        """
         resolved_organization_id = organization_id
         if resolved_organization_id and organization_name:
             raise exc.PyAirbyteInputError(
                 message="Provide either organization ID or organization name."
             )
         if resolved_organization_id is None and organization_name is None:
-            resolved_organization_id = self.organization_id
+            resolved_organization_id = self._resolve_default_organization_id()
         if not resolved_organization_id and not organization_name:
             raise exc.PyAirbyteInputError(
                 message="Organization ID or organization name is required."
             )
 
-        organizations = self._fetch_organizations()
         if resolved_organization_id:
+            organization = self._get_organization_by_id(resolved_organization_id)
+            if organization is not None:
+                return organization
             matching_organizations = [
-                organization
-                for organization in organizations
-                if organization.organization_id == resolved_organization_id
+                candidate
+                for candidate in self._fetch_organizations()
+                if candidate.organization_id == resolved_organization_id
             ]
         else:
             matching_organizations = [
-                organization
-                for organization in organizations
-                if organization.organization_name == organization_name
+                candidate
+                for candidate in self._search_organizations_by_name(organization_name)
+                if candidate.organization_name == organization_name
             ]
 
         if not matching_organizations:

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -3,48 +3,65 @@
 
 ## Organization and workspace resolution
 
-Most discovery operations need an organization context. `CloudClient` derives that
-context from whatever the caller supplies, falling back to the credentials' own
-configuration and finally to the authenticated user's memberships.
+Most operations need an organization and/or a workspace context. `CloudClient` derives
+that context from what the caller supplies, falling back to the credentials' own scope
+and finally to the authenticated user's organization memberships.
 
-### Resolving the organization
+Two rules govern the whole protocol: an explicitly passed ID always beats an ambient
+one, and within each of those tiers an organization ID beats a workspace ID.
 
-`CloudClient.list_workspaces` resolves an organization in this order, stopping at the
-first step that yields one:
+### Where a workspace ID comes from
 
-1. The explicit `organization_id` argument.
-2. The explicit `organization_name` argument, resolved by exact name via
-   `CloudClient.get_organization`. This scans every visible organization, so it is
-   never used to infer a default.
-3. The parent organization of an explicit `workspace_id` argument.
-4. The organization configured on the credentials (`CloudClient.organization_id`, from
-   the constructor or `AIRBYTE_CLOUD_ORGANIZATION_ID`).
-5. The parent organization of the configured default workspace
-   (`CloudClient.default_workspace_id`, from the constructor or
-   `AIRBYTE_CLOUD_WORKSPACE_ID`).
-6. The sole organization the authenticated user belongs to, read from that user's
-   permissions and cached for the life of the client.
+A workspace ID reaches the client from one of three places, in order:
 
-If step 6 finds several memberships, discovery stops with a `PyAirbyteInputError`
-carrying the candidate organization IDs and names, so the caller can retry with one of
-them instead of having to list organizations first. If it finds none — which happens
-for credentials whose grants are not organization-scoped — resolution yields no
-organization and listing falls back to the cross-organization path below. Passing
-`all_organizations=True` selects that path deliberately and cannot be combined with an
-organization or workspace argument.
+1. The `workspace_id` argument on the operation, such as `CloudClient.get_workspace`.
+2. The `X-Airbyte-Workspace-Id` header, when running as an MCP server over HTTP.
+3. The `AIRBYTE_CLOUD_WORKSPACE_ID` (or `AIRBYTE_WORKSPACE_ID`) environment variable,
+   read when the client is built with `CloudClient.from_auth(env_vars=True)`.
 
-### Resolving the workspace
+The last two become `CloudClient.default_workspace_id`, the ambient workspace context
+for the client. Workspace-scoped operations use it whenever no `workspace_id` argument
+is passed; `CloudClient.get_workspace` raises when neither is available, since an
+organization can hold many workspaces and there is nothing to guess from.
 
-`CloudClient.get_workspace` takes the explicit `workspace_id` argument if given, and
-otherwise the configured `CloudClient.default_workspace_id`. It raises when neither is
-available; it never guesses a workspace from the organization, since an organization
-can hold many.
+### If a workspace ID is known
+
+The workspace determines the organization: its parent organization is fetched in a
+single call and used as the organization context. That covers the common case, and
+nothing below applies.
+
+The one exception is an explicit `organization_id` or `organization_name` argument,
+which always wins over a workspace-derived organization — as does a configured
+`CloudClient.organization_id` over an *ambient* workspace.
+
+### If an organization ID is known but no workspace ID
+
+The organization is used as-is, whether it came from the `organization_id` argument,
+from `organization_name` (an exact-name lookup that scans every visible organization,
+so it is never used to infer a default), or from the credentials as
+`CloudClient.organization_id`.
+
+### If neither is known
+
+`CloudClient.list_workspaces` falls back to the authenticated user's memberships: the
+organizations that user holds permissions on, read once and cached for the life of the
+client.
+
+- Exactly one membership — that organization is the context.
+- Several memberships — discovery stops with a `PyAirbyteInputError` carrying the
+  candidate organization IDs and names, so the caller can retry with one of them
+  instead of having to list organizations first.
+- No memberships — which happens for credentials whose grants are not
+  organization-scoped — listing falls back to the cross-organization path below.
+
+Passing `all_organizations=True` selects that path deliberately and cannot be combined
+with an organization or workspace argument.
 
 ### Why the path matters
 
 The two listing paths differ in completeness, not just speed:
 
-- **Organization-scoped** (an organization resolved above) uses the Config API, which
+- **Organization-scoped** (an organization was resolved) uses the Config API, which
   filters by name server-side and paginates, so results are complete and each workspace
   carries its organization attribution.
 - **Cross-organization** (no organization resolved, or `all_organizations=True`) uses

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -22,8 +22,7 @@ if TYPE_CHECKING:
 
 
 CROSS_ORG_WORKSPACE_DEFAULT_LIMIT = 100
-CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES = 1
-CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = api_util.PAGE_SIZE * CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES
+CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS = 100
 CLOUD_ORGANIZATION_DEFAULT_LIMIT = 100
 
 
@@ -267,21 +266,33 @@ class CloudClient:
                 if limit is not None:
                     workspace_infos = workspace_infos[:limit]
             return workspace_infos
-        is_explicit_lookup = name is not None or name_filter is not None
         if name_contains is not None:
             if name_filter is not None:
                 raise exc.PyAirbyteInputError(
                     message="You can provide name_contains or name_filter, but not both."
                 )
             name_substring = name_contains
+            if limit is not None and limit <= 0:
+                raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
+            workspaces = api_util.list_workspaces(
+                workspace_id="",
+                api_root=self.public_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+                limit=CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS,
+            )
+            matching_workspaces = [
+                CloudWorkspaceInfo.from_api_response(workspace)
+                for workspace in workspaces
+                if name_substring in workspace.name
+            ]
+            return matching_workspaces[: limit or CROSS_ORG_WORKSPACE_DEFAULT_LIMIT]
 
-            def name_filter(workspace_name: str) -> bool:
-                return name_substring in workspace_name
-
+        is_explicit_lookup = name is not None or name_filter is not None
         effective_limit = (
             limit if limit is not None or is_explicit_lookup else CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
         )
-        max_pages = CROSS_ORG_WORKSPACE_SCAN_MAX_PAGES if name_contains is not None else None
         return [
             CloudWorkspaceInfo.from_api_response(workspace)
             for workspace in api_util.list_workspaces(
@@ -293,7 +304,6 @@ class CloudClient:
                 client_secret=self.client_secret,
                 bearer_token=self.bearer_token,
                 limit=effective_limit,
-                max_pages=max_pages,
             )
         ]
 

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -285,17 +285,19 @@ class AirbyteMissingWorkspaceContextError(PyAirbyteInputError):
             return
         if is_hosted_mcp_mode():
             self.guidance = (
-                "Call `list_cloud_organizations` and `list_cloud_workspaces` first. "
-                "If discovery returns exactly one workspace, provide its ID via the "
-                f"`{MCP_WORKSPACE_ID_HEADER}` header or the `workspace_id` parameter; "
-                "otherwise ask the user to choose."
+                "Call `list_cloud_workspaces` first, which resolves the organization "
+                "automatically; only call `list_cloud_organizations` to search "
+                "organizations by name. If discovery returns exactly one workspace, "
+                f"provide its ID via the `{MCP_WORKSPACE_ID_HEADER}` header or the "
+                "`workspace_id` parameter; otherwise ask the user to choose."
             )
         else:
             self.guidance = (
-                "Call `list_cloud_organizations` and `list_cloud_workspaces` first. "
-                "If discovery returns exactly one workspace, set its ID in "
-                f"`{CLOUD_WORKSPACE_ID_ENV_VAR}` or pass the `workspace_id` parameter; "
-                "otherwise ask the user to choose."
+                "Call `list_cloud_workspaces` first, which resolves the organization "
+                "automatically; only call `list_cloud_organizations` to search "
+                "organizations by name. If discovery returns exactly one workspace, "
+                f"set its ID in `{CLOUD_WORKSPACE_ID_ENV_VAR}` or pass the "
+                "`workspace_id` parameter; otherwise ask the user to choose."
             )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1528,22 +1528,11 @@ def list_cloud_workspaces(
             default=None,
         ),
     ],
-    all_organizations: Annotated[
-        bool,
-        Field(
-            description=(
-                "Whether to explicitly list across all organizations instead of resolving "
-                "an organization context."
-            ),
-            default=False,
-        ),
-    ],
 ) -> CloudWorkspaceListResult:
     """List all workspaces visible to the authenticated credentials.
 
     The client resolves an organization from the provided IDs, workspace context, or
-    the authenticated user's organization memberships. Set `all_organizations` to
-    explicitly search across all visible organizations.
+    the authenticated user's organization memberships.
     """
     client = _get_cloud_client(ctx)
 
@@ -1553,7 +1542,6 @@ def list_cloud_workspaces(
             organization_name=organization_name,
             name_contains=name_contains,
             limit=limit,
-            all_organizations=all_organizations,
         )
     except PyAirbyteInputError as error:
         context = error.context or {}

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1597,7 +1597,12 @@ def list_cloud_workspaces(
                     f"Results are capped at {CROSS_ORG_WORKSPACE_DEFAULT_LIMIT} "
                     "workspaces by default for "
                     "cross-organization discovery. Provide limit to change the cap."
-                    if is_cross_org and name_contains is None and limit is None
+                    if (
+                        is_cross_org
+                        and name_contains is None
+                        and limit is None
+                        and len(workspaces) == CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
+                    )
                     else None
                 ),
                 (
@@ -1675,7 +1680,7 @@ def list_cloud_organizations(
                 "organizations by default. Use name_contains to narrow the search "
                 "or provide limit to request a different cap."
             )
-            if limit is None
+            if (limit is None and len(organizations) == CLOUD_ORGANIZATION_DEFAULT_LIMIT)
             else (
                 f"Results are capped at {limit} organizations and may be truncated. "
                 "Use name_contains to narrow the search."

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -210,10 +210,10 @@ class CloudOrganizationResult(BaseModel):
 
     id: str
     """The organization ID."""
-    name: str
-    """Display name of the organization."""
-    email: str
-    """Email associated with the organization."""
+    name: str | None = None
+    """Display name of the organization, when available."""
+    email: str | None = None
+    """Email associated with the organization, when available."""
     payment_status: str | None = None
     """Payment status of the organization (e.g., 'okay', 'grace_period', 'disabled', 'locked').
     When 'disabled', syncs are blocked due to unpaid invoices."""
@@ -224,15 +224,6 @@ class CloudOrganizationResult(BaseModel):
     """Whether the account is locked due to billing issues.
     True if payment_status is 'disabled'/'locked' or subscription_status is 'unsubscribed'.
     Defaults to False unless we have affirmative evidence of a locked state."""
-
-
-class CloudOrganizationCandidate(BaseModel):
-    """Organization candidate for resolving an ambiguous workspace listing."""
-
-    id: str
-    """Organization ID."""
-    name: str | None = None
-    """Organization name when available."""
 
 
 class CloudOrganizationListResult(BaseModel):
@@ -281,7 +272,7 @@ class CloudWorkspaceListResult(BaseModel):
     message: str | None = None
     """Additional guidance when discovery returns no results."""
 
-    candidate_organizations: list[CloudOrganizationCandidate] | None = None
+    available_organizations: list[CloudOrganizationResult] | None = None
     """Organizations to choose from when the credentials match multiple organizations."""
 
 
@@ -1548,7 +1539,7 @@ def list_cloud_workspaces(
         candidates = context.get("organization_candidates")
         if not isinstance(candidates, list):
             raise
-        candidate_organizations: list[CloudOrganizationCandidate] = []
+        available_organizations: list[CloudOrganizationResult] = []
         for candidate in candidates:
             if not isinstance(candidate, dict):
                 continue
@@ -1556,18 +1547,18 @@ def list_cloud_workspaces(
             if not isinstance(candidate_id, str):
                 continue
             candidate_name = candidate.get("organization_name")
-            candidate_organizations.append(
-                CloudOrganizationCandidate(
+            available_organizations.append(
+                CloudOrganizationResult(
                     id=candidate_id,
                     name=candidate_name if isinstance(candidate_name, str) else None,
                 )
             )
         message = error.get_message()
-        if candidate_organizations:
+        if available_organizations:
             message += " Retry with one of the candidate organization IDs."
         return CloudWorkspaceListResult(
             workspaces=[],
-            candidate_organizations=candidate_organizations,
+            available_organizations=available_organizations,
             message=message,
         )
     except AirbyteError as error:
@@ -1649,8 +1640,8 @@ def list_cloud_organizations(
         organizations=[
             CloudOrganizationResult(
                 id=organization.organization_id,
-                name=organization.organization_name or "",
-                email=organization.email or "",
+                name=organization.organization_name,
+                email=organization.email,
             )
             for organization in organizations
         ],

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1555,7 +1555,10 @@ def list_cloud_workspaces(
             )
         message = error.get_message()
         if available_organizations:
-            message += " Retry with one of the candidate organization IDs."
+            message += (
+                " Retry with an explicit organization ID from the provided list of the "
+                "available organizations."
+            )
         return CloudWorkspaceListResult(
             workspaces=[],
             available_organizations=available_organizations,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -366,6 +366,7 @@ def _get_cloud_client(
     client_secret = get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET)
     api_url = get_mcp_config(ctx, MCP_CONFIG_API_URL)
     config_api_url = get_mcp_config(ctx, MCP_CONFIG_CONFIG_API_URL)
+    workspace_id = get_mcp_config(ctx, MCP_CONFIG_WORKSPACE_ID)
 
     return CloudClient(
         client_id=client_id,
@@ -373,6 +374,7 @@ def _get_cloud_client(
         bearer_token=bearer_token,
         public_api_root=api_url,
         config_api_root=config_api_url,
+        workspace_id=workspace_id,
         organization_id=organization_id,
     )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1587,7 +1587,7 @@ def list_cloud_workspaces(
             message
             for message in [
                 (
-                    "Results are partial because cross-organization name searches "
+                    "Results may be partial because cross-organization name searches "
                     f"scan at most {CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS} workspaces. "
                     "Pass organization_id for complete results."
                     if is_cross_org and name_contains is not None

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -21,7 +21,11 @@ from pydantic import BaseModel, Field
 
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
-from airbyte.cloud.client import CloudClient
+from airbyte.cloud.client import (
+    CROSS_ORG_WORKSPACE_DEFAULT_LIMIT,
+    CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS,
+    CloudClient,
+)
 from airbyte.cloud.connectors import CheckResult, CustomCloudSourceDefinition
 from airbyte.cloud.constants import FAILED_STATUSES
 from airbyte.cloud.models import JobTypeEnum
@@ -1575,12 +1579,44 @@ def list_cloud_workspaces(
     ]
     return CloudWorkspaceListResult(
         workspaces=results,
-        message=(
-            "No workspaces were returned for these credentials. Verify the "
-            "credentials or ask the user to provide a workspace ID."
-            if not results
-            else None
-        ),
+        message=" ".join(
+            message
+            for message in [
+                (
+                    "Results are partial because cross-organization name searches "
+                    f"scan at most {CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS} workspaces. "
+                    "Pass organization_id for complete results."
+                    if (
+                        organization_id is None
+                        and organization_name is None
+                        and getattr(client, "organization_id", None) is None
+                        and name_contains is not None
+                    )
+                    else None
+                ),
+                (
+                    f"Results are capped at {CROSS_ORG_WORKSPACE_DEFAULT_LIMIT} "
+                    "workspaces by default for "
+                    "cross-organization discovery. Provide limit to change the cap."
+                    if (
+                        organization_id is None
+                        and organization_name is None
+                        and getattr(client, "organization_id", None) is None
+                        and name_contains is None
+                        and limit is None
+                    )
+                    else None
+                ),
+                (
+                    "No workspaces were returned for these credentials. Verify the "
+                    "credentials or ask the user to provide a workspace ID."
+                    if not results
+                    else None
+                ),
+            ]
+            if message is not None
+        )
+        or None,
     )
 
 
@@ -1592,10 +1628,27 @@ def list_cloud_workspaces(
 )
 def list_cloud_organizations(
     ctx: Context,
+    name_contains: Annotated[
+        str | None,
+        Field(
+            description="Optional case-insensitive substring to filter organization names.",
+            default=None,
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        Field(
+            description="Optional maximum number of organizations to return.",
+            default=None,
+        ),
+    ] = None,
 ) -> CloudOrganizationListResult:
     """List organizations visible to the authenticated Airbyte Cloud credentials."""
     try:
-        organizations = _get_cloud_client(ctx).list_organizations()
+        organizations = _get_cloud_client(ctx).list_organizations(
+            name_contains=name_contains,
+            limit=limit,
+        )
     except AirbyteError as error:
         return _handle_discovery_permission_error(
             error,
@@ -1622,7 +1675,13 @@ def list_cloud_organizations(
                 email=organization.email or "",
             )
             for organization in organizations
-        ]
+        ],
+        message=(
+            f"Results are capped at {limit} organizations and may be truncated. "
+            "Use name_contains to narrow the search."
+            if limit is not None and len(organizations) == limit
+            else None
+        ),
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1582,10 +1582,13 @@ def list_cloud_workspaces(
                     name=candidate_name if isinstance(candidate_name, str) else None,
                 )
             )
+        message = error.get_message()
+        if candidate_organizations:
+            message += " Retry with one of the candidate organization IDs."
         return CloudWorkspaceListResult(
             workspaces=[],
             candidate_organizations=candidate_organizations,
-            message=(f"{error.get_message()} Retry with one of the candidate organization IDs."),
+            message=message,
         )
     except AirbyteError as error:
         return _handle_discovery_permission_error(

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -60,9 +60,10 @@ from airbyte.mcp._tool_utils import (
 CLOUD_AUTH_TIP_TEXT = (
     f"When connecting to a hosted MCP server, provide a bearer token via the "
     f"`{MCP_BEARER_TOKEN_HEADER}` header, or client credentials via the transport "
-    f"`Client-Id` and `Client-Secret` headers. To discover available organizations "
-    f"and workspaces, call `list_cloud_organizations` and `list_cloud_workspaces` "
-    f"before asking the user for an ID. For local or "
+    f"`Client-Id` and `Client-Secret` headers. To discover your organization and "
+    f"workspaces, call `list_cloud_workspaces`, which resolves your organization "
+    f"automatically. Only call `list_cloud_organizations` when you need to search "
+    f"organizations by name, passing `name_contains`. For local or "
     f"stdio connections, set the `{CLOUD_BEARER_TOKEN_ENV_VAR}` environment "
     f"variable, or both `{CLOUD_CLIENT_ID_ENV_VAR}` and "
     f"`{CLOUD_CLIENT_SECRET_ENV_VAR}`. If discovery returns multiple candidates, "
@@ -1583,14 +1584,32 @@ def list_cloud_workspaces(
         )
         for ws in workspaces
     ]
+    organization_ids = {
+        result.organization_id for result in results if result.organization_id is not None
+    }
+    message = (
+        "No workspaces were returned for these credentials. Verify the "
+        "credentials or ask the user to provide a workspace ID."
+        if not results
+        else None
+    )
+    if len(organization_ids) == 1:
+        resolved_organization_id = next(iter(organization_ids))
+        try:
+            organization = client.get_organization(organization_id=resolved_organization_id)
+        except AirbyteError:
+            pass
+        else:
+            for result in results:
+                result.organization_name = organization.organization_name
+            if organization_id is None and organization_name is None:
+                message = (
+                    f"Resolved organization {organization.organization_name} "
+                    f"({resolved_organization_id}) for these credentials."
+                )
     return CloudWorkspaceListResult(
         workspaces=results,
-        message=(
-            "No workspaces were returned for these credentials. Verify the "
-            "credentials or ask the user to provide a workspace ID."
-            if not results
-            else None
-        ),
+        message=message,
     )
 
 
@@ -1612,16 +1631,17 @@ def list_cloud_organizations(
     limit: Annotated[
         int | None,
         Field(
-            description="Optional maximum number of organizations to return.",
+            description="Optional maximum number of organizations to return (default: 100).",
             default=None,
         ),
     ] = None,
 ) -> CloudOrganizationListResult:
     """List organizations visible to the authenticated Airbyte Cloud credentials."""
+    effective_limit = 100 if limit is None else limit
     try:
         organizations = _get_cloud_client(ctx).list_organizations(
             name_contains=name_contains,
-            limit=limit,
+            limit=effective_limit,
         )
     except AirbyteError as error:
         return _handle_discovery_permission_error(
@@ -1651,9 +1671,9 @@ def list_cloud_organizations(
             for organization in organizations
         ],
         message=(
-            f"Results are capped at {limit} organizations and may be truncated. "
-            "Use name_contains to narrow the search."
-            if len(organizations) == limit
+            f"Showing the first {effective_limit} organizations; more may exist. "
+            "Pass `name_contains` to narrow the search, or a larger `limit`."
+            if len(organizations) == effective_limit
             else None
         ),
     )
@@ -1671,7 +1691,10 @@ def describe_cloud_organization(
     organization_id: Annotated[
         str | None,
         Field(
-            description="Organization ID. Required if organization_name is not provided.",
+            description=(
+                "Organization ID. With no arguments, resolves from the configured "
+                "default or the authenticated user's sole membership."
+            ),
             default=None,
         ),
     ],
@@ -1679,7 +1702,9 @@ def describe_cloud_organization(
         str | None,
         Field(
             description=(
-                "Organization name (exact match). " "Required if organization_id is not provided."
+                "Organization name (exact match). With no arguments, resolves from the "
+                "configured default or the authenticated user's sole membership. With "
+                "multiple memberships, the error lists candidate organization IDs."
             ),
             default=None,
         ),
@@ -1687,8 +1712,10 @@ def describe_cloud_organization(
 ) -> CloudOrganizationResult:
     """Get details about a specific organization including billing status.
 
-    Requires either organization_id OR organization_name (exact match) to be provided.
-    This tool is useful for looking up an organization's ID from its name, or vice versa.
+    With no arguments, resolves the organization from the configured default or the
+    authenticated user's sole membership. With multiple memberships, the error lists
+    candidate organization IDs. Use organization_id or organization_name (exact match)
+    to look up a specific organization.
     """
     org = _get_cloud_client(ctx).get_organization(
         organization_id=organization_id,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -22,9 +22,6 @@ from pydantic import BaseModel, Field
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
 from airbyte.cloud.client import (
-    CLOUD_ORGANIZATION_DEFAULT_LIMIT,
-    CROSS_ORG_WORKSPACE_DEFAULT_LIMIT,
-    CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS,
     CloudClient,
 )
 from airbyte.cloud.connectors import CheckResult, CustomCloudSourceDefinition
@@ -229,6 +226,15 @@ class CloudOrganizationResult(BaseModel):
     Defaults to False unless we have affirmative evidence of a locked state."""
 
 
+class CloudOrganizationCandidate(BaseModel):
+    """Organization candidate for resolving an ambiguous workspace listing."""
+
+    id: str
+    """Organization ID."""
+    name: str | None = None
+    """Organization name when available."""
+
+
 class CloudOrganizationListResult(BaseModel):
     """Result of discovering organizations in Airbyte Cloud."""
 
@@ -274,6 +280,9 @@ class CloudWorkspaceListResult(BaseModel):
 
     message: str | None = None
     """Additional guidance when discovery returns no results."""
+
+    candidate_organizations: list[CloudOrganizationCandidate] | None = None
+    """Organizations to choose from when the credentials match multiple organizations."""
 
 
 class LogReadResult(BaseModel):
@@ -1482,23 +1491,6 @@ def list_deployed_cloud_connections(
     return results
 
 
-def _resolve_organization_id(
-    organization_id: str | None,
-    organization_name: str | None,
-    *,
-    client: CloudClient,
-) -> str:
-    """Resolve organization ID from either ID or exact name match."""
-    if organization_id is not None:
-        return organization_id
-
-    org = client.get_organization(
-        organization_id=organization_id,
-        organization_name=organization_name,
-    )
-    return org.organization_id
-
-
 @mcp_tool(
     read_only=True,
     idempotent=True,
@@ -1536,33 +1528,64 @@ def list_cloud_workspaces(
             default=None,
         ),
     ],
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description="Optional workspace ID used to resolve its organization.",
+            default=None,
+        ),
+    ],
+    all_organizations: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to explicitly list across all organizations instead of resolving "
+                "an organization context."
+            ),
+            default=False,
+        ),
+    ],
 ) -> CloudWorkspaceListResult:
     """List all workspaces visible to the authenticated credentials.
 
-    When an organization ID or exact organization name is provided, the Config API
-    lists workspaces in that organization. When neither is provided and the client
-    has no default organization, the public API lists workspaces across organizations
-    visible to the current credentials. Otherwise, results are scoped to the client's
-    default organization.
+    The client resolves an organization from the provided IDs, workspace context, or
+    the authenticated user's organization memberships. Set `all_organizations` to
+    explicitly search across all visible organizations.
     """
     client = _get_cloud_client(ctx)
-    is_cross_org = (
-        organization_id is None and organization_name is None and client.organization_id is None
-    )
 
     try:
         workspaces = client.list_workspaces(
-            organization_id=(
-                _resolve_organization_id(
-                    organization_id=organization_id,
-                    organization_name=organization_name,
-                    client=client,
-                )
-                if organization_id is not None or organization_name is not None
-                else None
-            ),
+            organization_id=organization_id,
+            organization_name=organization_name,
+            workspace_id=workspace_id,
             name_contains=name_contains,
             limit=limit,
+            all_organizations=all_organizations,
+        )
+    except PyAirbyteInputError as error:
+        context = error.context or {}
+        candidates = context.get("organization_candidates")
+        if not isinstance(candidates, list):
+            raise
+        candidate_organizations: list[CloudOrganizationCandidate] = []
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            candidate_id = candidate.get("organization_id")
+            if not isinstance(candidate_id, str):
+                continue
+            candidate_name = candidate.get("organization_name")
+            candidate_organizations.append(
+                CloudOrganizationCandidate(
+                    id=candidate_id,
+                    name=candidate_name if isinstance(candidate_name, str) else None,
+                )
+            )
+        return CloudWorkspaceListResult(
+            workspaces=[],
+            candidate_organizations=candidate_organizations,
+            message=(f"{error.get_message()} Retry with one of the candidate organization IDs."),
         )
     except AirbyteError as error:
         return _handle_discovery_permission_error(
@@ -1583,38 +1606,12 @@ def list_cloud_workspaces(
     ]
     return CloudWorkspaceListResult(
         workspaces=results,
-        message=" ".join(
-            message
-            for message in [
-                (
-                    "Results may be partial because cross-organization name searches "
-                    f"scan at most {CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS} workspaces. "
-                    "Pass organization_id for complete results."
-                    if is_cross_org and name_contains is not None
-                    else None
-                ),
-                (
-                    f"Results are capped at {CROSS_ORG_WORKSPACE_DEFAULT_LIMIT} "
-                    "workspaces by default for "
-                    "cross-organization discovery. Provide limit to change the cap."
-                    if (
-                        is_cross_org
-                        and name_contains is None
-                        and limit is None
-                        and len(workspaces) == CROSS_ORG_WORKSPACE_DEFAULT_LIMIT
-                    )
-                    else None
-                ),
-                (
-                    "No workspaces were returned for these credentials. Verify the "
-                    "credentials or ask the user to provide a workspace ID."
-                    if not results
-                    else None
-                ),
-            ]
-            if message is not None
-        )
-        or None,
+        message=(
+            "No workspaces were returned for these credentials. Verify the "
+            "credentials or ask the user to provide a workspace ID."
+            if not results
+            else None
+        ),
     )
 
 
@@ -1675,18 +1672,10 @@ def list_cloud_organizations(
             for organization in organizations
         ],
         message=(
-            (
-                f"Results are capped at {CLOUD_ORGANIZATION_DEFAULT_LIMIT} "
-                "organizations by default. Use name_contains to narrow the search "
-                "or provide limit to request a different cap."
-            )
-            if (limit is None and len(organizations) == CLOUD_ORGANIZATION_DEFAULT_LIMIT)
-            else (
-                f"Results are capped at {limit} organizations and may be truncated. "
-                "Use name_contains to narrow the search."
-                if len(organizations) == limit
-                else None
-            )
+            f"Results are capped at {limit} organizations and may be truncated. "
+            "Use name_contains to narrow the search."
+            if len(organizations) == limit
+            else None
         ),
     )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
 from airbyte.cloud.client import (
+    CLOUD_ORGANIZATION_DEFAULT_LIMIT,
     CROSS_ORG_WORKSPACE_DEFAULT_LIMIT,
     CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS,
     CloudClient,
@@ -1545,6 +1546,9 @@ def list_cloud_workspaces(
     default organization.
     """
     client = _get_cloud_client(ctx)
+    is_cross_org = (
+        organization_id is None and organization_name is None and client.organization_id is None
+    )
 
     try:
         workspaces = client.list_workspaces(
@@ -1586,25 +1590,14 @@ def list_cloud_workspaces(
                     "Results are partial because cross-organization name searches "
                     f"scan at most {CROSS_ORG_WORKSPACE_SCAN_MAX_RECORDS} workspaces. "
                     "Pass organization_id for complete results."
-                    if (
-                        organization_id is None
-                        and organization_name is None
-                        and getattr(client, "organization_id", None) is None
-                        and name_contains is not None
-                    )
+                    if is_cross_org and name_contains is not None
                     else None
                 ),
                 (
                     f"Results are capped at {CROSS_ORG_WORKSPACE_DEFAULT_LIMIT} "
                     "workspaces by default for "
                     "cross-organization discovery. Provide limit to change the cap."
-                    if (
-                        organization_id is None
-                        and organization_name is None
-                        and getattr(client, "organization_id", None) is None
-                        and name_contains is None
-                        and limit is None
-                    )
+                    if is_cross_org and name_contains is None and limit is None
                     else None
                 ),
                 (
@@ -1677,10 +1670,18 @@ def list_cloud_organizations(
             for organization in organizations
         ],
         message=(
-            f"Results are capped at {limit} organizations and may be truncated. "
-            "Use name_contains to narrow the search."
-            if limit is not None and len(organizations) == limit
-            else None
+            (
+                f"Results are capped at {CLOUD_ORGANIZATION_DEFAULT_LIMIT} "
+                "organizations by default. Use name_contains to narrow the search "
+                "or provide limit to request a different cap."
+            )
+            if limit is None
+            else (
+                f"Results are capped at {limit} organizations and may be truncated. "
+                "Use name_contains to narrow the search."
+                if len(organizations) == limit
+                else None
+            )
         ),
     )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1528,13 +1528,6 @@ def list_cloud_workspaces(
             default=None,
         ),
     ],
-    workspace_id: Annotated[
-        str | None,
-        Field(
-            description="Optional workspace ID used to resolve its organization.",
-            default=None,
-        ),
-    ],
     all_organizations: Annotated[
         bool,
         Field(
@@ -1558,7 +1551,6 @@ def list_cloud_workspaces(
         workspaces = client.list_workspaces(
             organization_id=organization_id,
             organization_name=organization_name,
-            workspace_id=workspace_id,
             name_contains=name_contains,
             limit=limit,
             all_organizations=all_organizations,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1601,7 +1601,8 @@ def list_cloud_workspaces(
             pass
         else:
             for result in results:
-                result.organization_name = organization.organization_name
+                if result.organization_id == resolved_organization_id:
+                    result.organization_name = organization.organization_name
             if organization_id is None and organization_name is None:
                 message = (
                     f"Resolved organization {organization.organization_name} "

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1604,10 +1604,12 @@ def list_cloud_workspaces(
                 if result.organization_id == resolved_organization_id:
                     result.organization_name = organization.organization_name
             if organization_id is None and organization_name is None:
-                message = (
-                    f"Resolved organization {organization.organization_name} "
-                    f"({resolved_organization_id}) for these credentials."
+                resolved_organization = (
+                    f"{organization.organization_name} ({resolved_organization_id})"
+                    if organization.organization_name is not None
+                    else resolved_organization_id
                 )
+                message = f"Resolved organization {resolved_organization} for these credentials."
     return CloudWorkspaceListResult(
         workspaces=results,
         message=message,

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -215,6 +215,81 @@ def test_list_permissions_for_user_rejects_unexpected_response(
         )
 
 
+@pytest.mark.parametrize(
+    ("name_contains", "limit", "expected_count", "expected_last", "request_count"),
+    [
+        pytest.param(
+            None,
+            150,
+            150,
+            "organization-149",
+            2,
+            id="without-name-filter",
+        ),
+        pytest.param(
+            "Airbyte",
+            None,
+            200,
+            "organization-199",
+            3,
+            id="with-name-filter",
+        ),
+    ],
+)
+def test_list_organizations_for_user_id_paginates_and_forwards_filters(
+    monkeypatch: pytest.MonkeyPatch,
+    name_contains: str | None,
+    limit: int | None,
+    expected_count: int,
+    expected_last: str,
+    request_count: int,
+) -> None:
+    requests: list[dict[str, object]] = []
+    pages = [
+        {
+            "organizations": [
+                {"organizationId": f"organization-{index}"} for index in range(100)
+            ]
+        },
+        {
+            "organizations": [
+                {"organizationId": f"organization-{index}"} for index in range(100, 200)
+            ]
+        },
+        {"organizations": []},
+    ]
+
+    def fake_config_request(**kwargs: object) -> dict[str, object]:
+        request = kwargs["json"]
+        assert isinstance(request, dict)
+        requests.append(request)
+        return pages.pop(0)
+
+    monkeypatch.setattr(api_util, "_make_config_api_request", fake_config_request)
+
+    result = api_util.list_organizations_for_user_id(
+        "user-id",
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+        name_contains=name_contains,
+        limit=limit,
+    )
+
+    result_ids = [organization["organizationId"] for organization in result]
+    assert len(result_ids) == expected_count
+    assert result_ids[0] == "organization-0"
+    assert result_ids[-1] == expected_last
+    assert requests[0] == {
+        "userId": "user-id",
+        "pagination": {"pageSize": 100, "rowOffset": 0},
+        **({"nameContains": name_contains} if name_contains is not None else {}),
+    }
+    assert requests[1]["pagination"] == {"pageSize": 100, "rowOffset": 100}
+    assert len(requests) == request_count
+
+
 def test_create_workspace_forwards_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -592,53 +592,6 @@ def test_list_workspaces_caps_unfiltered_api_page_size(
     ] == [(None, 1, 0)]
 
 
-def test_list_workspaces_stops_after_max_pages(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verify filtered workspace listing stops at its scan ceiling."""
-    captured_requests: list[api.ListWorkspacesRequest] = []
-    pages = [
-        _list_workspaces_response(
-            [_workspace_response("first", 1)],
-            next_page="next",
-        ),
-        _list_workspaces_response(
-            [_workspace_response("second", 2)],
-            next_page=None,
-        ),
-    ]
-
-    def list_workspaces(
-        request: api.ListWorkspacesRequest,
-    ) -> api.ListWorkspacesResponse:
-        captured_requests.append(request)
-        return pages.pop(0)
-
-    airbyte_instance = SimpleNamespace(
-        workspaces=SimpleNamespace(list_workspaces=list_workspaces),
-    )
-    monkeypatch.setattr(
-        api_util,
-        "get_airbyte_server_instance",
-        lambda **_: airbyte_instance,
-    )
-
-    result = api_util.list_workspaces(
-        workspace_id="context-workspace-id",
-        api_root="https://api.airbyte.com/v1/",
-        client_id=SecretString("client-id"),
-        client_secret=SecretString("client-secret"),
-        bearer_token=None,
-        name_filter=lambda name: name == "second",
-        max_pages=1,
-    )
-
-    assert result == []
-    assert [(request.limit, request.offset) for request in captured_requests] == [
-        (100, 0)
-    ]
-
-
 @pytest.mark.parametrize("limit", [0, -1])
 def test_list_connections_rejects_invalid_limits(limit: int) -> None:
     """Verify connection list pagination rejects non-positive limits."""

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any
 
 import pytest
 import requests
@@ -124,37 +123,98 @@ def test_get_user_id_from_bearer_token() -> None:
 
 
 @pytest.mark.parametrize(
-    "token",
+    ("token", "expected_message"),
     [
-        "not-a-jwt",
-        "header.not-json.signature",
+        pytest.param(
+            "not-a-jwt",
+            "not a valid JWT",
+            id="invalid-jwt",
+        ),
+        pytest.param(
+            "header.not-json.signature",
+            "could not be decoded",
+            id="undecodable-payload",
+        ),
+        pytest.param(
+            "header.e30.signature",
+            "does not contain a user ID",
+            id="missing-user-id",
+        ),
     ],
 )
-def test_get_user_id_from_bearer_token_rejects_invalid_tokens(token: str) -> None:
-    with pytest.raises(PyAirbyteInputError):
+def test_get_user_id_from_bearer_token_rejects_invalid_tokens(
+    token: str,
+    expected_message: str,
+) -> None:
+    with pytest.raises(PyAirbyteInputError, match=expected_message):
         api_util.get_user_id_from_bearer_token(SecretString(token))
 
 
-def test_get_user_id_from_bearer_token_requires_user_id() -> None:
-    with pytest.raises(PyAirbyteInputError, match="does not contain a user ID"):
-        api_util.get_user_id_from_bearer_token(
-            SecretString("header.e30.signature"),
-        )
-
-
-def test_get_user_by_auth_id_forwards_config_api_request(
+@pytest.mark.parametrize(
+    (
+        "helper",
+        "kwargs",
+        "expected_path",
+        "expected_json",
+        "fake_response",
+        "expected_result",
+    ),
+    [
+        pytest.param(
+            api_util.get_user_by_auth_id,
+            {"auth_user_id": "auth-user-id"},
+            "/users/get_by_auth_id",
+            {"authUserId": "auth-user-id", "authProvider": "keycloak"},
+            {"userId": "user-id"},
+            {"userId": "user-id"},
+            id="user-by-auth-id",
+        ),
+        pytest.param(
+            api_util.list_permissions_for_user,
+            {"user_id": "user-id"},
+            "/permissions/list_by_user",
+            {"userId": "user-id"},
+            [{"permissionType": "organization_member", "organizationId": "org-id"}],
+            [{"permissionType": "organization_member", "organizationId": "org-id"}],
+            id="permissions-list",
+        ),
+        pytest.param(
+            api_util.list_permissions_for_user,
+            {"user_id": "user-id"},
+            "/permissions/list_by_user",
+            {"userId": "user-id"},
+            {
+                "permissions": [
+                    {
+                        "permissionType": "organization_member",
+                        "organizationId": "org-id",
+                    }
+                ]
+            },
+            [{"permissionType": "organization_member", "organizationId": "org-id"}],
+            id="permissions-envelope",
+        ),
+    ],
+)
+def test_config_api_helpers_forward_requests(
     monkeypatch: pytest.MonkeyPatch,
+    helper: Callable[..., object],
+    kwargs: dict[str, str],
+    expected_path: str,
+    expected_json: dict[str, str],
+    fake_response: object,
+    expected_result: object,
 ) -> None:
     captured: dict[str, object] = {}
 
-    def fake_config_request(**kwargs: object) -> dict[str, object]:
-        captured.update(kwargs)
-        return {"userId": "user-id"}
+    def fake_config_request(**request_kwargs: object) -> object:
+        captured.update(request_kwargs)
+        return fake_response
 
     monkeypatch.setattr(api_util, "_make_config_api_request", fake_config_request)
 
-    result = api_util.get_user_by_auth_id(
-        "auth-user-id",
+    result = helper(
+        **kwargs,
         api_root="https://api.example",
         config_api_root="https://config.example",
         client_id=None,
@@ -162,25 +222,93 @@ def test_get_user_by_auth_id_forwards_config_api_request(
         bearer_token=SecretString("token"),
     )
 
-    assert result == {"userId": "user-id"}
-    assert captured["path"] == "/users/get_by_auth_id"
-    assert captured["json"] == {
-        "authUserId": "auth-user-id",
-        "authProvider": "keycloak",
-    }
+    assert result == expected_result
+    assert captured["path"] == expected_path
+    assert captured["json"] == expected_json
     assert captured["config_api_root"] == "https://config.example"
 
 
 @pytest.mark.parametrize(
-    "response",
+    ("helper", "kwargs", "response", "expected_message"),
     [
-        pytest.param([], id="list"),
-        pytest.param("unexpected", id="string"),
+        pytest.param(
+            api_util.get_user_by_auth_id,
+            {"auth_user_id": "auth-user-id"},
+            [],
+            "user API returned an unexpected response",
+            id="user-list",
+        ),
+        pytest.param(
+            api_util.get_user_by_auth_id,
+            {"auth_user_id": "auth-user-id"},
+            "unexpected",
+            "user API returned an unexpected response",
+            id="user-string",
+        ),
+        pytest.param(
+            api_util.list_permissions_for_user,
+            {"user_id": "user-id"},
+            "unexpected",
+            "permissions API returned an unexpected response",
+            id="permissions-string",
+        ),
+        pytest.param(
+            api_util.list_permissions_for_user,
+            {"user_id": "user-id"},
+            {"permissions": {}},
+            "permissions API returned an unexpected response",
+            id="permissions-non-list-envelope",
+        ),
+        pytest.param(
+            api_util.list_organizations_for_user_id,
+            {"user_id": "user-id"},
+            [],
+            "organizations API returned an unexpected response",
+            id="organizations-list",
+        ),
+        pytest.param(
+            api_util.list_organizations_for_user_id,
+            {"user_id": "user-id"},
+            {"organizations": {}},
+            "organizations API returned an unexpected response",
+            id="organizations-non-list-envelope",
+        ),
+        pytest.param(
+            api_util.get_organization_info,
+            {"organization_id": "organization-id"},
+            [],
+            "organization API returned an unexpected response",
+            id="organization-list",
+        ),
+        pytest.param(
+            api_util.get_organization_info,
+            {"organization_id": "organization-id"},
+            "unexpected",
+            "organization API returned an unexpected response",
+            id="organization-string",
+        ),
+        pytest.param(
+            api_util.get_workspace_organization_info,
+            {"workspace_id": "workspace-id"},
+            [],
+            "workspace API returned an unexpected response",
+            id="workspace-list",
+        ),
+        pytest.param(
+            api_util.get_workspace_organization_info,
+            {"workspace_id": "workspace-id"},
+            "unexpected",
+            "workspace API returned an unexpected response",
+            id="workspace-string",
+        ),
     ],
 )
-def test_get_user_by_auth_id_rejects_unexpected_response(
+def test_config_api_helpers_reject_unexpected_response(
     monkeypatch: pytest.MonkeyPatch,
+    helper: Callable[..., object],
+    kwargs: dict[str, str],
     response: object,
+    expected_message: str,
 ) -> None:
     monkeypatch.setattr(
         api_util,
@@ -188,12 +316,9 @@ def test_get_user_by_auth_id_rejects_unexpected_response(
         lambda **_: response,
     )
 
-    with pytest.raises(
-        AirbyteError,
-        match="user API returned an unexpected response",
-    ) as exc_info:
-        api_util.get_user_by_auth_id(
-            "auth-user-id",
+    with pytest.raises(AirbyteError, match=expected_message) as exc_info:
+        helper(
+            **kwargs,
             api_root="https://api.example",
             client_id=None,
             client_secret=None,
@@ -201,52 +326,6 @@ def test_get_user_by_auth_id_rejects_unexpected_response(
         )
 
     assert exc_info.value.context == {"response": response}
-
-
-def test_list_permissions_for_user_accepts_direct_list_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-    permissions = [
-        {"permissionType": "organization_member", "organizationId": "org-id"}
-    ]
-
-    def fake_config_request(**kwargs: object) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return permissions
-
-    monkeypatch.setattr(api_util, "_make_config_api_request", fake_config_request)
-
-    result = api_util.list_permissions_for_user(
-        "user-id",
-        api_root="https://api.example",
-        client_id=None,
-        client_secret=None,
-        bearer_token=SecretString("token"),
-    )
-
-    assert result == permissions
-    assert captured["path"] == "/permissions/list_by_user"
-    assert captured["json"] == {"userId": "user-id"}
-
-
-def test_list_permissions_for_user_rejects_unexpected_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        api_util,
-        "_make_config_api_request",
-        lambda **_: "unexpected",
-    )
-
-    with pytest.raises(AirbyteError):
-        api_util.list_permissions_for_user(
-            "user-id",
-            api_root="https://api.example",
-            client_id=None,
-            client_secret=None,
-            bearer_token=SecretString("token"),
-        )
 
 
 @pytest.mark.parametrize(
@@ -322,87 +401,6 @@ def test_list_organizations_for_user_id_paginates_and_forwards_filters(
     }
     assert requests[1]["pagination"] == {"pageSize": 100, "rowOffset": 100}
     assert len(requests) == request_count
-
-
-@pytest.mark.parametrize(
-    "response",
-    [
-        pytest.param([], id="list"),
-        pytest.param({"organizations": {}}, id="non-list-organizations"),
-    ],
-)
-def test_list_organizations_for_user_id_rejects_unexpected_response(
-    monkeypatch: pytest.MonkeyPatch,
-    response: object,
-) -> None:
-    monkeypatch.setattr(
-        api_util,
-        "_make_config_api_request",
-        lambda **_: response,
-    )
-
-    with pytest.raises(
-        AirbyteError,
-        match="organizations API returned an unexpected response",
-    ) as exc_info:
-        api_util.list_organizations_for_user_id(
-            "user-id",
-            api_root="https://api.example",
-            client_id=None,
-            client_secret=None,
-            bearer_token=SecretString("token"),
-        )
-
-    assert exc_info.value.context == {"response": response}
-
-
-@pytest.mark.parametrize(
-    ("helper", "payload", "message"),
-    [
-        pytest.param(
-            api_util.get_organization_info,
-            {"organization_id": "organization-id"},
-            "organization API returned an unexpected response",
-            id="organization",
-        ),
-        pytest.param(
-            api_util.get_workspace_organization_info,
-            {"workspace_id": "workspace-id"},
-            "workspace API returned an unexpected response",
-            id="workspace",
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "response",
-    [
-        pytest.param([], id="list"),
-        pytest.param("unexpected", id="string"),
-    ],
-)
-def test_config_info_helpers_reject_unexpected_response(
-    monkeypatch: pytest.MonkeyPatch,
-    helper: Callable[..., dict[str, Any]],
-    payload: dict[str, str],
-    message: str,
-    response: object,
-) -> None:
-    monkeypatch.setattr(
-        api_util,
-        "_make_config_api_request",
-        lambda **_: response,
-    )
-
-    with pytest.raises(AirbyteError, match=message) as exc_info:
-        helper(
-            **payload,
-            api_root="https://api.example",
-            client_id=None,
-            client_secret=None,
-            bearer_token=SecretString("token"),
-        )
-
-    assert exc_info.value.context == {"response": response}
 
 
 def test_create_workspace_forwards_request(

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -592,6 +592,53 @@ def test_list_workspaces_caps_unfiltered_api_page_size(
     ] == [(None, 1, 0)]
 
 
+def test_list_workspaces_stops_after_max_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify filtered workspace listing stops at its scan ceiling."""
+    captured_requests: list[api.ListWorkspacesRequest] = []
+    pages = [
+        _list_workspaces_response(
+            [_workspace_response("first", 1)],
+            next_page="next",
+        ),
+        _list_workspaces_response(
+            [_workspace_response("second", 2)],
+            next_page=None,
+        ),
+    ]
+
+    def list_workspaces(
+        request: api.ListWorkspacesRequest,
+    ) -> api.ListWorkspacesResponse:
+        captured_requests.append(request)
+        return pages.pop(0)
+
+    airbyte_instance = SimpleNamespace(
+        workspaces=SimpleNamespace(list_workspaces=list_workspaces),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_airbyte_server_instance",
+        lambda **_: airbyte_instance,
+    )
+
+    result = api_util.list_workspaces(
+        workspace_id="context-workspace-id",
+        api_root="https://api.airbyte.com/v1/",
+        client_id=SecretString("client-id"),
+        client_secret=SecretString("client-secret"),
+        bearer_token=None,
+        name_filter=lambda name: name == "second",
+        max_pages=1,
+    )
+
+    assert result == []
+    assert [(request.limit, request.offset) for request in captured_requests] == [
+        (100, 0)
+    ]
+
+
 @pytest.mark.parametrize("limit", [0, -1])
 def test_list_connections_rejects_invalid_limits(limit: int) -> None:
     """Verify connection list pagination rejects non-positive limits."""

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -196,6 +196,25 @@ def test_list_permissions_for_user_accepts_direct_list_response(
     assert captured["json"] == {"userId": "user-id"}
 
 
+def test_list_permissions_for_user_rejects_unexpected_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "_make_config_api_request",
+        lambda **_: "unexpected",
+    )
+
+    with pytest.raises(AirbyteError):
+        api_util.list_permissions_for_user(
+            "user-id",
+            api_root="https://api.example",
+            client_id=None,
+            client_secret=None,
+            bearer_token=SecretString("token"),
+        )
+
+
 def test_create_workspace_forwards_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -112,6 +112,90 @@ def _list_workspaces_response(
     )
 
 
+def test_get_user_id_from_bearer_token() -> None:
+    assert (
+        api_util.get_user_id_from_bearer_token(
+            SecretString("header.eyJ1c2VyX2lkIjoiYXV0aC11c2VyLWlkIn0.signature")
+        )
+        == "auth-user-id"
+    )
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "not-a-jwt",
+        "header.not-json.signature",
+    ],
+)
+def test_get_user_id_from_bearer_token_rejects_invalid_tokens(token: str) -> None:
+    with pytest.raises(PyAirbyteInputError):
+        api_util.get_user_id_from_bearer_token(SecretString(token))
+
+
+def test_get_user_id_from_bearer_token_requires_user_id() -> None:
+    with pytest.raises(PyAirbyteInputError, match="does not contain a user ID"):
+        api_util.get_user_id_from_bearer_token(
+            SecretString("header.e30.signature"),
+        )
+
+
+def test_get_user_by_auth_id_forwards_config_api_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_config_request(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"userId": "user-id"}
+
+    monkeypatch.setattr(api_util, "_make_config_api_request", fake_config_request)
+
+    result = api_util.get_user_by_auth_id(
+        "auth-user-id",
+        api_root="https://api.example",
+        config_api_root="https://config.example",
+        client_id=None,
+        client_secret=None,
+        bearer_token=SecretString("token"),
+    )
+
+    assert result == {"userId": "user-id"}
+    assert captured["path"] == "/users/get_by_auth_id"
+    assert captured["json"] == {
+        "authUserId": "auth-user-id",
+        "authProvider": "keycloak",
+    }
+    assert captured["config_api_root"] == "https://config.example"
+
+
+def test_list_permissions_for_user_accepts_direct_list_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    permissions = [
+        {"permissionType": "organization_member", "organizationId": "org-id"}
+    ]
+
+    def fake_config_request(**kwargs: object) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return permissions
+
+    monkeypatch.setattr(api_util, "_make_config_api_request", fake_config_request)
+
+    result = api_util.list_permissions_for_user(
+        "user-id",
+        api_root="https://api.example",
+        client_id=None,
+        client_secret=None,
+        bearer_token=SecretString("token"),
+    )
+
+    assert result == permissions
+    assert captured["path"] == "/permissions/list_by_user"
+    assert captured["json"] == {"userId": "user-id"}
+
+
 def test_create_workspace_forwards_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import requests
@@ -345,6 +347,55 @@ def test_list_organizations_for_user_id_rejects_unexpected_response(
     ) as exc_info:
         api_util.list_organizations_for_user_id(
             "user-id",
+            api_root="https://api.example",
+            client_id=None,
+            client_secret=None,
+            bearer_token=SecretString("token"),
+        )
+
+    assert exc_info.value.context == {"response": response}
+
+
+@pytest.mark.parametrize(
+    ("helper", "payload", "message"),
+    [
+        pytest.param(
+            api_util.get_organization_info,
+            {"organization_id": "organization-id"},
+            "organization API returned an unexpected response",
+            id="organization",
+        ),
+        pytest.param(
+            api_util.get_workspace_organization_info,
+            {"workspace_id": "workspace-id"},
+            "workspace API returned an unexpected response",
+            id="workspace",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param([], id="list"),
+        pytest.param("unexpected", id="string"),
+    ],
+)
+def test_config_info_helpers_reject_unexpected_response(
+    monkeypatch: pytest.MonkeyPatch,
+    helper: Callable[..., dict[str, Any]],
+    payload: dict[str, str],
+    message: str,
+    response: object,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "_make_config_api_request",
+        lambda **_: response,
+    )
+
+    with pytest.raises(AirbyteError, match=message) as exc_info:
+        helper(
+            **payload,
             api_root="https://api.example",
             client_id=None,
             client_secret=None,

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -169,6 +169,38 @@ def test_get_user_by_auth_id_forwards_config_api_request(
     assert captured["config_api_root"] == "https://config.example"
 
 
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param([], id="list"),
+        pytest.param("unexpected", id="string"),
+    ],
+)
+def test_get_user_by_auth_id_rejects_unexpected_response(
+    monkeypatch: pytest.MonkeyPatch,
+    response: object,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "_make_config_api_request",
+        lambda **_: response,
+    )
+
+    with pytest.raises(
+        AirbyteError,
+        match="user API returned an unexpected response",
+    ) as exc_info:
+        api_util.get_user_by_auth_id(
+            "auth-user-id",
+            api_root="https://api.example",
+            client_id=None,
+            client_secret=None,
+            bearer_token=SecretString("token"),
+        )
+
+    assert exc_info.value.context == {"response": response}
+
+
 def test_list_permissions_for_user_accepts_direct_list_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -288,6 +320,38 @@ def test_list_organizations_for_user_id_paginates_and_forwards_filters(
     }
     assert requests[1]["pagination"] == {"pageSize": 100, "rowOffset": 100}
     assert len(requests) == request_count
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param([], id="list"),
+        pytest.param({"organizations": {}}, id="non-list-organizations"),
+    ],
+)
+def test_list_organizations_for_user_id_rejects_unexpected_response(
+    monkeypatch: pytest.MonkeyPatch,
+    response: object,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "_make_config_api_request",
+        lambda **_: response,
+    )
+
+    with pytest.raises(
+        AirbyteError,
+        match="organizations API returned an unexpected response",
+    ) as exc_info:
+        api_util.list_organizations_for_user_id(
+            "user-id",
+            api_root="https://api.example",
+            client_id=None,
+            client_secret=None,
+            bearer_token=SecretString("token"),
+        )
+
+    assert exc_info.value.context == {"response": response}
 
 
 def test_create_workspace_forwards_request(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -937,6 +937,36 @@ def test_cloud_client_config_org_listing_reuses_authenticated_bearer_token(
     assert token_calls == 1
 
 
+def test_cloud_client_config_lookups_reuse_authenticated_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issued_token = SecretString("issued-token")
+    token_calls = 0
+    captured_bearer_tokens: list[object] = []
+
+    def fake_get_bearer_token(**_: object) -> SecretString:
+        nonlocal token_calls
+        token_calls += 1
+        return issued_token
+
+    def fake_get_organization_info(**kwargs: object) -> dict[str, object]:
+        captured_bearer_tokens.append(kwargs["bearer_token"])
+        return {
+            "organizationId": "organization-id",
+            "organizationName": "Organization",
+        }
+
+    monkeypatch.setattr(api_util, "get_bearer_token", fake_get_bearer_token)
+    monkeypatch.setattr(api_util, "get_organization_info", fake_get_organization_info)
+
+    client = CloudClient(client_id="client-id", client_secret="client-secret")
+    client.get_organization(organization_id="organization-id")
+    client.get_organization(organization_id="organization-id")
+
+    assert captured_bearer_tokens == [issued_token, issued_token]
+    assert token_calls == 1
+
+
 def test_cloud_client_get_organization_requires_context_without_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import NoReturn
+
 import pytest
 from airbyte_api import models
 
@@ -18,6 +21,13 @@ from airbyte.exceptions import (
 )
 from airbyte.mcp import cloud as mcp_cloud
 from airbyte.secrets.base import SecretString
+
+
+def _raise(error: Exception) -> Callable[..., NoReturn]:
+    def _raiser(*_args: object, **_kwargs: object) -> NoReturn:
+        raise error
+
+    return _raiser
 
 
 def _patch_workspace_discovery(
@@ -267,15 +277,13 @@ def test_cloud_client_list_workspaces_handles_ambient_resolution_failures(
         monkeypatch.setattr(
             client,
             "_get_membership_organization_ids",
-            lambda: (_ for _ in ()).throw(AirbyteError(message="membership failed")),
+            _raise(AirbyteError(message="membership failed")),
         )
     else:
         monkeypatch.setattr(
             client,
             "_get_workspace_parent_organization_id",
-            lambda _: (_ for _ in ()).throw(
-                PyAirbyteInputError(message="workspace lookup failed")
-            ),
+            _raise(PyAirbyteInputError(message="workspace lookup failed")),
         )
         monkeypatch.setattr(client, "_get_membership_organization_ids", lambda: ())
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
@@ -840,9 +848,7 @@ def test_cloud_client_default_organization_handles_resolution_failures(
         monkeypatch.setattr(
             client,
             "_get_workspace_parent_organization_id",
-            lambda _: (_ for _ in ()).throw(
-                PyAirbyteInputError(message="workspace lookup failed")
-            ),
+            _raise(PyAirbyteInputError(message="workspace lookup failed")),
         )
         monkeypatch.setattr(
             client,
@@ -853,7 +859,7 @@ def test_cloud_client_default_organization_handles_resolution_failures(
         monkeypatch.setattr(
             client,
             "_get_membership_organization_ids",
-            lambda: (_ for _ in ()).throw(AirbyteError(message="membership failed")),
+            _raise(AirbyteError(message="membership failed")),
         )
 
     assert client._resolve_default_organization_id() == expected_id

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -679,7 +679,7 @@ def test_cloud_client_get_organization_uses_unbounded_organization_list(
                 )
             ],
             1,
-            "capped",
+            None,
             id="single-organization",
         ),
         pytest.param(
@@ -696,7 +696,7 @@ def test_cloud_client_get_organization_uses_unbounded_organization_list(
                 ),
             ],
             2,
-            "capped",
+            None,
             id="multiple-organizations",
         ),
         pytest.param(
@@ -803,7 +803,7 @@ def test_mcp_list_cloud_workspaces_discovery(
     else:
         assert result.workspaces[0].workspace_id == "workspace-id"
         assert result.workspaces[1].organization_id is None
-        assert "capped at 100" in (result.message or "")
+        assert result.message is None
 
 
 def test_mcp_list_cloud_organizations_forwards_filter_and_limit(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -168,24 +168,44 @@ def test_cloud_client_list_workspaces_forwards_limit(
 def test_cloud_client_list_workspaces_applies_name_contains_to_non_org_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured_filter = None
+    captured: dict[str, object] = {}
 
     def fake_list_workspaces(
-        *,
-        name_filter: object = None,
-        **_: object,
-    ) -> list[object]:
-        nonlocal captured_filter
-        captured_filter = name_filter
-        return []
+        **kwargs: object,
+    ) -> list[models.WorkspaceResponse]:
+        captured.update(kwargs)
+        return [
+            models.WorkspaceResponse(
+                data_residency="auto",
+                name="target-one",
+                notifications=models.NotificationsConfig(),
+                workspace_id="workspace-target-one",
+            ),
+            models.WorkspaceResponse(
+                data_residency="auto",
+                name="other",
+                notifications=models.NotificationsConfig(),
+                workspace_id="workspace-other",
+            ),
+            models.WorkspaceResponse(
+                data_residency="auto",
+                name="target-two",
+                notifications=models.NotificationsConfig(),
+                workspace_id="workspace-target-two",
+            ),
+        ]
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
-    CloudClient(bearer_token="token").list_workspaces(name_contains="target")
+    result = CloudClient(bearer_token="token").list_workspaces(
+        name_contains="target",
+        limit=1,
+    )
 
-    assert captured_filter is not None
-    assert captured_filter("a-target-workspace")
-    assert not captured_filter("other-workspace")
+    assert captured.get("name") is None
+    assert captured.get("name_filter") is None
+    assert captured["limit"] == 100
+    assert [workspace.name for workspace in result] == ["target-one"]
 
 
 def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before_limit(
@@ -641,15 +661,9 @@ def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
 
     client.list_workspaces()
     assert captured["limit"] == 100
-    assert captured["max_pages"] is None
-
-    client.list_workspaces(name_contains="target", limit=10)
-    assert captured["limit"] == 10
-    assert captured["max_pages"] == 1
 
     client.list_workspaces(name_filter=lambda _: True)
     assert captured["limit"] is None
-    assert captured["max_pages"] is None
 
 
 def test_cloud_client_get_organization_uses_unbounded_organization_list(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -889,6 +889,54 @@ def test_cloud_client_list_organizations_falls_back_to_public_listing(
     ]
 
 
+def test_cloud_client_config_org_listing_reuses_authenticated_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issued_token = SecretString("issued-token")
+    token_calls = 0
+    captured_bearer_token: object = None
+
+    def fake_get_bearer_token(**_: object) -> SecretString:
+        nonlocal token_calls
+        token_calls += 1
+        return issued_token
+
+    def fake_list_organizations_for_user_id(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        nonlocal captured_bearer_token
+        captured_bearer_token = kwargs["bearer_token"]
+        return [{"organizationId": "organization-id"}]
+
+    monkeypatch.setattr(api_util, "get_bearer_token", fake_get_bearer_token)
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user_id",
+        fake_list_organizations_for_user_id,
+    )
+
+    result = CloudClient(
+        client_id="client-id",
+        client_secret="client-secret",
+    ).list_organizations(limit=1)
+
+    assert [organization.organization_id for organization in result] == [
+        "organization-id"
+    ]
+    assert captured_bearer_token is issued_token
+    assert token_calls == 1
+
+
 def test_cloud_client_get_organization_requires_context_without_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1526,6 +1574,8 @@ def test_mcp_list_cloud_workspaces_discovery(
     else:
         assert result.workspaces[0].workspace_id == "workspace-id"
         assert result.workspaces[1].organization_id is None
+        assert result.workspaces[0].organization_name == "Organization"
+        assert result.workspaces[1].organization_name is None
         assert (
             result.message
             == "Resolved organization Organization (organization-id) for these credentials."

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -966,9 +966,11 @@ def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candida
     }
 
 
-def test_cloud_client_list_workspaces_rejects_missing_membership(
+def test_cloud_client_list_workspaces_falls_back_to_all_organizations_without_membership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    captured: dict[str, object] = {}
+
     monkeypatch.setattr(
         api_util,
         "get_user_id_from_bearer_token",
@@ -981,8 +983,24 @@ def test_cloud_client_list_workspaces_rejects_missing_membership(
     )
     monkeypatch.setattr(api_util, "list_permissions_for_user", lambda *_, **__: [])
 
-    with pytest.raises(PyAirbyteInputError, match="No organization membership"):
-        CloudClient(bearer_token="token").list_workspaces()
+    def fake_list_workspaces(**kwargs: object) -> list[models.WorkspaceResponse]:
+        captured.update(kwargs)
+        return [
+            models.WorkspaceResponse(
+                data_residency="auto",
+                name="Workspace",
+                notifications=models.NotificationsConfig(),
+                workspace_id="workspace-id",
+            )
+        ]
+
+    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
+
+    result = CloudClient(bearer_token="token").list_workspaces()
+
+    assert captured["workspace_id"] == ""
+    assert captured["limit"] is None
+    assert [workspace.workspace_id for workspace in result] == ["workspace-id"]
 
 
 def test_cloud_client_list_workspaces_all_organizations_is_explicit(
@@ -1030,7 +1048,6 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
         organization_name=None,
         name_contains=None,
         limit=None,
-        all_organizations=False,
     )
 
     assert result.workspaces == []
@@ -1061,7 +1078,6 @@ def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(
         organization_name=None,
         name_contains=None,
         limit=None,
-        all_organizations=False,
     )
 
     assert result.candidate_organizations == []
@@ -1214,7 +1230,6 @@ def test_mcp_list_cloud_workspaces_discovery(
         organization_name=None,
         name_contains=None,
         limit=None,
-        all_organizations=False,
     )
 
     assert captured_organization_id is None

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -874,16 +874,14 @@ def test_cloud_client_list_workspaces_resolves_organization_context(
 def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured = _patch_workspace_discovery(
-        monkeypatch,
-        permissions=[
-            {"permissionType": "instance_admin"},
-            {
-                "permissionType": "organization_member",
-                "organizationId": "organization-id",
-            },
-        ],
-    )
+    permissions: list[dict[str, object]] = [
+        {"permissionType": "instance_admin"},
+        {
+            "permissionType": "organization_member",
+            "organizationId": "organization-id",
+        },
+    ]
+    captured = _patch_workspace_discovery(monkeypatch, permissions=permissions)
     calls = {"user": 0, "permissions": 0}
 
     def fake_get_user_by_auth_id(*_: object, **__: object) -> dict[str, object]:
@@ -894,13 +892,7 @@ def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
         *_: object, **__: object
     ) -> list[dict[str, object]]:
         calls["permissions"] += 1
-        return [
-            {"permissionType": "instance_admin"},
-            {
-                "permissionType": "organization_member",
-                "organizationId": "organization-id",
-            },
-        ]
+        return permissions
 
     monkeypatch.setattr(api_util, "get_user_by_auth_id", fake_get_user_by_auth_id)
     monkeypatch.setattr(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -647,6 +647,10 @@ def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
     assert captured["limit"] == 10
     assert captured["max_pages"] == 1
 
+    client.list_workspaces(name_filter=lambda _: True)
+    assert captured["limit"] is None
+    assert captured["max_pages"] is None
+
 
 def test_cloud_client_get_organization_uses_unbounded_organization_list(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -664,15 +664,54 @@ def test_cloud_client_list_workspaces_keeps_explicit_lookup_unbounded(
 ) -> None:
     captured: dict[str, object] = {}
 
-    def fake_list_workspaces(**kwargs: object) -> list[object]:
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
         captured.update(kwargs)
-        return []
+        return [
+            {"workspaceId": f"workspace-{index}", "name": f"Workspace {index}"}
+            for index in range(101)
+        ]
 
-    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_permissions_for_user",
+        lambda *_, **__: [
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-id",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces",
+        lambda **_: pytest.fail("implicit cross-organization lookup is not allowed"),
+    )
     client = CloudClient(bearer_token="token")
 
-    client.list_workspaces(name_filter=lambda _: True)
+    result = client.list_workspaces(
+        name_filter=lambda _: True,
+    )
+
+    assert captured["organization_id"] == "organization-id"
     assert captured["limit"] is None
+    assert len(result) == 101
 
 
 def test_cloud_client_list_workspaces_resolves_explicit_workspace_parent(
@@ -872,13 +911,23 @@ def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candida
         ],
     )
 
+    def fake_get_organization_info(**kwargs: object) -> dict[str, object]:
+        if kwargs["organization_id"] == "organization-2":
+            raise AirbyteError(message="Forbidden")
+        return {"organizationName": "Organization 1"}
+
+    monkeypatch.setattr(api_util, "get_organization_info", fake_get_organization_info)
+
     with pytest.raises(PyAirbyteInputError) as exc_info:
         CloudClient(bearer_token="token").list_workspaces()
 
     assert exc_info.value.context == {
         "organization_ids": ["organization-1", "organization-2"],
         "organization_candidates": [
-            {"organization_id": "organization-1", "organization_name": None},
+            {
+                "organization_id": "organization-1",
+                "organization_name": "Organization 1",
+            },
             {"organization_id": "organization-2", "organization_name": None},
         ],
     }

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -224,6 +224,72 @@ def test_cloud_client_list_workspaces_forwards_limit(
 
 
 @pytest.mark.parametrize(
+    ("client_kwargs", "request_kwargs", "failure", "expected_message"),
+    [
+        pytest.param(
+            {},
+            {},
+            "membership",
+            None,
+            id="membership-failure-falls-back",
+        ),
+        pytest.param(
+            {"workspace_id": "configured-workspace-id"},
+            {},
+            "workspace-parent",
+            None,
+            id="configured-workspace-parent-failure-falls-back",
+        ),
+        pytest.param(
+            {},
+            {"workspace_id": "explicit-workspace-id"},
+            "workspace-parent",
+            "workspace lookup failed",
+            id="explicit-workspace-failure-propagates",
+        ),
+    ],
+)
+def test_cloud_client_list_workspaces_handles_ambient_resolution_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    client_kwargs: dict[str, str],
+    request_kwargs: dict[str, str],
+    failure: str,
+    expected_message: str | None,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_list_workspaces(**kwargs: object) -> list[object]:
+        captured.update(kwargs)
+        return []
+
+    client = CloudClient(bearer_token="token", **client_kwargs)
+    if failure == "membership":
+        monkeypatch.setattr(
+            client,
+            "_get_membership_organization_ids",
+            lambda: (_ for _ in ()).throw(AirbyteError(message="membership failed")),
+        )
+    else:
+        monkeypatch.setattr(
+            client,
+            "_get_workspace_parent_organization_id",
+            lambda _: (_ for _ in ()).throw(
+                PyAirbyteInputError(message="workspace lookup failed")
+            ),
+        )
+        monkeypatch.setattr(client, "_get_membership_organization_ids", lambda: ())
+    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
+
+    if expected_message is None:
+        assert client.list_workspaces(**request_kwargs) == []
+        assert captured["workspace_id"] == ""
+    else:
+        with pytest.raises(PyAirbyteInputError, match=expected_message):
+            client.list_workspaces(**request_kwargs)
+        assert captured == {}
+
+
+@pytest.mark.parametrize(
     ("request_kwargs", "expected_message"),
     [
         pytest.param(
@@ -743,6 +809,56 @@ def test_cloud_client_get_organization_rejects_ambiguous_default_context(
     assert error.context["total_candidates"] == 12
 
 
+@pytest.mark.parametrize(
+    ("client_kwargs", "failure", "membership_ids", "expected_id"),
+    [
+        pytest.param(
+            {"workspace_id": "configured-workspace"},
+            "workspace-parent",
+            ("membership-org",),
+            "membership-org",
+            id="workspace-parent-failure-falls-back-to-membership",
+        ),
+        pytest.param(
+            {},
+            "membership",
+            (),
+            None,
+            id="membership-failure-falls-back-to-no-organization",
+        ),
+    ],
+)
+def test_cloud_client_default_organization_handles_resolution_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    client_kwargs: dict[str, str],
+    failure: str,
+    membership_ids: tuple[str, ...],
+    expected_id: str | None,
+) -> None:
+    client = CloudClient(bearer_token="token", **client_kwargs)
+    if failure == "workspace-parent":
+        monkeypatch.setattr(
+            client,
+            "_get_workspace_parent_organization_id",
+            lambda _: (_ for _ in ()).throw(
+                PyAirbyteInputError(message="workspace lookup failed")
+            ),
+        )
+        monkeypatch.setattr(
+            client,
+            "_get_membership_organization_ids",
+            lambda: membership_ids,
+        )
+    else:
+        monkeypatch.setattr(
+            client,
+            "_get_membership_organization_ids",
+            lambda: (_ for _ in ()).throw(AirbyteError(message="membership failed")),
+        )
+
+    assert client._resolve_default_organization_id() == expected_id
+
+
 def test_cloud_client_get_organization_uses_single_config_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -832,6 +948,7 @@ def test_cloud_client_list_organizations_uses_config_api_for_filter_or_limit(
     name_contains: str | None,
     expected_ids: list[str],
 ) -> None:
+    captured: dict[str, object] = {}
     organizations = [
         models.OrganizationResponse(
             organization_id="organization-id-1",
@@ -849,17 +966,33 @@ def test_cloud_client_list_organizations_uses_config_api_for_filter_or_limit(
             email="three@example.com",
         ),
     ]
-    monkeypatch.setattr(
-        api_util,
-        "list_organizations_for_user_id",
-        lambda **kwargs: [
+
+    def fake_list_organizations_for_user_id(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        filtered = organizations
+        if kwargs["name_contains"] is not None:
+            name_substring = str(kwargs["name_contains"]).casefold()
+            filtered = [
+                organization
+                for organization in filtered
+                if name_substring in (organization.organization_name or "").casefold()
+            ]
+        limit = kwargs["limit"]
+        return [
             {
                 "organizationId": organization.organization_id,
                 "organizationName": organization.organization_name,
                 "email": organization.email,
             }
-            for organization in organizations[: kwargs["limit"]]
-        ],
+            for organization in filtered[: limit if isinstance(limit, int) else None]
+        ]
+
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user_id",
+        fake_list_organizations_for_user_id,
     )
     monkeypatch.setattr(
         api_util, "get_user_id_from_bearer_token", lambda _: "auth-user-id"
@@ -874,6 +1007,8 @@ def test_cloud_client_list_organizations_uses_config_api_for_filter_or_limit(
     )
 
     assert [organization.organization_id for organization in result] == expected_ids
+    assert captured["name_contains"] == name_contains
+    assert captured["limit"] == 1
 
 
 def test_cloud_client_list_organizations_falls_back_to_public_listing(
@@ -1091,8 +1226,8 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
     ),
     [
         pytest.param(
-            {"workspace_id": "workspace-id"},
-            {"limit": 3},
+            {},
+            {"limit": 3, "workspace_id": "workspace-id"},
             None,
             "parent-organization-id",
             "parent-organization-id",
@@ -1560,7 +1695,7 @@ def test_mcp_list_cloud_organizations_preserves_missing_details(
 
 
 @pytest.mark.parametrize(
-    ("workspaces_or_error", "expect_message"),
+    ("workspaces_or_error", "expect_message", "organization_name"),
     [
         pytest.param(
             [
@@ -1576,16 +1711,36 @@ def test_mcp_list_cloud_organizations_preserves_missing_details(
                 ),
             ],
             False,
+            "Organization",
             id="org-less-public-api",
+        ),
+        pytest.param(
+            [
+                CloudWorkspaceInfo(
+                    workspaceId="workspace-id",
+                    name="Workspace",
+                    organizationId="organization-id",
+                ),
+                CloudWorkspaceInfo(
+                    workspaceId="workspace-without-org",
+                    name="Workspace without organization",
+                    organizationId=None,
+                ),
+            ],
+            False,
+            None,
+            id="org-less-public-api-without-organization-name",
         ),
         pytest.param(
             AirbyteError(context={"status_code": 401}),
             True,
+            None,
             id="unauthorized",
         ),
         pytest.param(
             AirbyteError(context={"status_code": 403}),
             True,
+            None,
             id="forbidden",
         ),
     ],
@@ -1594,6 +1749,7 @@ def test_mcp_list_cloud_workspaces_discovery(
     monkeypatch: pytest.MonkeyPatch,
     workspaces_or_error: list[CloudWorkspaceInfo] | AirbyteError,
     expect_message: bool,
+    organization_name: str | None,
 ) -> None:
     captured_organization_id: str | None = "unset"
 
@@ -1612,7 +1768,7 @@ def test_mcp_list_cloud_workspaces_discovery(
         def get_organization(self, *, organization_id: str) -> CloudOrganization:
             return CloudOrganization(
                 organization_id=organization_id,
-                organization_name="Organization",
+                organization_name=organization_name,
             )
 
     monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
@@ -1632,11 +1788,12 @@ def test_mcp_list_cloud_workspaces_discovery(
     else:
         assert result.workspaces[0].workspace_id == "workspace-id"
         assert result.workspaces[1].organization_id is None
-        assert result.workspaces[0].organization_name == "Organization"
+        assert result.workspaces[0].organization_name == organization_name
         assert result.workspaces[1].organization_name is None
-        assert (
-            result.message
-            == "Resolved organization Organization (organization-id) for these credentials."
+        assert result.message == (
+            "Resolved organization Organization (organization-id) for these credentials."
+            if organization_name is not None
+            else "Resolved organization organization-id for these credentials."
         )
 
 

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1051,12 +1051,16 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
     )
 
     assert result.workspaces == []
-    assert result.candidate_organizations is not None
-    assert [candidate.id for candidate in result.candidate_organizations] == [
+    assert result.available_organizations is not None
+    assert all(
+        isinstance(candidate, mcp_cloud.CloudOrganizationResult)
+        for candidate in result.available_organizations
+    )
+    assert [candidate.id for candidate in result.available_organizations] == [
         "organization-1",
         "organization-2",
     ]
-    assert result.candidate_organizations[1].name == "Organization 2"
+    assert result.available_organizations[1].name == "Organization 2"
     assert "Retry with one of the candidate organization IDs." in (result.message or "")
 
 
@@ -1080,7 +1084,7 @@ def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(
         limit=None,
     )
 
-    assert result.candidate_organizations == []
+    assert result.available_organizations == []
     assert result.message == "No organization membership was found."
 
 
@@ -1170,6 +1174,26 @@ def test_mcp_list_cloud_organizations_discovery(
         assert expected_message in (result.message or "")
     else:
         assert result.message is None
+
+
+def test_mcp_list_cloud_organizations_preserves_missing_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DiscoveryClient:
+        def list_organizations(self, **_: object) -> list[CloudOrganization]:
+            return [CloudOrganization(organization_id="organization-id")]
+
+    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
+
+    result = mcp_cloud.list_cloud_organizations(None)
+
+    assert result.organizations == [
+        mcp_cloud.CloudOrganizationResult(
+            id="organization-id",
+            name=None,
+            email=None,
+        )
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -571,6 +571,27 @@ def test_cloud_client_list_organizations_filters_case_insensitively_and_limits(
     ]
 
 
+def test_cloud_client_list_organizations_applies_default_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organizations = [
+        models.OrganizationResponse(
+            organization_id=f"organization-id-{index}",
+            organization_name=f"Organization {index}",
+            email=f"test-{index}@example.com",
+        )
+        for index in range(101)
+    ]
+    monkeypatch.setattr(
+        api_util, "list_organizations_for_user", lambda **_: organizations
+    )
+
+    result = CloudClient(bearer_token="token").list_organizations()
+
+    assert len(result) == 100
+    assert result[-1].organization_id == "organization-id-99"
+
+
 def test_cloud_client_list_organizations_reports_ambiguity_candidates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -583,7 +604,7 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         for index in range(11)
     ]
     client = CloudClient(bearer_token="token")
-    monkeypatch.setattr(client, "list_organizations", lambda: organizations)
+    monkeypatch.setattr(client, "_fetch_organizations", lambda: organizations)
 
     with pytest.raises(PyAirbyteInputError) as exc_info:
         client.get_organization(organization_name="Duplicate")
@@ -627,7 +648,7 @@ def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
     assert captured["max_pages"] == 1
 
 
-def test_cloud_client_get_organization_reuses_list_organizations(
+def test_cloud_client_get_organization_uses_unbounded_organization_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     organizations = [
@@ -638,7 +659,7 @@ def test_cloud_client_get_organization_reuses_list_organizations(
         )
     ]
     client = CloudClient(bearer_token="token")
-    monkeypatch.setattr(client, "list_organizations", lambda: organizations)
+    monkeypatch.setattr(client, "_fetch_organizations", lambda: organizations)
 
     result = client.get_organization(organization_id="organization-id")
 
@@ -658,7 +679,7 @@ def test_cloud_client_get_organization_reuses_list_organizations(
                 )
             ],
             1,
-            None,
+            "capped",
             id="single-organization",
         ),
         pytest.param(
@@ -675,7 +696,7 @@ def test_cloud_client_get_organization_reuses_list_organizations(
                 ),
             ],
             2,
-            None,
+            "capped",
             id="multiple-organizations",
         ),
         pytest.param(
@@ -754,6 +775,8 @@ def test_mcp_list_cloud_workspaces_discovery(
     captured_organization_id: str | None = "unset"
 
     class DiscoveryClient:
+        organization_id: str | None = None
+
         def list_workspaces(
             self, *, organization_id: str | None = None, **_: object
         ) -> list[CloudWorkspaceInfo]:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -537,6 +537,96 @@ def test_cloud_client_list_organizations_returns_typed_resources(
     ]
 
 
+def test_cloud_client_list_organizations_filters_case_insensitively_and_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organizations = [
+        models.OrganizationResponse(
+            organization_id="organization-id-1",
+            organization_name="Development",
+            email="one@example.com",
+        ),
+        models.OrganizationResponse(
+            organization_id="organization-id-2",
+            organization_name="development-copy",
+            email="two@example.com",
+        ),
+        models.OrganizationResponse(
+            organization_id="organization-id-3",
+            organization_name="Production",
+            email="three@example.com",
+        ),
+    ]
+    monkeypatch.setattr(
+        api_util, "list_organizations_for_user", lambda **_: organizations
+    )
+
+    result = CloudClient(bearer_token="token").list_organizations(
+        name_contains="DEVELOP",
+        limit=1,
+    )
+
+    assert [organization.organization_id for organization in result] == [
+        "organization-id-1"
+    ]
+
+
+def test_cloud_client_list_organizations_reports_ambiguity_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organizations = [
+        CloudOrganization(
+            organization_id=f"organization-id-{index}",
+            organization_name="Duplicate",
+            email=f"test-{index}@example.com",
+        )
+        for index in range(11)
+    ]
+    client = CloudClient(bearer_token="token")
+    monkeypatch.setattr(client, "list_organizations", lambda: organizations)
+
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        client.get_organization(organization_name="Duplicate")
+
+    error = exc_info.value
+    assert "showing 10 of 11" in str(error)
+    assert "organization-id-0" in str(error)
+    assert "test-0@example.com" in str(error)
+    assert "organization-id-10" not in str(error)
+    assert error.context == {
+        "organization_name": "Duplicate",
+        "matching_organizations": [
+            {
+                "organization_id": f"organization-id-{index}",
+                "email": f"test-{index}@example.com",
+            }
+            for index in range(10)
+        ],
+        "total_matches": 11,
+    }
+
+
+def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_list_workspaces(**kwargs: object) -> list[object]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
+    client = CloudClient(bearer_token="token")
+
+    client.list_workspaces()
+    assert captured["limit"] == 100
+    assert captured["max_pages"] is None
+
+    client.list_workspaces(name_contains="target", limit=10)
+    assert captured["limit"] == 10
+    assert captured["max_pages"] == 1
+
+
 def test_cloud_client_get_organization_reuses_list_organizations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -609,7 +699,7 @@ def test_mcp_list_cloud_organizations_discovery(
     expected_message: str | None,
 ) -> None:
     class DiscoveryClient:
-        def list_organizations(self) -> list[CloudOrganization]:
+        def list_organizations(self, **_: object) -> list[CloudOrganization]:
             if isinstance(organizations_or_error, AirbyteError):
                 raise organizations_or_error
             return organizations_or_error
@@ -690,7 +780,36 @@ def test_mcp_list_cloud_workspaces_discovery(
     else:
         assert result.workspaces[0].workspace_id == "workspace-id"
         assert result.workspaces[1].organization_id is None
-        assert result.message is None
+        assert "capped at 100" in (result.message or "")
+
+
+def test_mcp_list_cloud_organizations_forwards_filter_and_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class DiscoveryClient:
+        def list_organizations(self, **kwargs: object) -> list[CloudOrganization]:
+            captured.update(kwargs)
+            return [
+                CloudOrganization(
+                    organization_id="organization-id",
+                    organization_name="Development",
+                    email="test@example.com",
+                )
+            ]
+
+    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
+
+    result = mcp_cloud.list_cloud_organizations(
+        None,
+        name_contains="develop",
+        limit=1,
+    )
+
+    assert captured == {"name_contains": "develop", "limit": 1}
+    assert len(result.organizations) == 1
+    assert "capped at 1" in (result.message or "")
 
 
 def test_mcp_resolve_organization_id_skips_lookup_when_id_provided() -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -209,7 +209,7 @@ def test_cloud_client_list_workspaces_applies_name_contains_to_all_org_results(
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
     result = CloudClient(bearer_token="token").list_workspaces(
-        name_contains="target",
+        name_contains="TARGET",
         limit=1,
         all_organizations=True,
     )
@@ -256,6 +256,39 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
     assert all(isinstance(workspace, CloudWorkspaceInfo) for workspace in result)
     assert [workspace.name for workspace in result] == ["target-one"]
     assert [workspace.workspace_id for workspace in result] == ["workspace-target-one"]
+
+
+def test_cloud_client_list_workspaces_matches_exact_name_after_server_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return [
+            {"name": "Production-old", "workspaceId": "workspace-production-old"},
+            {"name": "Prod", "workspaceId": "workspace-prod"},
+        ]
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    result = CloudClient(
+        bearer_token="token",
+        organization_id="organization-id",
+    ).list_workspaces(
+        name="Prod",
+        limit=1,
+    )
+
+    assert captured["name_contains"] == "Prod"
+    assert captured["limit"] is None
+    assert [workspace.name for workspace in result] == ["Prod"]
 
 
 def test_cloud_client_create_workspace_uses_default_organization_id(
@@ -1008,6 +1041,33 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
         "organization-2",
     ]
     assert result.candidate_organizations[1].name == "Organization 2"
+    assert "Retry with one of the candidate organization IDs." in (result.message or "")
+
+
+def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DiscoveryClient:
+        def list_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
+            raise PyAirbyteInputError(
+                message="No organization membership was found.",
+                context={"organization_candidates": []},
+            )
+
+    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
+
+    result = mcp_cloud.list_cloud_workspaces(
+        None,
+        organization_id=None,
+        organization_name=None,
+        name_contains=None,
+        limit=None,
+        workspace_id=None,
+        all_organizations=False,
+    )
+
+    assert result.candidate_organizations == []
+    assert result.message == "No organization membership was found."
 
 
 def test_cloud_client_get_organization_uses_unbounded_organization_list(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1061,7 +1061,10 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
         "organization-2",
     ]
     assert result.available_organizations[1].name == "Organization 2"
-    assert "Retry with one of the candidate organization IDs." in (result.message or "")
+    assert (
+        "Retry with an explicit organization ID from the provided list of the "
+        "available organizations." in (result.message or "")
+    )
 
 
 def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1061,6 +1061,24 @@ def test_mcp_list_cloud_workspaces_reports_available_organizations(
         assert result.message == "No organization membership was found."
 
 
+def test_mcp_get_cloud_client_uses_configured_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = {
+        mcp_cloud.MCP_CONFIG_BEARER_TOKEN: "token",
+        mcp_cloud.MCP_CONFIG_WORKSPACE_ID: "workspace-id",
+    }
+    monkeypatch.setattr(
+        mcp_cloud,
+        "get_mcp_config",
+        lambda _, key: config.get(key),
+    )
+
+    client = mcp_cloud._get_cloud_client(None)
+
+    assert client.default_workspace_id == "workspace-id"
+
+
 def test_cloud_client_get_organization_uses_unbounded_organization_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -160,12 +160,15 @@ def test_cloud_client_list_workspaces_forwards_limit(
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
-    CloudClient(bearer_token="token").list_workspaces(limit=3)
+    CloudClient(bearer_token="token").list_workspaces(
+        limit=3,
+        all_organizations=True,
+    )
 
     assert captured_limit == 3
 
 
-def test_cloud_client_list_workspaces_applies_name_contains_to_non_org_results(
+def test_cloud_client_list_workspaces_applies_name_contains_to_all_org_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -174,7 +177,7 @@ def test_cloud_client_list_workspaces_applies_name_contains_to_non_org_results(
         **kwargs: object,
     ) -> list[models.WorkspaceResponse]:
         captured.update(kwargs)
-        return [
+        workspaces = [
             models.WorkspaceResponse(
                 data_residency="auto",
                 name="target-one",
@@ -194,17 +197,26 @@ def test_cloud_client_list_workspaces_applies_name_contains_to_non_org_results(
                 workspace_id="workspace-target-two",
             ),
         ]
+        workspace_filter = kwargs["name_filter"]
+        assert callable(workspace_filter)
+        matching_workspaces = [
+            workspace for workspace in workspaces if workspace_filter(workspace.name)
+        ]
+        return matching_workspaces[
+            : kwargs["limit"] if isinstance(kwargs["limit"], int) else None
+        ]
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
     result = CloudClient(bearer_token="token").list_workspaces(
         name_contains="target",
         limit=1,
+        all_organizations=True,
     )
 
     assert captured.get("name") is None
-    assert captured.get("name_filter") is None
-    assert captured["limit"] == 100
+    assert callable(captured["name_filter"])
+    assert captured["limit"] == 1
     assert [workspace.name for workspace in result] == ["target-one"]
 
 
@@ -591,7 +603,7 @@ def test_cloud_client_list_organizations_filters_case_insensitively_and_limits(
     ]
 
 
-def test_cloud_client_list_organizations_applies_default_limit(
+def test_cloud_client_list_organizations_has_no_default_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     organizations = [
@@ -608,8 +620,8 @@ def test_cloud_client_list_organizations_applies_default_limit(
 
     result = CloudClient(bearer_token="token").list_organizations()
 
-    assert len(result) == 100
-    assert result[-1].organization_id == "organization-id-99"
+    assert len(result) == 101
+    assert result[-1].organization_id == "organization-id-100"
 
 
 def test_cloud_client_list_organizations_reports_ambiguity_candidates(
@@ -647,7 +659,7 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
     }
 
 
-def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
+def test_cloud_client_list_workspaces_keeps_explicit_lookup_unbounded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -659,11 +671,294 @@ def test_cloud_client_list_workspaces_bounds_cross_organization_discovery(
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
     client = CloudClient(bearer_token="token")
 
-    client.list_workspaces()
-    assert captured["limit"] == 100
-
     client.list_workspaces(name_filter=lambda _: True)
     assert captured["limit"] is None
+
+
+def test_cloud_client_list_workspaces_resolves_explicit_workspace_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        api_util,
+        "get_workspace_organization_info",
+        lambda **_: {"organizationId": "parent-organization-id"},
+    )
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    CloudClient(bearer_token="token").list_workspaces(workspace_id="workspace-id")
+
+    assert captured["organization_id"] == "parent-organization-id"
+
+
+def test_cloud_client_list_workspaces_uses_configured_organization_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    CloudClient(
+        bearer_token="token",
+        organization_id="configured-organization-id",
+    ).list_workspaces()
+
+    assert captured["organization_id"] == "configured-organization-id"
+
+
+def test_cloud_client_list_workspaces_resolves_configured_workspace_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        api_util,
+        "get_workspace_organization_info",
+        lambda **_: {"organizationId": "parent-organization-id"},
+    )
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    CloudClient(
+        bearer_token="token",
+        workspace_id="configured-workspace-id",
+    ).list_workspaces()
+
+    assert captured["organization_id"] == "parent-organization-id"
+
+
+def test_cloud_client_list_workspaces_prefers_configured_organization_over_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fail_workspace_lookup(**_: object) -> dict[str, object]:
+        pytest.fail("configured organization ID should take precedence")
+
+    monkeypatch.setattr(
+        api_util, "get_workspace_organization_info", fail_workspace_lookup
+    )
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+
+    CloudClient(
+        bearer_token="token",
+        organization_id="configured-organization-id",
+        workspace_id="configured-workspace-id",
+    ).list_workspaces()
+
+    assert captured["organization_id"] == "configured-organization-id"
+
+
+def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    calls = {"user": 0, "permissions": 0}
+
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+
+    def fake_get_user_by_auth_id(*_: object, **__: object) -> dict[str, object]:
+        calls["user"] += 1
+        return {"userId": "user-id"}
+
+    def fake_list_permissions_for_user(
+        *_: object, **__: object
+    ) -> list[dict[str, object]]:
+        calls["permissions"] += 1
+        return [
+            {"permissionType": "instance_admin"},
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-id",
+            },
+        ]
+
+    monkeypatch.setattr(api_util, "get_user_by_auth_id", fake_get_user_by_auth_id)
+    monkeypatch.setattr(
+        api_util, "list_permissions_for_user", fake_list_permissions_for_user
+    )
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+    client = CloudClient(bearer_token="token")
+    client.list_workspaces()
+    client.list_workspaces()
+
+    assert captured["organization_id"] == "organization-id"
+    assert calls == {"user": 1, "permissions": 1}
+
+
+def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_permissions_for_user",
+        lambda *_, **__: [
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-1",
+            },
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-2",
+            },
+        ],
+    )
+
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        CloudClient(bearer_token="token").list_workspaces()
+
+    assert exc_info.value.context == {
+        "organization_ids": ["organization-1", "organization-2"],
+        "organization_candidates": [
+            {"organization_id": "organization-1", "organization_name": None},
+            {"organization_id": "organization-2", "organization_name": None},
+        ],
+    }
+
+
+def test_cloud_client_list_workspaces_rejects_missing_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(api_util, "list_permissions_for_user", lambda *_, **__: [])
+
+    with pytest.raises(PyAirbyteInputError, match="No organization membership"):
+        CloudClient(bearer_token="token").list_workspaces()
+
+
+def test_cloud_client_list_workspaces_all_organizations_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_list_workspaces(**kwargs: object) -> list[models.WorkspaceResponse]:
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
+
+    CloudClient(bearer_token="token").list_workspaces(all_organizations=True)
+
+    assert captured["limit"] is None
+
+
+def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DiscoveryClient:
+        def list_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
+            raise PyAirbyteInputError(
+                message="Multiple organization memberships were found.",
+                context={
+                    "organization_candidates": [
+                        {
+                            "organization_id": "organization-1",
+                            "organization_name": None,
+                        },
+                        {
+                            "organization_id": "organization-2",
+                            "organization_name": "Organization 2",
+                        },
+                    ]
+                },
+            )
+
+    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
+
+    result = mcp_cloud.list_cloud_workspaces(
+        None,
+        organization_id=None,
+        organization_name=None,
+        name_contains=None,
+        limit=None,
+        workspace_id=None,
+        all_organizations=False,
+    )
+
+    assert result.workspaces == []
+    assert result.candidate_organizations is not None
+    assert [candidate.id for candidate in result.candidate_organizations] == [
+        "organization-1",
+        "organization-2",
+    ]
+    assert result.candidate_organizations[1].name == "Organization 2"
 
 
 def test_cloud_client_get_organization_uses_unbounded_organization_list(
@@ -812,6 +1107,8 @@ def test_mcp_list_cloud_workspaces_discovery(
         organization_name=None,
         name_contains=None,
         limit=None,
+        workspace_id=None,
+        all_organizations=False,
     )
 
     assert captured_organization_id is None
@@ -851,20 +1148,6 @@ def test_mcp_list_cloud_organizations_forwards_filter_and_limit(
     assert captured == {"name_contains": "develop", "limit": 1}
     assert len(result.organizations) == 1
     assert "capped at 1" in (result.message or "")
-
-
-def test_mcp_resolve_organization_id_skips_lookup_when_id_provided() -> None:
-    class FailingClient:
-        def get_organization(self, **_: object) -> object:
-            pytest.fail("get_organization should not be called")
-
-    resolved_organization_id = mcp_cloud._resolve_organization_id(  # noqa: SLF001
-        organization_id="organization-id",
-        organization_name=None,
-        client=FailingClient(),
-    )
-
-    assert resolved_organization_id == "organization-id"
 
 
 def test_cloud_organization_fetch_returns_cached_info_after_refresh_failure(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -20,6 +20,61 @@ from airbyte.mcp import cloud as mcp_cloud
 from airbyte.secrets.base import SecretString
 
 
+def _patch_workspace_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    permissions: list[dict[str, object]] | None = None,
+    parent_organization_id: str | None = None,
+    org_scoped_result: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_permissions_for_user",
+        lambda *_, **__: permissions or [],
+    )
+
+    def fake_get_workspace_organization_info(**_: object) -> dict[str, object]:
+        if parent_organization_id is None:
+            pytest.fail("workspace parent lookup should not be called")
+        return {"organizationId": parent_organization_id}
+
+    monkeypatch.setattr(
+        api_util,
+        "get_workspace_organization_info",
+        fake_get_workspace_organization_info,
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces",
+        lambda **_: pytest.fail("cross-organization lookup should not be called"),
+    )
+
+    def fake_list_workspaces_in_organization(
+        **kwargs: object,
+    ) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return org_scoped_result if org_scoped_result is not None else []
+
+    monkeypatch.setattr(
+        api_util,
+        "list_workspaces_in_organization",
+        fake_list_workspaces_in_organization,
+    )
+    return captured
+
+
 def test_airbyte_credentials_from_auth_uses_pyairbyte_secret_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -692,189 +747,144 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
     }
 
 
-def test_cloud_client_list_workspaces_keeps_explicit_lookup_unbounded(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return [
-            {"workspaceId": f"workspace-{index}", "name": f"Workspace {index}"}
-            for index in range(101)
-        ]
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
-    )
-    monkeypatch.setattr(
-        api_util,
-        "get_user_id_from_bearer_token",
-        lambda _: "auth-user-id",
-    )
-    monkeypatch.setattr(
-        api_util,
-        "get_user_by_auth_id",
-        lambda *_, **__: {"userId": "user-id"},
-    )
-    monkeypatch.setattr(
-        api_util,
-        "list_permissions_for_user",
-        lambda *_, **__: [
+@pytest.mark.parametrize(
+    (
+        "client_kwargs",
+        "request_kwargs",
+        "permissions",
+        "parent_organization_id",
+        "expected_organization_id",
+        "expected_limit",
+        "org_scoped_result",
+        "expected_result_count",
+    ),
+    [
+        pytest.param(
+            {"workspace_id": "workspace-id"},
+            {"limit": 3},
+            None,
+            "parent-organization-id",
+            "parent-organization-id",
+            3,
+            None,
+            0,
+            id="explicit_workspace_parent",
+        ),
+        pytest.param(
+            {"organization_id": "configured-organization-id"},
+            {"limit": 3},
+            None,
+            None,
+            "configured-organization-id",
+            3,
+            None,
+            0,
+            id="configured_organization",
+        ),
+        pytest.param(
+            {"workspace_id": "configured-workspace-id"},
+            {"limit": 3},
+            None,
+            "parent-organization-id",
+            "parent-organization-id",
+            3,
+            None,
+            0,
+            id="configured_workspace_parent",
+        ),
+        pytest.param(
             {
-                "permissionType": "organization_member",
-                "organizationId": "organization-id",
-            }
-        ],
-    )
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces",
-        lambda **_: pytest.fail("implicit cross-organization lookup is not allowed"),
-    )
-    client = CloudClient(bearer_token="token")
-
-    result = client.list_workspaces(
-        name_filter=lambda _: True,
-    )
-
-    assert captured["organization_id"] == "organization-id"
-    assert captured["limit"] is None
-    assert len(result) == 101
-
-
-def test_cloud_client_list_workspaces_resolves_explicit_workspace_parent(
+                "organization_id": "configured-organization-id",
+                "workspace_id": "configured-workspace-id",
+            },
+            {"limit": 3},
+            None,
+            None,
+            "configured-organization-id",
+            3,
+            None,
+            0,
+            id="configured_organization_precedes_workspace",
+        ),
+        pytest.param(
+            {},
+            {"limit": 3},
+            [
+                {"permissionType": "instance_admin"},
+                {
+                    "permissionType": "organization_member",
+                    "organizationId": "organization-id",
+                },
+            ],
+            None,
+            "organization-id",
+            3,
+            None,
+            0,
+            id="single_membership_ignores_instance_admin",
+        ),
+        pytest.param(
+            {},
+            {"name_filter": lambda _: True},
+            [
+                {
+                    "permissionType": "organization_member",
+                    "organizationId": "organization-id",
+                }
+            ],
+            None,
+            "organization-id",
+            None,
+            [
+                {"workspaceId": f"workspace-{index}", "name": f"Workspace {index}"}
+                for index in range(101)
+            ],
+            101,
+            id="explicit_lookup_is_unbounded",
+        ),
+    ],
+)
+def test_cloud_client_list_workspaces_resolves_organization_context(
     monkeypatch: pytest.MonkeyPatch,
+    client_kwargs: dict[str, str],
+    request_kwargs: dict[str, object],
+    permissions: list[dict[str, object]] | None,
+    parent_organization_id: str | None,
+    expected_organization_id: str,
+    expected_limit: int | None,
+    org_scoped_result: list[dict[str, object]] | None,
+    expected_result_count: int,
 ) -> None:
-    captured: dict[str, object] = {}
-
-    monkeypatch.setattr(
-        api_util,
-        "get_workspace_organization_info",
-        lambda **_: {"organizationId": "parent-organization-id"},
+    captured = _patch_workspace_discovery(
+        monkeypatch,
+        permissions=permissions,
+        parent_organization_id=parent_organization_id,
+        org_scoped_result=org_scoped_result,
     )
 
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
+    result = CloudClient(bearer_token="token", **client_kwargs).list_workspaces(
+        **request_kwargs
     )
 
-    CloudClient(bearer_token="token").list_workspaces(workspace_id="workspace-id")
-
-    assert captured["organization_id"] == "parent-organization-id"
-
-
-def test_cloud_client_list_workspaces_uses_configured_organization_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
-    )
-
-    CloudClient(
-        bearer_token="token",
-        organization_id="configured-organization-id",
-    ).list_workspaces()
-
-    assert captured["organization_id"] == "configured-organization-id"
-
-
-def test_cloud_client_list_workspaces_resolves_configured_workspace_parent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    monkeypatch.setattr(
-        api_util,
-        "get_workspace_organization_info",
-        lambda **_: {"organizationId": "parent-organization-id"},
-    )
-
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
-    )
-
-    CloudClient(
-        bearer_token="token",
-        workspace_id="configured-workspace-id",
-    ).list_workspaces()
-
-    assert captured["organization_id"] == "parent-organization-id"
-
-
-def test_cloud_client_list_workspaces_prefers_configured_organization_over_workspace(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    def fail_workspace_lookup(**_: object) -> dict[str, object]:
-        pytest.fail("configured organization ID should take precedence")
-
-    monkeypatch.setattr(
-        api_util, "get_workspace_organization_info", fail_workspace_lookup
-    )
-
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
-    )
-
-    CloudClient(
-        bearer_token="token",
-        organization_id="configured-organization-id",
-        workspace_id="configured-workspace-id",
-    ).list_workspaces()
-
-    assert captured["organization_id"] == "configured-organization-id"
+    assert captured["organization_id"] == expected_organization_id
+    assert captured["limit"] == expected_limit
+    assert len(result) == expected_result_count
 
 
 def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, object] = {}
-    calls = {"user": 0, "permissions": 0}
-
-    monkeypatch.setattr(
-        api_util,
-        "get_user_id_from_bearer_token",
-        lambda _: "auth-user-id",
+    captured = _patch_workspace_discovery(
+        monkeypatch,
+        permissions=[
+            {"permissionType": "instance_admin"},
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-id",
+            },
+        ],
     )
+    calls = {"user": 0, "permissions": 0}
 
     def fake_get_user_by_auth_id(*_: object, **__: object) -> dict[str, object]:
         calls["user"] += 1
@@ -896,18 +906,6 @@ def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
     monkeypatch.setattr(
         api_util, "list_permissions_for_user", fake_list_permissions_for_user
     )
-
-    def fake_list_workspaces_in_organization(
-        **kwargs: object,
-    ) -> list[dict[str, object]]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(
-        api_util,
-        "list_workspaces_in_organization",
-        fake_list_workspaces_in_organization,
-    )
     client = CloudClient(bearer_token="token")
     client.list_workspaces()
     client.list_workspaces()
@@ -919,20 +917,9 @@ def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
 def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candidates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        api_util,
-        "get_user_id_from_bearer_token",
-        lambda _: "auth-user-id",
-    )
-    monkeypatch.setattr(
-        api_util,
-        "get_user_by_auth_id",
-        lambda *_, **__: {"userId": "user-id"},
-    )
-    monkeypatch.setattr(
-        api_util,
-        "list_permissions_for_user",
-        lambda *_, **__: [
+    _patch_workspace_discovery(
+        monkeypatch,
+        permissions=[
             {
                 "permissionType": "organization_member",
                 "organizationId": "organization-1",
@@ -966,22 +953,24 @@ def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candida
     }
 
 
-def test_cloud_client_list_workspaces_falls_back_to_all_organizations_without_membership(
+@pytest.mark.parametrize(
+    ("permissions", "all_organizations"),
+    [
+        pytest.param([], False, id="zero_memberships"),
+        pytest.param(None, True, id="explicit_opt_in"),
+    ],
+)
+def test_cloud_client_list_workspaces_uses_cross_organization_listing(
     monkeypatch: pytest.MonkeyPatch,
+    permissions: list[dict[str, object]] | None,
+    all_organizations: bool,
 ) -> None:
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr(
-        api_util,
-        "get_user_id_from_bearer_token",
-        lambda _: "auth-user-id",
+    _patch_workspace_discovery(
+        monkeypatch,
+        permissions=permissions,
     )
-    monkeypatch.setattr(
-        api_util,
-        "get_user_by_auth_id",
-        lambda *_, **__: {"userId": "user-id"},
-    )
-    monkeypatch.setattr(api_util, "list_permissions_for_user", lambda *_, **__: [])
 
     def fake_list_workspaces(**kwargs: object) -> list[models.WorkspaceResponse]:
         captured.update(kwargs)
@@ -996,47 +985,55 @@ def test_cloud_client_list_workspaces_falls_back_to_all_organizations_without_me
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
-    result = CloudClient(bearer_token="token").list_workspaces()
+    result = CloudClient(bearer_token="token").list_workspaces(
+        all_organizations=all_organizations,
+    )
 
     assert captured["workspace_id"] == ""
     assert captured["limit"] is None
     assert [workspace.workspace_id for workspace in result] == ["workspace-id"]
 
 
-def test_cloud_client_list_workspaces_all_organizations_is_explicit(
+@pytest.mark.parametrize(
+    ("candidates", "expected_ids", "expected_names", "has_retry_guidance"),
+    [
+        pytest.param(
+            [
+                {
+                    "organization_id": "organization-1",
+                    "organization_name": None,
+                },
+                {
+                    "organization_id": "organization-2",
+                    "organization_name": "Organization 2",
+                },
+            ],
+            ["organization-1", "organization-2"],
+            [None, "Organization 2"],
+            True,
+            id="with_available_organizations",
+        ),
+        pytest.param([], [], [], False, id="without_available_organizations"),
+    ],
+)
+def test_mcp_list_cloud_workspaces_reports_available_organizations(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_list_workspaces(**kwargs: object) -> list[models.WorkspaceResponse]:
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
-
-    CloudClient(bearer_token="token").list_workspaces(all_organizations=True)
-
-    assert captured["limit"] is None
-
-
-def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
-    monkeypatch: pytest.MonkeyPatch,
+    candidates: list[dict[str, str | None]],
+    expected_ids: list[str],
+    expected_names: list[str | None],
+    has_retry_guidance: bool,
 ) -> None:
     class DiscoveryClient:
         def list_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
+            message = (
+                "Multiple organization memberships were found."
+                if candidates
+                else "No organization membership was found."
+            )
             raise PyAirbyteInputError(
-                message="Multiple organization memberships were found.",
+                message=message,
                 context={
-                    "organization_candidates": [
-                        {
-                            "organization_id": "organization-1",
-                            "organization_name": None,
-                        },
-                        {
-                            "organization_id": "organization-2",
-                            "organization_name": "Organization 2",
-                        },
-                    ]
+                    "organization_candidates": candidates,
                 },
             )
 
@@ -1056,39 +1053,20 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
         isinstance(candidate, mcp_cloud.CloudOrganizationResult)
         for candidate in result.available_organizations
     )
-    assert [candidate.id for candidate in result.available_organizations] == [
-        "organization-1",
-        "organization-2",
-    ]
-    assert result.available_organizations[1].name == "Organization 2"
-    assert (
+    assert [
+        candidate.id for candidate in result.available_organizations
+    ] == expected_ids
+    assert [
+        candidate.name for candidate in result.available_organizations
+    ] == expected_names
+    retry_guidance = (
         "Retry with an explicit organization ID from the provided list of the "
-        "available organizations." in (result.message or "")
+        "available organizations."
     )
-
-
-def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class DiscoveryClient:
-        def list_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
-            raise PyAirbyteInputError(
-                message="No organization membership was found.",
-                context={"organization_candidates": []},
-            )
-
-    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
-
-    result = mcp_cloud.list_cloud_workspaces(
-        None,
-        organization_id=None,
-        organization_name=None,
-        name_contains=None,
-        limit=None,
-    )
-
-    assert result.available_organizations == []
-    assert result.message == "No organization membership was found."
+    if has_retry_guidance:
+        assert retry_guidance in (result.message or "")
+    else:
+        assert result.message == "No organization membership was found."
 
 
 def test_cloud_client_get_organization_uses_unbounded_organization_list(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -575,6 +575,11 @@ def test_cloud_workspace_explicit_credentials_do_not_resolve_env_vars(
 def test_cloud_client_get_organization_adds_missing_lookup_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **_: (_ for _ in ()).throw(AirbyteError(message="Unavailable")),
+    )
     monkeypatch.setattr(api_util, "list_organizations_for_user", lambda **_: [])
 
     with pytest.raises(AirbyteMissingResourceError) as exc_info:
@@ -599,6 +604,15 @@ def test_cloud_client_get_organization_uses_default_organization_id(
             )
         ],
     )
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **_: {
+            "organizationId": "default-org",
+            "organizationName": "Default Org",
+            "email": "test@example.com",
+        },
+    )
 
     organization = CloudClient(
         bearer_token="token",
@@ -606,6 +620,127 @@ def test_cloud_client_get_organization_uses_default_organization_id(
     ).get_organization()
 
     assert organization.organization_id == "default-org"
+
+
+@pytest.mark.parametrize(
+    ("client_kwargs", "parent_organization_id", "permissions", "expected_id"),
+    [
+        pytest.param(
+            {"organization_id": "configured-org"},
+            None,
+            None,
+            "configured-org",
+            id="configured-organization",
+        ),
+        pytest.param(
+            {"workspace_id": "configured-workspace"},
+            "workspace-parent-org",
+            None,
+            "workspace-parent-org",
+            id="configured-workspace-parent",
+        ),
+        pytest.param(
+            {},
+            None,
+            [{"organizationId": "membership-org"}],
+            "membership-org",
+            id="sole-membership",
+        ),
+    ],
+)
+def test_cloud_client_get_organization_resolves_default_context(
+    monkeypatch: pytest.MonkeyPatch,
+    client_kwargs: dict[str, str],
+    parent_organization_id: str | None,
+    permissions: list[dict[str, object]] | None,
+    expected_id: str,
+) -> None:
+    monkeypatch.setattr(
+        api_util, "get_user_id_from_bearer_token", lambda _: "auth-user-id"
+    )
+    monkeypatch.setattr(
+        api_util, "get_user_by_auth_id", lambda *_, **__: {"userId": "user-id"}
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_permissions_for_user",
+        lambda *_, **__: permissions or [],
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_workspace_organization_info",
+        lambda **_: {"organizationId": parent_organization_id}
+        if parent_organization_id is not None
+        else pytest.fail("workspace parent lookup should not be called"),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **kwargs: {
+            "organizationId": kwargs["organization_id"],
+            "organizationName": "Organization",
+        },
+    )
+
+    organization = CloudClient(bearer_token="token", **client_kwargs).get_organization()
+
+    assert organization.organization_id == expected_id
+
+
+def test_cloud_client_get_organization_rejects_ambiguous_default_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization_ids = tuple(f"organization-{index}" for index in range(12))
+    monkeypatch.setattr(
+        CloudClient,
+        "_get_membership_organization_ids",
+        lambda _: organization_ids,
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **kwargs: {
+            "organizationName": f"Organization {kwargs['organization_id']}"
+        },
+    )
+
+    with pytest.raises(PyAirbyteInputError) as exc_info:
+        CloudClient(bearer_token="token").get_organization()
+
+    error = exc_info.value
+    assert "organization-0 (Organization organization-0)" in str(error)
+    assert "organization-10" not in error.message
+    assert error.context["organization_ids"] == list(organization_ids)
+    assert len(error.context["organization_candidates"]) == 10
+    assert error.context["total_candidates"] == 12
+
+
+def test_cloud_client_get_organization_uses_single_config_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_get_organization_info(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {
+            "organizationId": "organization-id",
+            "organizationName": "Organization",
+            "email": "test@example.com",
+        }
+
+    monkeypatch.setattr(api_util, "get_organization_info", fake_get_organization_info)
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user",
+        lambda **_: pytest.fail("full organization listing should not be called"),
+    )
+
+    organization = CloudClient(bearer_token="token").get_organization(
+        organization_id="organization-id"
+    )
+
+    assert organization.organization_id == "organization-id"
+    assert [call["organization_id"] for call in calls] == ["organization-id"]
 
 
 @pytest.mark.parametrize(
@@ -657,8 +792,17 @@ def test_cloud_client_list_organizations_returns_typed_resources(
     ]
 
 
-def test_cloud_client_list_organizations_filters_case_insensitively_and_limits(
+@pytest.mark.parametrize(
+    ("name_contains", "expected_ids"),
+    [
+        pytest.param("DEVELOP", ["organization-id-1"], id="name-filter"),
+        pytest.param(None, ["organization-id-1"], id="limit-only"),
+    ],
+)
+def test_cloud_client_list_organizations_uses_config_api_for_filter_or_limit(
     monkeypatch: pytest.MonkeyPatch,
+    name_contains: str | None,
+    expected_ids: list[str],
 ) -> None:
     organizations = [
         models.OrganizationResponse(
@@ -678,17 +822,83 @@ def test_cloud_client_list_organizations_filters_case_insensitively_and_limits(
         ),
     ]
     monkeypatch.setattr(
-        api_util, "list_organizations_for_user", lambda **_: organizations
+        api_util,
+        "list_organizations_for_user_id",
+        lambda **kwargs: [
+            {
+                "organizationId": organization.organization_id,
+                "organizationName": organization.organization_name,
+                "email": organization.email,
+            }
+            for organization in organizations[: kwargs["limit"]]
+        ],
+    )
+    monkeypatch.setattr(
+        api_util, "get_user_id_from_bearer_token", lambda _: "auth-user-id"
+    )
+    monkeypatch.setattr(
+        api_util, "get_user_by_auth_id", lambda *_, **__: {"userId": "user-id"}
     )
 
     result = CloudClient(bearer_token="token").list_organizations(
-        name_contains="DEVELOP",
+        name_contains=name_contains,
+        limit=1,
+    )
+
+    assert [organization.organization_id for organization in result] == expected_ids
+
+
+def test_cloud_client_list_organizations_falls_back_to_public_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organizations = [
+        models.OrganizationResponse(
+            organization_id="organization-id",
+            organization_name="Development",
+            email="test@example.com",
+        )
+    ]
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user_id",
+        lambda **_: (_ for _ in ()).throw(AirbyteError(message="Unavailable")),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user",
+        lambda **_: organizations,
+    )
+
+    result = CloudClient(bearer_token="token").list_organizations(
+        name_contains="develop",
         limit=1,
     )
 
     assert [organization.organization_id for organization in result] == [
-        "organization-id-1"
+        "organization-id"
     ]
+
+
+def test_cloud_client_get_organization_requires_context_without_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(CloudClient, "_get_membership_organization_ids", lambda _: ())
+
+    with pytest.raises(
+        PyAirbyteInputError,
+        match="Organization ID or organization name is required.",
+    ):
+        CloudClient(bearer_token="token").get_organization()
 
 
 def test_cloud_client_list_organizations_has_no_default_limit(
@@ -724,6 +934,21 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         for index in range(11)
     ]
     client = CloudClient(bearer_token="token")
+    monkeypatch.setattr(
+        api_util,
+        "get_user_id_from_bearer_token",
+        lambda _: "auth-user-id",
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_user_by_auth_id",
+        lambda *_, **__: {"userId": "user-id"},
+    )
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user_id",
+        lambda **_: (_ for _ in ()).throw(AirbyteError(message="Unavailable")),
+    )
     monkeypatch.setattr(client, "_fetch_organizations", lambda: organizations)
 
     with pytest.raises(PyAirbyteInputError) as exc_info:
@@ -942,6 +1167,7 @@ def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candida
             },
             {"organization_id": "organization-2", "organization_name": None},
         ],
+        "total_candidates": 2,
     }
 
 
@@ -1079,6 +1305,36 @@ def test_mcp_get_cloud_client_uses_configured_workspace(
     assert client.default_workspace_id == "workspace-id"
 
 
+def test_mcp_describe_cloud_organization_resolves_without_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DiscoveryClient:
+        def get_organization(
+            self,
+            *,
+            organization_id: str | None = None,
+            organization_name: str | None = None,
+        ) -> CloudOrganization:
+            assert organization_id is None
+            assert organization_name is None
+            return CloudOrganization(
+                organization_id="organization-id",
+                organization_name="Organization",
+                email="test@example.com",
+            )
+
+    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
+
+    result = mcp_cloud.describe_cloud_organization(
+        None,
+        organization_id=None,
+        organization_name=None,
+    )
+
+    assert result.id == "organization-id"
+    assert result.name == "Organization"
+
+
 def test_cloud_client_get_organization_uses_unbounded_organization_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1090,6 +1346,16 @@ def test_cloud_client_get_organization_uses_unbounded_organization_list(
         )
     ]
     client = CloudClient(bearer_token="token")
+    monkeypatch.setattr(
+        api_util,
+        "list_organizations_for_user_id",
+        lambda **_: (_ for _ in ()).throw(AirbyteError(message="Unavailable")),
+    )
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **_: (_ for _ in ()).throw(AirbyteError(message="Unavailable")),
+    )
     monkeypatch.setattr(client, "_fetch_organizations", lambda: organizations)
 
     result = client.get_organization(organization_id="organization-id")
@@ -1237,6 +1503,12 @@ def test_mcp_list_cloud_workspaces_discovery(
                 raise workspaces_or_error
             return workspaces_or_error
 
+        def get_organization(self, *, organization_id: str) -> CloudOrganization:
+            return CloudOrganization(
+                organization_id=organization_id,
+                organization_name="Organization",
+            )
+
     monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
 
     result = mcp_cloud.list_cloud_workspaces(
@@ -1254,7 +1526,10 @@ def test_mcp_list_cloud_workspaces_discovery(
     else:
         assert result.workspaces[0].workspace_id == "workspace-id"
         assert result.workspaces[1].organization_id is None
-        assert result.message is None
+        assert (
+            result.message
+            == "Resolved organization Organization (organization-id) for these credentials."
+        )
 
 
 def test_mcp_list_cloud_organizations_forwards_filter_and_limit(
@@ -1283,7 +1558,10 @@ def test_mcp_list_cloud_organizations_forwards_filter_and_limit(
 
     assert captured == {"name_contains": "develop", "limit": 1}
     assert len(result.organizations) == 1
-    assert "capped at 1" in (result.message or "")
+    assert (
+        result.message == "Showing the first 1 organizations; more may exist. "
+        "Pass `name_contains` to narrow the search, or a larger `limit`."
+    )
 
 
 def test_cloud_organization_fetch_returns_cached_info_after_refresh_failure(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1030,7 +1030,6 @@ def test_mcp_list_cloud_workspaces_returns_typed_organization_candidates(
         organization_name=None,
         name_contains=None,
         limit=None,
-        workspace_id=None,
         all_organizations=False,
     )
 
@@ -1062,7 +1061,6 @@ def test_mcp_list_cloud_workspaces_without_candidates_omits_retry_guidance(
         organization_name=None,
         name_contains=None,
         limit=None,
-        workspace_id=None,
         all_organizations=False,
     )
 
@@ -1216,7 +1214,6 @@ def test_mcp_list_cloud_workspaces_discovery(
         organization_name=None,
         name_contains=None,
         limit=None,
-        workspace_id=None,
         all_organizations=False,
     )
 

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -223,6 +223,34 @@ def test_cloud_client_list_workspaces_forwards_limit(
     assert captured_limit == 3
 
 
+@pytest.mark.parametrize(
+    ("request_kwargs", "expected_message"),
+    [
+        pytest.param(
+            {"all_organizations": True, "organization_id": "organization-id"},
+            "all_organizations option cannot be combined",
+            id="all-organizations-with-organization",
+        ),
+        pytest.param(
+            {"name_contains": "target", "name_filter": lambda _: True},
+            "provide name_contains or name_filter, but not both",
+            id="name-contains-with-name-filter",
+        ),
+        pytest.param(
+            {"name": "target", "name_contains": "target"},
+            "provide name or name_contains, but not both",
+            id="name-with-name-contains",
+        ),
+    ],
+)
+def test_cloud_client_list_workspaces_rejects_invalid_argument_combinations(
+    request_kwargs: dict[str, object],
+    expected_message: str,
+) -> None:
+    with pytest.raises(PyAirbyteInputError, match=expected_message):
+        CloudClient(bearer_token="token").list_workspaces(**request_kwargs)
+
+
 def test_cloud_client_list_workspaces_applies_name_contains_to_all_org_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -109,16 +109,20 @@ def test_cloud_credentials_error_guidance(
     [
         pytest.param(
             True,
-            "Call `list_cloud_organizations` and `list_cloud_workspaces` first. If "
-            "discovery returns exactly one workspace, provide its ID via the "
+            "Call `list_cloud_workspaces` first, which resolves the organization "
+            "automatically; only call `list_cloud_organizations` to search "
+            "organizations by name. If discovery returns exactly one workspace, "
+            "provide its ID via the "
             "`X-Airbyte-Workspace-Id` header or the `workspace_id` parameter; "
             "otherwise ask the user to choose.",
             id="hosted",
         ),
         pytest.param(
             False,
-            "Call `list_cloud_organizations` and `list_cloud_workspaces` first. If "
-            "discovery returns exactly one workspace, set its ID in "
+            "Call `list_cloud_workspaces` first, which resolves the organization "
+            "automatically; only call `list_cloud_organizations` to search "
+            "organizations by name. If discovery returns exactly one workspace, "
+            "set its ID in "
             "`AIRBYTE_CLOUD_WORKSPACE_ID` or pass the `workspace_id` parameter; "
             "otherwise ask the user to choose.",
             id="local",


### PR DESCRIPTION
## Summary

Makes organization and workspace discovery resolve a context instead of dumping everything the credentials can see, and moves organization search onto an endpoint that can actually filter and paginate.

Two problems remained after the resolution work earlier in this branch, both only visible with instance-admin credentials (167k visible organizations):

1. `list_cloud_organizations` was unbounded. The public `GET /organizations` endpoint the SDK wraps ignores `limit`, `offset` and `pageSize` — every variant returns the same 23.6 MB / 167,651-row body. Over the hosted SSE transport that payload never makes it back to the agent: the stream pings and closes at 40-70s. The Config API's `POST /organizations/list_by_user_id` does support `nameContains` and `pagination {pageSize, rowOffset}` server-side, so filtered and limited lookups now go there:

   ```python
   client.list_organizations(name_contains="Airbyte Team")  # 2 rows, ~1.2s (was ~29s, all 167k rows scanned client-side)
   client.list_organizations(limit=5)                        # 5 rows, ~0.6s
   client.list_organizations()                               # unchanged: one public-API request, all rows
   ```

   The unfiltered library path deliberately stays on the public API — one 2.3s request beats 1,600 paginated ones. The MCP tool defaults `limit` to 100 and always states in `message` that the result is the first N of possibly more, so a truncated list is never presented as complete.

2. `get_organization()` with no arguments errored, so an agent asking "which organization am I in?" had to go through `list_cloud_workspaces` and then describe by ID. It now resolves the same way workspace listing does — configured `organization_id`, then the parent organization of `default_workspace_id`, then the authenticated user's sole membership:

   ```python
   client.get_organization()  # -> Airbyte Team (664c690e-…), ~0.6s
   ```

   With several memberships it raises `PyAirbyteInputError` whose **message text** enumerates up to ten candidates (`<id> (<name>)`, plus `showing 10 of N`), not just its `context` — `describe_cloud_organization` returns a single object and the error string is the only channel an agent sees. Lookups by ID are now a single `organizations/get_organization_info` call instead of a full-listing scan; name lookups narrow server-side first. All of these fall back to the public listing on `AirbyteError` so self-managed deployments keep working.

Also in this change, from agent-behavior testing of the preview deployment:

- `CLOUD_AUTH_TIP_TEXT` and `AirbyteMissingWorkspaceContextError.guidance` no longer tell agents to call `list_cloud_organizations` first — that text was the direct cause of every no-arg call that hung. They now point at `list_cloud_workspaces` (which resolves the organization itself) and mention the organization tool only for `name_contains` searches.
- `list_cloud_workspaces` populates `organization_name` on each row and, when it resolved the organization implicitly, says so in `message` ("Resolved organization Airbyte Team (664c690e-…)"), saving the agent a follow-up call. The extra lookup is one Config API call and failures are swallowed rather than failing the listing.

No new caps beyond the two stated above (MCP default `limit=100`, always announced; ten-candidate ambiguity list).

## Test plan

- `pytest tests/unit_tests/test_cloud_api_util.py tests/unit_tests/test_cloud_credentials.py tests/unit_tests/test_exceptions.py` — 101 passed. New cases cover the Config API pagination/filter payload, the Config-vs-public routing in `list_organizations` and its fallback, all three no-argument `get_organization` resolution paths, the ten-candidate ambiguity message and context, the single-call ID lookup, and `describe_cloud_organization` with no arguments.
- `ruff format .`, `ruff check .`, `pyrefly check` — clean.
- Live against Airbyte Cloud with instance-admin credentials: the four timings quoted above, plus bare `list_workspaces()` returning the Airbyte Team workspaces with `organization_id` populated.
- Not covered: the multi-membership ambiguity path is mocks-only — both credentials available here are single-organization.

Requested by AJ Steers.


Link to Devin session: https://app.devin.ai/sessions/290cd017df694ae4bdba43f2247dd27a
Open in Devin Desktop: https://app.devin.ai/desktop/session/290cd017df694ae4bdba43f2247dd27a?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved organization and workspace discovery using IDs, names, workspace context, configured defaults, or memberships.
  * Added organization name filtering and result limits.
  * Workspace listings now provide clearer organization details and available organization options.
  * Added automatic organization resolution for cloud workspace operations.

* **Bug Fixes**
  * Improved handling of ambiguous memberships and unexpected API responses.
  * Added fallback behavior when organization membership data is unavailable.

* **Documentation**
  * Updated missing-workspace guidance to recommend listing workspaces first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->