### PR TITLE
feat(mcp): add typed Airbyte Agents entity tools

### DIFF
--- a/airbyte/mcp/__init__.py
+++ b/airbyte/mcp/__init__.py
@@ -312,11 +312,12 @@ For issues and questions:
 
 """  # noqa: D415
 
-from airbyte.mcp import agents, cloud, local, registry, server
+from airbyte.mcp import agents, agents_entities, cloud, local, registry, server
 
 
 __all__: list[str] = [
     "agents",
+    "agents_entities",
     "cloud",
     "local",
     "registry",

--- a/airbyte/mcp/agents_entities.py
+++ b/airbyte/mcp/agents_entities.py
@@ -1,0 +1,553 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Airbyte Agents entity MCP operations.
+
+.. include:: ../../docs/mcp-generated/agents_entities.md
+"""
+
+# No public Python API — MCP primitives are registered via decorators and
+# documented via the generated Markdown include above. Setting `__all__` to an
+# empty list tells pdoc (and other doc tools) not to surface the individual
+# tool / helper definitions as a redundant "API Documentation" list.
+__all__: list[str] = []
+
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from fastmcp_extensions import mcp_tool, register_mcp_tools
+from pydantic import BaseModel, Field
+
+from airbyte.exceptions import PyAirbyteInputError
+from airbyte.mcp._tool_utils import AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET
+from airbyte.mcp.agents import (
+    AGENTS_AUTH_TIP_TEXT,
+    WORKSPACE_ID_TIP_TEXT,
+    AgentExecuteToolResult,
+    _execute,
+)
+from airbyte.mcp.cloud import _add_defaults_for_exclude_args
+
+
+CONNECTOR_ID_TIP_TEXT = "The ID of the Airbyte Agents connector."
+ENTITY_TYPE_TIP_TEXT = (
+    "The type of entity to act on, for example 'issues'. Call `describe_agent_connector` "
+    "to see the entity types a connector supports."
+)
+API_ARGS_TIP_TEXT = (
+    "Connector-specific arguments for the action, as an object or a JSON object string. "
+    "For example {'repository': 'airbytehq/PyAirbyte'}."
+)
+
+
+class AgentEntityPageResult(BaseModel):
+    """One page of entities returned by an Airbyte Agents connector."""
+
+    status: str
+    """The execution status reported by the Agents API, for example `success`."""
+
+    entities: list[dict[str, Any]]
+    """The entities in this page."""
+
+    has_next_page: bool = False
+    """Whether the connector reported more entities after this page."""
+
+    end_cursor: str | None = None
+    """The cursor to pass as `cursor` to fetch the next page, when one is available."""
+
+    warning: dict[str, Any] | None = None
+    """A warning reported alongside an otherwise successful result."""
+
+
+class AgentEntityResult(BaseModel):
+    """A single entity returned by an Airbyte Agents connector."""
+
+    status: str
+    """The execution status reported by the Agents API, for example `success`."""
+
+    entity: dict[str, Any] | None = None
+    """The entity, or `null` when the connector found no match."""
+
+    warning: dict[str, Any] | None = None
+    """A warning reported alongside an otherwise successful result."""
+
+
+class AgentWriteResult(BaseModel):
+    """The outcome of a create, update, or delete action on an Airbyte Agents connector."""
+
+    status: str
+    """The execution status reported by the Agents API, for example `success`."""
+
+    entity: dict[str, Any] | None = None
+    """The written entity, when the connector echoes it back."""
+
+    result: Any = None
+    """The raw action payload, for connectors whose write response is not a single entity."""
+
+    warning: dict[str, Any] | None = None
+    """A warning reported alongside an otherwise successful result."""
+
+
+def _as_entity_list(result: AgentExecuteToolResult) -> list[dict[str, Any]]:
+    """Coerce an action payload into a list of entities."""
+    if result.result is None:
+        return []
+    if isinstance(result.result, dict):
+        return [result.result]
+    if isinstance(result.result, list) and all(
+        isinstance(entity, dict) for entity in result.result
+    ):
+        return result.result
+
+    raise PyAirbyteInputError(
+        message="This action did not return entities.",
+        guidance=(
+            "Use `execute_agent_connector_ro` to read the raw payload of actions that do "
+            "not return entities."
+        ),
+        context={"result_type": type(result.result).__name__},
+    )
+
+
+def _as_single_entity(result: AgentExecuteToolResult) -> dict[str, Any] | None:
+    """Coerce an action payload into at most one entity."""
+    entities = _as_entity_list(result)
+    if not entities:
+        return None
+    if len(entities) > 1:
+        raise PyAirbyteInputError(
+            message="This action returned more than one entity.",
+            guidance=(
+                "Narrow `api_args` to identify a single entity, or use "
+                "`list_agent_entities` to read a page of entities."
+            ),
+            context={"entity_count": len(entities)},
+        )
+    return entities[0]
+
+
+def _read_page(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
+    ctx: Context,
+    *,
+    connector_id: str,
+    workspace_id: str | None,
+    entity_type: str,
+    action: str,
+    api_args: dict[str, Any] | str | None,
+    select_fields: list[str] | str | None,
+    exclude_fields: list[str] | str | None,
+    page_size: int | None,
+    cursor: str | None,
+    intent: str | None,
+) -> AgentEntityPageResult:
+    """Run a page-returning read action and shape it into an `AgentEntityPageResult`."""
+    result = _execute(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action=action,
+        api_args=api_args,
+        select_fields=select_fields,
+        exclude_fields=exclude_fields,
+        page_size=page_size,
+        cursor=cursor,
+        intent=intent,
+        read_only=True,
+    )
+    return AgentEntityPageResult(
+        status=result.status,
+        entities=_as_entity_list(result),
+        has_next_page=result.has_next_page,
+        end_cursor=result.end_cursor,
+        warning=result.warning,
+    )
+
+
+def _write(
+    ctx: Context,
+    *,
+    connector_id: str,
+    workspace_id: str | None,
+    entity_type: str,
+    action: str,
+    api_args: dict[str, Any] | str,
+    intent: str | None,
+) -> AgentWriteResult:
+    """Run a write action and shape it into an `AgentWriteResult`."""
+    result = _execute(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action=action,
+        api_args=api_args,
+        select_fields=None,
+        exclude_fields=None,
+        page_size=None,
+        cursor=None,
+        intent=intent,
+    )
+    return AgentWriteResult(
+        status=result.status,
+        entity=result.result if isinstance(result.result, dict) else None,
+        result=result.result,
+        warning=result.warning,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def list_agent_entities(  # noqa: PLR0913  # Explicit args are the point of this tool.
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str | None,
+        Field(description=API_ARGS_TIP_TEXT, default=None),
+    ],
+    *,
+    select_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to keep in the returned entities, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
+    exclude_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to drop from the returned entities, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
+    page_size: Annotated[
+        int | None,
+        Field(description="Maximum number of entities to return in this page.", default=None),
+    ],
+    cursor: Annotated[
+        str | None,
+        Field(
+            description="Pagination cursor, taken from `end_cursor` of a previous result.",
+            default=None,
+        ),
+    ],
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the action is being run.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentEntityPageResult:
+    """List a page of entities of one type from an Airbyte Agents connector.
+
+    Entity types are connector-specific, so call `describe_agent_connector` first. Follow
+    `end_cursor` to read the next page while `has_next_page` is true. The connector must
+    belong to the given workspace.
+    """
+    return _read_page(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="list",
+        api_args=api_args,
+        select_fields=select_fields,
+        exclude_fields=exclude_fields,
+        page_size=page_size,
+        cursor=cursor,
+        intent=intent,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def search_agent_entities(  # noqa: PLR0913  # Explicit args are the point of this tool.
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str | None,
+        Field(
+            description=(
+                f"{API_ARGS_TIP_TEXT} Search terms are connector-specific and belong here, "
+                "for example {'query': 'flaky test'}."
+            ),
+            default=None,
+        ),
+    ],
+    *,
+    use_api_search: Annotated[
+        bool,
+        Field(
+            description=(
+                "Set to `true` to run the connector's `api_search` action, which queries the "
+                "upstream API directly instead of the Context Store."
+            ),
+            default=False,
+        ),
+    ],
+    select_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to keep in the returned entities, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
+    page_size: Annotated[
+        int | None,
+        Field(description="Maximum number of entities to return in this page.", default=None),
+    ],
+    cursor: Annotated[
+        str | None,
+        Field(
+            description="Pagination cursor, taken from `end_cursor` of a previous result.",
+            default=None,
+        ),
+    ],
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the action is being run.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentEntityPageResult:
+    """Search entities of one type on an Airbyte Agents connector.
+
+    Not every connector supports `search` for every entity type. Use `list_agent_entities`
+    when no search terms are needed. The connector must belong to the given workspace.
+    """
+    return _read_page(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="api_search" if use_api_search else "search",
+        api_args=api_args,
+        select_fields=select_fields,
+        exclude_fields=None,
+        page_size=page_size,
+        cursor=cursor,
+        intent=intent,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def get_agent_entity(
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str,
+        Field(
+            description=(
+                f"{API_ARGS_TIP_TEXT} The entity's identifying arguments belong here, for "
+                "example {'repository': 'airbytehq/PyAirbyte', 'number': 1127}."
+            ),
+        ),
+    ],
+    *,
+    select_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to keep in the returned entity, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the action is being run.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentEntityResult:
+    """Get a single entity of one type from an Airbyte Agents connector.
+
+    Which arguments identify an entity is connector-specific, so call
+    `describe_agent_connector` first. An action that returns more than one entity is
+    rejected: use `list_agent_entities` for that. The connector must belong to the given
+    workspace.
+    """
+    result = _execute(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="get",
+        api_args=api_args,
+        select_fields=select_fields,
+        exclude_fields=None,
+        page_size=None,
+        cursor=None,
+        intent=intent,
+        read_only=True,
+    )
+    return AgentEntityResult(
+        status=result.status,
+        entity=_as_single_entity(result),
+        warning=result.warning,
+    )
+
+
+@mcp_tool(
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def create_agent_entity(
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str,
+        Field(
+            description=(
+                f"{API_ARGS_TIP_TEXT} The new entity's fields belong here, for example "
+                "{'repository': 'airbytehq/PyAirbyte', 'title': 'Bug report'}."
+            ),
+        ),
+    ],
+    *,
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the entity is being created.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentWriteResult:
+    """Create an entity of one type on an Airbyte Agents connector.
+
+    This writes to the upstream system the connector is configured against. Which fields
+    are required is connector-specific, so call `describe_agent_connector` first. The
+    connector must belong to the given workspace.
+    """
+    return _write(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="create",
+        api_args=api_args,
+        intent=intent,
+    )
+
+
+@mcp_tool(
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def update_agent_entity(
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str,
+        Field(
+            description=(
+                f"{API_ARGS_TIP_TEXT} Both the entity's identifying arguments and the fields "
+                "to change belong here, for example {'number': 1127, 'state': 'closed'}."
+            ),
+        ),
+    ],
+    *,
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the entity is being updated.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentWriteResult:
+    """Update an entity of one type on an Airbyte Agents connector.
+
+    This writes to the upstream system the connector is configured against. Which fields
+    can be changed is connector-specific, so call `describe_agent_connector` first. The
+    connector must belong to the given workspace.
+    """
+    return _write(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="update",
+        api_args=api_args,
+        intent=intent,
+    )
+
+
+@mcp_tool(
+    destructive=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def delete_agent_entity(
+    ctx: Context,
+    connector_id: Annotated[str, Field(description=CONNECTOR_ID_TIP_TEXT)],
+    entity_type: Annotated[str, Field(description=ENTITY_TYPE_TIP_TEXT)],
+    api_args: Annotated[
+        dict[str, Any] | str,
+        Field(
+            description=(
+                f"{API_ARGS_TIP_TEXT} The entity's identifying arguments belong here, for "
+                "example {'repository': 'airbytehq/PyAirbyte', 'number': 1127}."
+            ),
+        ),
+    ],
+    *,
+    intent: Annotated[
+        str | None,
+        Field(description="A short description of why the entity is being deleted.", default=None),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(description=WORKSPACE_ID_TIP_TEXT, default=None),
+    ],
+) -> AgentWriteResult:
+    """Delete an entity of one type on an Airbyte Agents connector.
+
+    This deletes from the upstream system the connector is configured against and cannot be
+    undone by PyAirbyte. Which arguments identify an entity is connector-specific, so call
+    `describe_agent_connector` first. The connector must belong to the given workspace.
+    """
+    return _write(
+        ctx,
+        connector_id=connector_id,
+        workspace_id=workspace_id,
+        entity_type=entity_type,
+        action="delete",
+        api_args=api_args,
+        intent=intent,
+    )
+
+
+def register_agent_entity_tools(app: FastMCP) -> None:
+    """Register the Airbyte Agents entity tools with the FastMCP app."""
+    exclude_args = ["workspace_id"] if AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET else None
+    if exclude_args:
+        _add_defaults_for_exclude_args(exclude_args)
+    register_mcp_tools(
+        app,
+        mcp_module=__name__,
+        exclude_args=exclude_args,
+    )

--- a/airbyte/mcp/agents_entities.py
+++ b/airbyte/mcp/agents_entities.py
@@ -302,6 +302,13 @@ def search_agent_entities(  # noqa: PLR0913  # Explicit args are the point of th
             default=None,
         ),
     ],
+    exclude_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to drop from the returned entities, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
     page_size: Annotated[
         int | None,
         Field(description="Maximum number of entities to return in this page.", default=None),
@@ -335,7 +342,7 @@ def search_agent_entities(  # noqa: PLR0913  # Explicit args are the point of th
         action="api_search" if use_api_search else "search",
         api_args=api_args,
         select_fields=select_fields,
-        exclude_fields=None,
+        exclude_fields=exclude_fields,
         page_size=page_size,
         cursor=cursor,
         intent=intent,
@@ -369,6 +376,13 @@ def get_agent_entity(
             default=None,
         ),
     ],
+    exclude_fields: Annotated[
+        list[str] | str | None,
+        Field(
+            description="Fields to drop from the returned entity, as a list or a CSV string.",
+            default=None,
+        ),
+    ],
     intent: Annotated[
         str | None,
         Field(description="A short description of why the action is being run.", default=None),
@@ -393,7 +407,7 @@ def get_agent_entity(
         action="get",
         api_args=api_args,
         select_fields=select_fields,
-        exclude_fields=None,
+        exclude_fields=exclude_fields,
         page_size=None,
         cursor=None,
         intent=intent,

--- a/airbyte/mcp/server.py
+++ b/airbyte/mcp/server.py
@@ -89,6 +89,7 @@ from airbyte.mcp._tool_utils import (
     validate_airbyte_domains,
 )
 from airbyte.mcp.agents import register_agents_tools
+from airbyte.mcp.agents_entities import register_agent_entity_tools
 from airbyte.mcp.cloud import register_cloud_tools
 from airbyte.mcp.interactive import register_interactive_tools
 from airbyte.mcp.local import register_local_tools
@@ -369,6 +370,7 @@ app = mcp_server(
 # Register tools from each module
 register_cloud_tools(app)
 register_agents_tools(app)
+register_agent_entity_tools(app)
 register_local_tools(app)
 register_registry_tools(app)
 register_interactive_tools(app)

--- a/tests/unit_tests/test_mcp_agent_entities.py
+++ b/tests/unit_tests/test_mcp_agent_entities.py
@@ -126,6 +126,7 @@ def test_search_entities_selects_action(
         api_args='{"query": "flaky"}',
         use_api_search=use_api_search,
         select_fields=None,
+        exclude_fields=None,
         page_size=None,
         cursor=None,
         intent=None,
@@ -163,6 +164,7 @@ def test_get_entity_coerces_payload(
             entity_type="issues",
             api_args={"number": 1127},
             select_fields=None,
+            exclude_fields=None,
             intent=None,
             workspace_id="workspace-id",
         )

--- a/tests/unit_tests/test_mcp_agent_entities.py
+++ b/tests/unit_tests/test_mcp_agent_entities.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for the typed Airbyte Agents entity MCP tools."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from airbyte.agents.models import (
+    AgentConnectorMetadata,
+    AgentExecuteResult,
+    AgentExecutionMetadata,
+)
+from airbyte.exceptions import PyAirbyteInputError
+from airbyte.mcp import agents as agents_mcp
+from airbyte.mcp import agents_entities as entities_mcp
+from fastmcp import Context
+
+
+CTX = cast(Context, object())
+DEFAULT_PAYLOAD: Any = [{"id": "1"}]
+
+
+class _AgentConnectorLike:
+    """Records forwarded arguments and returns a caller-supplied payload."""
+
+    def __init__(
+        self,
+        payload: Any = DEFAULT_PAYLOAD,  # noqa: ANN401  # Any action payload.
+    ) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def execute(
+        self,
+        entity: str,
+        action: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to the recorded call.
+    ) -> AgentExecuteResult:
+        """Record the call and return the configured payload."""
+        self.calls.append({
+            "entity": entity,
+            "action": action,
+            "api_args": api_args,
+            **kwargs,
+        })
+        return AgentExecuteResult(
+            status="success",
+            result=self.payload,
+            connector_metadata=AgentConnectorMetadata(
+                has_next_page=True,
+                end_cursor="cursor-2",
+            ),
+            execution_metadata=AgentExecutionMetadata(
+                connector_instance_id="connector-id",
+                execution_time_ms=42,
+            ),
+        )
+
+
+@pytest.fixture
+def connector_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Any:  # noqa: ANN401  # Returns a closure over the patched resolver.
+    """Return a factory that patches the connector resolver with a recording stub."""
+
+    def _factory(payload: Any = DEFAULT_PAYLOAD) -> _AgentConnectorLike:  # noqa: ANN401
+        stub = _AgentConnectorLike(payload)
+        monkeypatch.setattr(
+            agents_mcp,
+            "_get_agent_connector",
+            lambda ctx, connector_id, workspace_id=None: stub,
+        )
+        return stub
+
+    return _factory
+
+
+def test_list_entities_shapes_page(connector_factory: Any) -> None:  # noqa: ANN401
+    """Verify `list_agent_entities` returns entities plus the pagination cursor."""
+    connector = connector_factory([{"id": "1"}, {"id": "2"}])
+
+    result = entities_mcp.list_agent_entities(
+        ctx=CTX,
+        connector_id="connector-id",
+        entity_type="issues",
+        api_args={"repository": "airbytehq/PyAirbyte"},
+        select_fields="id,title",
+        exclude_fields=None,
+        page_size=2,
+        cursor="cursor-1",
+        intent=None,
+        workspace_id="workspace-id",
+    )
+
+    assert result.entities == [{"id": "1"}, {"id": "2"}]
+    assert result.has_next_page is True
+    assert result.end_cursor == "cursor-2"
+    assert connector.calls[0]["action"] == "list"
+    assert connector.calls[0]["select_fields"] == ["id", "title"]
+    assert connector.calls[0]["page_size"] == 2
+    assert connector.calls[0]["cursor"] == "cursor-1"
+
+
+@pytest.mark.parametrize(
+    ("use_api_search", "expected_action"),
+    [
+        pytest.param(False, "search", id="context_store_search"),
+        pytest.param(True, "api_search", id="upstream_api_search"),
+    ],
+)
+def test_search_entities_selects_action(
+    connector_factory: Any,  # noqa: ANN401
+    use_api_search: bool,
+    expected_action: str,
+) -> None:
+    """Verify `use_api_search` chooses between the two search actions."""
+    connector = connector_factory()
+
+    entities_mcp.search_agent_entities(
+        ctx=CTX,
+        connector_id="connector-id",
+        entity_type="issues",
+        api_args='{"query": "flaky"}',
+        use_api_search=use_api_search,
+        select_fields=None,
+        page_size=None,
+        cursor=None,
+        intent=None,
+        workspace_id="workspace-id",
+    )
+
+    assert connector.calls[0]["action"] == expected_action
+    assert connector.calls[0]["api_args"] == {"query": "flaky"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_entity", "is_rejected"),
+    [
+        pytest.param({"id": "1"}, {"id": "1"}, False, id="single_object"),
+        pytest.param([{"id": "1"}], {"id": "1"}, False, id="single_item_list"),
+        pytest.param([], None, False, id="no_match"),
+        pytest.param(None, None, False, id="null_payload"),
+        pytest.param([{"id": "1"}, {"id": "2"}], None, True, id="multiple_matches"),
+        pytest.param("not-an-entity", None, True, id="non_entity_payload"),
+    ],
+)
+def test_get_entity_coerces_payload(
+    connector_factory: Any,  # noqa: ANN401
+    payload: Any,  # noqa: ANN401
+    expected_entity: dict[str, Any] | None,
+    is_rejected: bool,
+) -> None:
+    """Verify `get_agent_entity` returns at most one entity, or raises when it cannot."""
+    connector_factory(payload)
+
+    def _call() -> entities_mcp.AgentEntityResult:
+        return entities_mcp.get_agent_entity(
+            ctx=CTX,
+            connector_id="connector-id",
+            entity_type="issues",
+            api_args={"number": 1127},
+            select_fields=None,
+            intent=None,
+            workspace_id="workspace-id",
+        )
+
+    if is_rejected:
+        with pytest.raises(PyAirbyteInputError):
+            _call()
+        return
+
+    assert _call().entity == expected_entity
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected_action"),
+    [
+        pytest.param("create_agent_entity", "create", id="create"),
+        pytest.param("update_agent_entity", "update", id="update"),
+        pytest.param("delete_agent_entity", "delete", id="delete"),
+    ],
+)
+def test_write_tools_forward_action_and_payload(
+    connector_factory: Any,  # noqa: ANN401
+    tool_name: str,
+    expected_action: str,
+) -> None:
+    """Verify each write tool runs its own action and echoes the written entity."""
+    connector = connector_factory({"id": "1", "state": "closed"})
+
+    result = getattr(entities_mcp, tool_name)(
+        ctx=CTX,
+        connector_id="connector-id",
+        entity_type="issues",
+        api_args='{"number": 1127}',
+        intent="closing a stale issue",
+        workspace_id="workspace-id",
+    )
+
+    assert connector.calls[0]["action"] == expected_action
+    assert connector.calls[0]["api_args"] == {"number": 1127}
+    assert connector.calls[0]["intent"] == "closing a stale issue"
+    assert result.entity == {"id": "1", "state": "closed"}
+
+
+def test_entity_tools_are_registered_with_expected_hints() -> None:
+    """Verify the entity tools reach the server with the intended annotations."""
+    from airbyte.mcp.server import app  # noqa: PLC0415  # Importing builds the server.
+
+    tools = {tool.name: tool for tool in asyncio.run(app._list_tools())}  # noqa: SLF001
+
+    for read_tool in (
+        "list_agent_entities",
+        "search_agent_entities",
+        "get_agent_entity",
+    ):
+        assert tools[read_tool].annotations.readOnlyHint is True
+
+    for write_tool in (
+        "create_agent_entity",
+        "update_agent_entity",
+        "delete_agent_entity",
+    ):
+        assert tools[write_tool].annotations.readOnlyHint is False
+
+    assert tools["delete_agent_entity"].annotations.destructiveHint is True
+    assert tools["create_agent_entity"].annotations.destructiveHint is False


### PR DESCRIPTION
## Summary

Requested by AJ Steers as the follow-up to the merged Agents base work (#1127), which shipped the generic pair `execute_agent_connector_ro` / `execute_agent_connector`. Those two are enough to reach any connector action, but they push two costs onto the calling agent: it has to know the action vocabulary, and it gets back `result: Any` with no shape.

This adds six action-specific MCP tools in a new `airbyte/mcp/agents_entities.py`, all thin presentation over the same hidden `_execute()` helper the generic tools use — no new transport, no new auth path, no change to `airbyte/agents/`.

```python
# read, annotated read_only=True idempotent=True, so they survive readonly mode
list_agent_entities(...)   -> AgentEntityPageResult   # action="list"
search_agent_entities(..., use_api_search=False) -> AgentEntityPageResult  # "search" | "api_search"
get_agent_entity(...)      -> AgentEntityResult      # action="get"

# write
create_agent_entity(...)   -> AgentWriteResult
update_agent_entity(...)   -> AgentWriteResult
delete_agent_entity(...)   -> AgentWriteResult       # destructive=True
```

Two things this buys beyond naming:

1. **Readonly mode gets real reads.** `readOnlyHint` is a static annotation read by the server's readonly filter before any call, so the generic write-capable tool vanishes whole in readonly mode. The three read tools here are statically read-only, so a readonly deployment can still list, search, and get.
2. **Typed returns instead of `Any`.** The generic result carries `result: Any`; these return the shape the action actually produces — a page (`entities`, `has_next_page`, `end_cursor`), a single `entity | None`, or a write ack. Coercion is strict rather than permissive: `get_agent_entity` raises `PyAirbyteInputError` if the connector returns more than one entity, and any non-object payload is rejected rather than passed through as a mystery blob.

`entity_type` stays a free string, since `inspect` publishes only Context Store entities, not everything `execute()` accepts — typing it would reject legitimate calls.

Deliberately not done: no seventh tool for `api_search` (same read shape as `search`, so it's a `use_api_search` flag), and no separate `record`/`fields` argument on the writes — the payload stays in `api_args`, which is where the connector-specific arguments already live.

`workspace_id` behaves exactly as in the generic tools: exposed as an argument, hidden when statically configured, and the connector is resolved through its workspace so a connector belonging to another workspace is rejected before any action runs.

## Test Plan

- `uv run pytest tests/unit_tests/test_mcp_agent_entities.py tests/unit_tests/test_mcp_agents.py` — 13 new cases, 43 total, passing. Covers page shaping and cursor passthrough, the `use_api_search` action switch, all six coercion outcomes for `get_agent_entity` (including the multi-match and non-object rejections), per-tool action/payload forwarding on the writes, and a live-server assertion that the read tools register with `readOnlyHint=true` and `delete_agent_entity` with `destructiveHint=true`.
- `uv run ruff format` / `uv run ruff check` / `uv run pyrefly check` clean.
- `uv run poe mcp-docs-md` regenerates cleanly and emits `docs/mcp-generated/agents_entities.md` (gitignored, generated at build time).
- Live Agents execution is not exercised here; as in #1127 there are no cassettes for the Agents API.


Link to Devin session: https://app.devin.ai/sessions/57a0c3e7b98f4c52a9c09a5cd721ee3a
Open in Devin Desktop: https://app.devin.ai/desktop/session/57a0c3e7b98f4c52a9c09a5cd721ee3a?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Airbyte Agents entity tools for listing, searching, viewing, creating, updating, and deleting entities.
  * Added pagination, field selection, excluded-field filtering, search options, and workspace-aware configuration.
  * Registered the new tools with the MCP server, including clear status and warning information in results.

* **Tests**
  * Added coverage for entity retrieval, pagination, search handling, payload validation, write operations, and server registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->