### PR TITLE
ci: auto-deploy cloud-mcp preview on main, prod on release

### DIFF
--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -1,0 +1,157 @@
+# Deploys the cloud-mcp Cloud Run services, which run the PyAirbyte MCP server.
+#
+# The services themselves live in airbytehq/airbyte-ops-mcp, so this workflow
+# only resolves which PyAirbyte build should ship and hands it to that repo's
+# `Deploy MCP Server` workflow via `repository_dispatch`.
+#
+# Triggers:
+# - push (main) - Every merge refreshes cloud-mcp-preview with that commit,
+#   installed straight from git so no PyPI release is needed.
+# - workflow_call - `pypi_publish.yml` calls this after a publish to ship the
+#   published version: a public release goes to production, a prerelease to
+#   the preview service.
+
+name: Deploy Cloud MCP
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+    inputs:
+      pyairbyte-version:
+        description: 'Published PyAirbyte version to pin (e.g. "0.56.0"). Empty installs the triggering commit from git.'
+        required: false
+        type: string
+        default: ""
+      preview:
+        description: "Whether to deploy the preview service instead of production."
+        required: false
+        type: string
+        default: "true"
+
+permissions:
+  contents: read
+
+# Serialize per target service so two deploys cannot race the same Cloud Run
+# service. Preview only ever wants the newest commit, so supersede in-flight
+# preview runs; production deploys always run to completion.
+concurrency:
+  group: deploy-cloud-mcp-${{ inputs.preview || 'true' }}
+  cancel-in-progress: ${{ inputs.preview != 'false' }}
+
+jobs:
+  deploy_cloud_mcp:
+    name: Deploy Cloud MCP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Variables
+        id: resolve-vars
+        env:
+          PYAIRBYTE_VERSION: ${{ inputs.pyairbyte-version || '' }}
+          PREVIEW: ${{ inputs.preview || 'true' }}
+        run: |
+          set -euo pipefail
+          version="${PYAIRBYTE_VERSION#v}"
+
+          # ---------- Validate inputs (guard statements) ----------
+          printf '%s\n' true false | grep -qxF "$PREVIEW" \
+            || { echo "::error::Invalid preview value: '$PREVIEW' (allowed: true, false)"; exit 1; }
+          if [ -n "$version" ]; then
+            case "$version" in
+              [!0-9]*|*[!0-9A-Za-z.+!-]*)
+                echo "::error::Invalid PEP 440 version: $version"
+                exit 1
+                ;;
+            esac
+          fi
+
+          # ---------- Requirement to install into the image ----------
+          # A published version is pinned exactly; otherwise install the
+          # triggering commit from git, so a merge to main needs no release.
+          if [ -n "$version" ]; then
+            requirement="airbyte==$version"
+            pinned="true"
+          else
+            requirement="airbyte @ git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+            pinned="false"
+          fi
+
+          {
+            printf 'requirement=%s\n' "$requirement"
+            printf 'pinned=%s\n' "$pinned"
+            printf 'preview=%s\n' "$PREVIEW"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        if: steps.resolve-vars.outputs.pinned == 'true'
+        uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
+        with:
+          enable-cache: false
+
+      # Gate on `uv` itself: it reads the PEP 691 JSON variant of the simple
+      # index, which PyPI caches separately (`vary: Accept`) from the HTML one
+      # and which can stay stale for far longer. Polling anything else can go
+      # green while the cloud-mcp image build still cannot resolve the version.
+      - name: Wait for PyAirbyte version to be resolvable
+        if: steps.resolve-vars.outputs.pinned == 'true'
+        env:
+          PYPI_REQUIREMENT: ${{ steps.resolve-vars.outputs.requirement }}
+        run: |
+          set -euo pipefail
+          attempt=1
+          while [ "$attempt" -le 30 ]; do
+            if uv pip compile --quiet --no-cache --no-deps --python-version 3.12 \
+              --output-file "$RUNNER_TEMP/pyairbyte-requirement.txt" - \
+              <<<"$PYPI_REQUIREMENT"; then
+              break
+            fi
+            echo "$PYPI_REQUIREMENT is not resolvable from PyPI yet (attempt $attempt/30)."
+            if [ "$attempt" -lt 30 ]; then
+              sleep 10
+            fi
+            attempt=$((attempt + 1))
+          done
+          [ "$attempt" -le 30 ] \
+            || { echo "::error::$PYPI_REQUIREMENT did not become resolvable from PyPI after 30 attempts."; exit 1; }
+
+      - name: Build cloud-mcp dispatch payload
+        id: build-client-payload
+        env:
+          PYAIRBYTE_REQUIREMENT: ${{ steps.resolve-vars.outputs.requirement }}
+          PREVIEW: ${{ steps.resolve-vars.outputs.preview }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -cn \
+            --arg requirement "$PYAIRBYTE_REQUIREMENT" \
+            --arg preview "$PREVIEW" \
+            '{"mcp-server": "cloud-mcp", "preview": $preview, "cloud-mcp-pyairbyte-requirement": $requirement}')"
+          echo "payload=$payload" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Authenticate as GitHub App
+        id: get-app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          owner: airbytehq
+          repositories: airbyte-ops-mcp
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Trigger cloud-mcp deploy
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          repository: airbytehq/airbyte-ops-mcp
+          event-type: deploy-cloud-mcp
+          client-payload: ${{ steps.build-client-payload.outputs.payload }}
+
+      - name: Summarize dispatch
+        env:
+          PYAIRBYTE_REQUIREMENT: ${{ steps.resolve-vars.outputs.requirement }}
+          PREVIEW: ${{ steps.resolve-vars.outputs.preview }}
+        run: |
+          {
+            printf 'Requested a cloud-mcp deploy in airbytehq/airbyte-ops-mcp.\n'
+            printf 'Requirement: %s\n' "$PYAIRBYTE_REQUIREMENT"
+            printf 'Preview: %s\n' "$PREVIEW"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           PYAIRBYTE_VERSION: ${{ inputs.pyairbyte-version || '' }}
           PREVIEW: ${{ inputs.preview || 'true' }}
+          TRIGGER: ${{ github.event_name }}
         run: |
           set -euo pipefail
           version="${PYAIRBYTE_VERSION#v}"
@@ -65,6 +66,12 @@ jobs:
                 exit 1
                 ;;
             esac
+          elif [ "$TRIGGER" != push ]; then
+            # The git fallback below exists for the push-to-main preview only.
+            # A caller shipping a publish must name the published version, or it
+            # would silently deploy this ref instead of the released package.
+            echo "::error::pyairbyte-version is required when this workflow is called ($TRIGGER)."
+            exit 1
           fi
 
           # ---------- Requirement to install into the image ----------
@@ -137,6 +144,8 @@ jobs:
           repositories: airbyte-ops-mcp
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+          # `repository_dispatch` needs contents:write and nothing else.
+          permission-contents: write
 
       - name: Trigger cloud-mcp deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -20,15 +20,13 @@ on:
   workflow_call:
     inputs:
       pyairbyte-version:
-        description: 'Published PyAirbyte version to pin (e.g. "0.56.0"). Empty installs the triggering commit from git.'
-        required: false
+        description: 'Published PyAirbyte version to pin (e.g. "0.56.0").'
+        required: true
         type: string
-        default: ""
       preview:
-        description: "Whether to deploy the preview service instead of production."
-        required: false
+        description: 'Whether to deploy the preview service instead of production ("true" or "false").'
+        required: true
         type: string
-        default: "true"
 
 permissions:
   contents: read
@@ -50,15 +48,27 @@ jobs:
         id: resolve-vars
         env:
           PYAIRBYTE_VERSION: ${{ inputs.pyairbyte-version || '' }}
-          PREVIEW: ${{ inputs.preview || 'true' }}
-          TRIGGER: ${{ github.event_name }}
+          # `preview` is a required `workflow_call` input, so a non-empty value
+          # means a caller invoked this workflow. On the `push` trigger the
+          # `inputs` context is empty, which is what selects the git install
+          # below. This does not use `github.event_name`, which in a reusable
+          # workflow reports the *caller's* trigger.
+          PREVIEW: ${{ inputs.preview || '' }}
         run: |
           set -euo pipefail
           version="${PYAIRBYTE_VERSION#v}"
 
           # ---------- Validate inputs (guard statements) ----------
-          printf '%s\n' true false | grep -qxF "$PREVIEW" \
-            || { echo "::error::Invalid preview value: '$PREVIEW' (allowed: true, false)"; exit 1; }
+          if [ -n "$PREVIEW" ]; then
+            printf '%s\n' true false | grep -qxF "$PREVIEW" \
+              || { echo "::error::Invalid preview value: '$PREVIEW' (allowed: true, false)"; exit 1; }
+            # A caller shipping a publish must name the published version, or
+            # this would silently deploy the ref instead of the release.
+            [ -n "$version" ] \
+              || { echo "::error::pyairbyte-version is required when this workflow is called."; exit 1; }
+          else
+            PREVIEW=true
+          fi
           if [ -n "$version" ]; then
             case "$version" in
               [!0-9]*|*[!0-9A-Za-z.+!-]*)
@@ -66,12 +76,6 @@ jobs:
                 exit 1
                 ;;
             esac
-          elif [ "$TRIGGER" != push ]; then
-            # The git fallback below exists for the push-to-main preview only.
-            # A caller shipping a publish must name the published version, or it
-            # would silently deploy this ref instead of the released package.
-            echo "::error::pyairbyte-version is required when this workflow is called ($TRIGGER)."
-            exit 1
           fi
 
           # ---------- Requirement to install into the image ----------

--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -33,9 +33,10 @@ on:
 permissions:
   contents: read
 
-# Serialize per target service so two deploys cannot race the same Cloud Run
-# service. Preview only ever wants the newest commit, so supersede in-flight
-# preview runs; production deploys always run to completion.
+# Serialize the dispatch requests per target service. The Cloud Run rollout
+# itself happens in airbyte-ops-mcp, which does not guard concurrency, so this
+# narrows the race rather than removing it. Preview only ever wants the newest
+# commit, so supersede in-flight preview runs; production runs to completion.
 concurrency:
   group: deploy-cloud-mcp-${{ inputs.preview || 'true' }}
   cancel-in-progress: ${{ inputs.preview != 'false' }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -80,90 +80,15 @@ jobs:
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  # Prod cloud-mcp is bumped via Dependabot on airbytehq/airbyte-ops-mcp, not here.
-  # A PyPI publish refreshes the cloud-mcp preview with the exact published
-  # PyAirbyte requirement.
-  deploy_cloud_mcp_preview:
-    name: Deploy Cloud MCP (Preview)
+  # A publish ships the exact published version to cloud-mcp: a public release
+  # promotes it to production, while a GitHub prerelease or an on-demand
+  # prerelease build only refreshes the preview service.
+  deploy_cloud_mcp:
+    name: Deploy Cloud MCP
     needs: publish_to_pypi
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Resolve published PyAirbyte requirement
-        id: resolve-pyairbyte-requirement
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
-          VERSION_OVERRIDE: ${{ github.event.inputs.version_override || '' }}
-        run: |
-          set -euo pipefail
-          version="${RELEASE_TAG#v}"
-          version="${version:-${VERSION_OVERRIDE#v}}"
-          [ -n "$version" ] || { echo "::error::Could not resolve the published PyAirbyte version."; exit 1; }
-          case "$version" in
-            ''|[!0-9]*|*[!0-9A-Za-z.+!-]*)
-              echo "::error::Invalid PEP 440 version: $version"
-              exit 1
-              ;;
-          esac
-          echo "version=$version" | tee -a "$GITHUB_OUTPUT"
-          echo "requirement=airbyte==$version" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
-        with:
-          enable-cache: false
-
-      # Gate on `uv` itself: it reads the PEP 691 JSON variant of the simple
-      # index, which PyPI caches separately (`vary: Accept`) from the HTML one
-      # and which can stay stale for far longer. Polling anything else can go
-      # green while the cloud-mcp image build still cannot resolve the version.
-      - name: Wait for PyAirbyte version to be resolvable
-        env:
-          PYPI_REQUIREMENT: ${{ steps.resolve-pyairbyte-requirement.outputs.requirement }}
-        run: |
-          set -euo pipefail
-          attempt=1
-          while [ "$attempt" -le 30 ]; do
-            if uv pip compile --quiet --no-cache --no-deps --python-version 3.12 \
-              --output-file "$RUNNER_TEMP/pyairbyte-requirement.txt" - \
-              <<<"$PYPI_REQUIREMENT"; then
-              break
-            fi
-            echo "$PYPI_REQUIREMENT is not resolvable from PyPI yet (attempt $attempt/30)."
-            if [ "$attempt" -lt 30 ]; then
-              sleep 10
-            fi
-            attempt=$((attempt + 1))
-          done
-          [ "$attempt" -le 30 ] \
-            || { echo "::error::$PYPI_REQUIREMENT did not become resolvable from PyPI after 30 attempts."; exit 1; }
-
-      - name: Build cloud-mcp dispatch payload
-        id: build-client-payload
-        env:
-          PYPI_REQUIREMENT: ${{ steps.resolve-pyairbyte-requirement.outputs.requirement }}
-        run: |
-          set -euo pipefail
-          payload="$(jq -cn \
-            --arg requirement "$PYPI_REQUIREMENT" \
-            '{"mcp-server": "cloud-mcp", "preview": "true", "cloud-mcp-pyairbyte-requirement": $requirement}')"
-          echo "payload=$payload" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Authenticate as GitHub App
-        id: get-app-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        with:
-          owner: airbytehq
-          repositories: airbyte-ops-mcp
-          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-
-      - name: Trigger cloud-mcp preview deploy
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ steps.get-app-token.outputs.token }}
-          repository: airbytehq/airbyte-ops-mcp
-          event-type: deploy-cloud-mcp
-          client-payload: ${{ steps.build-client-payload.outputs.payload }}
+    uses: ./.github/workflows/deploy_cloud_mcp.yml
+    secrets: inherit
+    with:
+      pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
+      preview: ${{ (github.event_name == 'release' && github.event.release.prerelease != true) && 'false' || 'true' }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -87,6 +87,10 @@ jobs:
     name: Deploy Cloud MCP
     needs: publish_to_pypi
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+    # The dispatch to airbyte-ops-mcp is authenticated with a GitHub App token,
+    # not `GITHUB_TOKEN`, so this job needs nothing beyond reading the workflow.
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy_cloud_mcp.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Requested by AJ Steers: make the cloud-mcp deploys automatic on both sides — every merge to `main` refreshes `cloud-mcp-preview`, and every public release promotes to production `cloud-mcp`.

Before, the only cloud-mcp dispatch lived inside `pypi_publish.yml` and always targeted preview; production was bumped only when Dependabot's daily PyAirbyte pin PR merged in `airbytehq/airbyte-ops-mcp`.

The dispatch logic moves into a new reusable `deploy_cloud_mcp.yml` (`workflow_call` + `push: main`), which resolves the requirement to install into the image and hands it to `airbyte-ops-mcp`'s `Deploy MCP Server` workflow:

```
push to main        -> preview=true,  airbyte @ git+https://github.com/airbytehq/PyAirbyte@<sha>
release (public)    -> preview=false, airbyte==<tag>
release (prerelease)-> preview=true,  airbyte==<tag>
prerelease dispatch -> preview=true,  airbyte==<version_override>
```

Merges to `main` need no PyPI release: the cloud-mcp `Dockerfile` already accepts a full requirement spec via `PYAIRBYTE_REQUIREMENT` and has `git` installed, so the preview installs the merged commit straight from git. The PyPI index-staleness wait is therefore skipped unless the requirement is a pinned `airbyte==` version.

`pypi_publish.yml`'s deploy job shrinks to a call:

```yaml
  deploy_cloud_mcp:
    needs: publish_to_pypi
    uses: ./.github/workflows/deploy_cloud_mcp.yml
    secrets: inherit
    with:
      pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
      preview: ${{ (github.event_name == 'release' && github.event.release.prerelease != true) && 'false' || 'true' }}
```

One thing to note: a release-triggered production deploy installs the released version over the pin in `infra/internal-mcp-servers/docker/cloud-mcp/requirements.txt`, which Dependabot still bumps daily. Until that pin PR merges, an unrelated change to the cloud-mcp image directory would rebuild production from the older pin. A follow-up in `airbyte-ops-mcp` can close that window by having the release dispatch bump the pin instead of overriding it.

## Test plan

- `actionlint -ignore 'unknown permission scope "code-quality"' .github/workflows/deploy_cloud_mcp.yml .github/workflows/pypi_publish.yml` passes locally (same invocation as the `GitHub action linting` check).
- Not exercised end to end: the `push: main` trigger and the release path only run once merged. First merge to `main` after this lands should show a `Deploy Cloud MCP` run dispatching to `airbytehq/airbyte-ops-mcp`, and `https://mcp.internal.airbyte.ai/cloud-mcp-preview` serving that commit.


Link to Devin session: https://app.devin.ai/sessions/b8361cd4cc904e8b9ffc65ed7e073c66
Open in Devin Desktop: https://app.devin.ai/desktop/session/b8361cd4cc904e8b9ffc65ed7e073c66?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Cloud MCP service deployments following PyAirbyte releases.
  * Public releases now deploy to the production service automatically.
  * Prereleases and on-demand builds refresh the preview service without affecting production.
  * Added support for deploying a specific PyAirbyte version or build.
  * Improved deployment validation and status reporting for more reliable release handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**