### PR TITLE
ci: add `TK-TODO` check workflow

### DIFF
--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check  # IGNORE:TK - this workflow checks for TK-TODO markers
+name: TK-TODO Check  # IGNORE:TK
 
 on:
   push:
@@ -18,28 +18,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Check for TK-TODO markers  # IGNORE:TK
-        run: |
-          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line  # IGNORE:TK
-          # Exit with error if any are found
-
-          echo "Checking for TK-TODO markers..."  # IGNORE:TK
-
-          # Use git ls-files to only check tracked files (excludes gitignored files)
-          # grep -i for case-insensitive matching
-          # grep -v for excluding lines with IGNORE:TK
-          # grep -n for line numbers
-
-          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true)  # IGNORE:TK
-
-          if [ -n "$FOUND_TODOS" ]; then
-            echo ""
-            echo "ERROR: Found TK-TODO markers that must be resolved before merge:"  # IGNORE:TK
-            echo ""
-            echo "$FOUND_TODOS"
-            echo ""
-            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line."  # IGNORE:TK
-            echo ""
-            exit 1
-          else
-            echo "No unresolved TK-TODO markers found."  # IGNORE:TK
-          fi
+        uses: aaronsteers/tk-todo-check-action@v1.0.0  # IGNORE:TK

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,0 +1,45 @@
+name: TK-TODO Check  # IGNORE:TK - this workflow checks for TK-TODO markers
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  tk-todo-check:  # IGNORE:TK
+    name: Check for TK-TODO markers  # IGNORE:TK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Check for TK-TODO markers  # IGNORE:TK
+        run: |
+          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line  # IGNORE:TK
+          # Exit with error if any are found
+
+          echo "Checking for TK-TODO markers..."  # IGNORE:TK
+
+          # Use git ls-files to only check tracked files (excludes gitignored files)
+          # grep -i for case-insensitive matching
+          # grep -v for excluding lines with IGNORE:TK
+          # grep -n for line numbers
+
+          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true)  # IGNORE:TK
+
+          if [ -n "$FOUND_TODOS" ]; then
+            echo ""
+            echo "ERROR: Found TK-TODO markers that must be resolved before merge:"  # IGNORE:TK
+            echo ""
+            echo "$FOUND_TODOS"
+            echo ""
+            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line."  # IGNORE:TK
+            echo ""
+            exit 1
+          else
+            echo "No unresolved TK-TODO markers found."  # IGNORE:TK
+          fi

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Check for TK-TODO markers  # IGNORE:TK
-        uses: aaronsteers/tk-todo-check-action@v1.0.0  # IGNORE:TK
+        uses: aaronsteers/tk-todo-check-action@76cd8dbb434bc93c7898ebdf43eff6105ca186ac # v1.0.0 IGNORE:TK


### PR DESCRIPTION
## Summary

Adds a `TK-TODO Check` workflow, mirroring the existing pattern in `fastmcp-extensions` and `airbyte-ops-mcp`. On PRs and pushes to `main`, it fails if any tracked file contains a `TK-TODO` marker (case-insensitive) without an `IGNORE:TK` suppression on the same line:

```
git ls-files | xargs grep -i -n "TK-TODO" | grep -i -v "IGNORE:TK"
```

The `actions/checkout` step uses the same pinned SHA as the other PyAirbyte workflows. Verified locally that the repo currently has no unsuppressed markers, and that the workflow passes `actionlint`.

Requested by AJ Steers.

Link to Devin session: https://app.devin.ai/sessions/7e2c7fa291e447c5ae872011d209eb85
Open in Devin Desktop: https://app.devin.ai/desktop/session/7e2c7fa291e447c5ae872011d209eb85?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for unresolved `TK-TODO` markers on pushes to the main branch and on pull requests.
  * Checks provide visibility into outstanding follow-up items during code review and continuous integration.
  * The validation runs with read-only access and uses a fixed, verified checker version for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._