### PR TITLE
docs: fix CacheBase.streams docstring

### DIFF
--- a/airbyte/caches/base.py
+++ b/airbyte/caches/base.py
@@ -324,7 +324,7 @@ class CacheBase(SqlConfig, AirbyteWriterInterface):  # noqa: PLR0904
     @final
     @property
     def streams(self) -> dict[str, CachedDataset]:
-        """Return a temporary table name."""
+        """Return a mapping of stream names to cached datasets."""
         result = {}
         stream_names = set(self._catalog_backend.stream_names)
 


### PR DESCRIPTION
## Summary
Fixes a copy-paste docstring on `CacheBase.streams` — it read "Return a temporary table name." (copied from `SqlProcessorBase._get_temp_table_name`) despite returning `dict[str, CachedDataset]`. Now reads "Return a mapping of stream names to cached datasets."

Surfaced by Copilot review on the regenerated API reference in airbytehq/airbyte#85090.

Link to Devin session: https://app.devin.ai/sessions/8b64278f1f054e8dbed5d9965d30776b
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the description of cached stream data to accurately reflect the mapping returned.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->