### PR TITLE
docs(agents): add experimental warnings to Agents module docstrings

### DIFF
--- a/airbyte/agents/__init__.py
+++ b/airbyte/agents/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 """PyAirbyte classes and methods for the Airbyte Agents platform.
 
-> **WARNING:**
-> The Airbyte Agents interfaces in this module are experimental and may change without notice
-> between minor versions of PyAirbyte, including breaking changes to class names, method
-> signatures, and result models. Pin an exact PyAirbyte version if you depend on them.
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
 
 Airbyte Agents connectors expose read and write actions on individual entities, executed
 one action at a time, rather than the batch record replication that `airbyte.cloud`

--- a/airbyte/agents/connectors.py
+++ b/airbyte/agents/connectors.py
@@ -1,5 +1,12 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
-"""Airbyte Agents connectors, and the single-action `execute` interface."""
+"""Airbyte Agents connectors, and the single-action `execute` interface.
+
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+"""
 
 from __future__ import annotations
 

--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -1,6 +1,12 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 """Response models for the Airbyte Agents API.
 
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+
 All models allow extra fields, because the Agents API returns rich connector-specific
 payloads that PyAirbyte deliberately does not attempt to model exhaustively.
 """

--- a/airbyte/agents/organizations.py
+++ b/airbyte/agents/organizations.py
@@ -1,5 +1,12 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
-"""Airbyte Agents organizations."""
+"""Airbyte Agents organizations.
+
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+"""
 
 from __future__ import annotations
 

--- a/airbyte/agents/workspaces.py
+++ b/airbyte/agents/workspaces.py
@@ -1,5 +1,12 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
-"""Airbyte Agents workspaces."""
+"""Airbyte Agents workspaces.
+
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+"""
 
 from __future__ import annotations
 

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -1,6 +1,14 @@
 # Copyright (c) 2026 Airbyte, Inc., all rights reserved.
 """Airbyte Agents MCP operations.
 
+> ## ⚠️ Experimental Tools — Insiders Only
+>
+> **The Airbyte Agents MCP tools are experimental and hidden by default.** They are advertised
+> only when insiders mode is enabled (`AIRBYTE_MCP_INSIDERS` for stdio servers, `X-MCP-Insiders`
+> for hosted servers) or when the include-modules setting explicitly names `agents`. Tool names,
+> arguments, and result shapes may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+
 .. include:: ../../docs/mcp-generated/agents.md
 """
 


### PR DESCRIPTION
## Summary

Requested by AJ Steers: make the experimental status of the Airbyte Agents surfaces unmissable in the pdoc output, where previously only `airbyte.agents` (the package page) said anything and its child modules said nothing at all.

Docstring-only change, no code. Two warning variants, deliberately different:

- `airbyte.agents` and every child module (`connectors`, `models`, `organizations`, `workspaces`) get a warning about the Python interfaces only — class names, method signatures, and result models may change; pin an exact version. No mention of insiders mode, since the Python API is not gated.
- `airbyte.mcp.agents` gets the MCP variant, which additionally states that the tools are hidden by default and names the two ways to turn them on (`AIRBYTE_MCP_INSIDERS`, `X-MCP-Insiders`, or naming `agents` in include-modules).

Both use a blockquoted `##` heading so pdoc renders them as a large bold callout rather than an easily-skipped note; the pre-existing `> **NOTE:**`-style line in `airbyte/agents/__init__.py` is replaced by the louder form:

```markdown
> ## ⚠️ Experimental Interface
>
> **The Airbyte Agents Python interfaces are experimental.** ...
```

Note the insiders mechanism named in the `airbyte.mcp.agents` warning lands in #1135, which is not yet merged into `main`; that text is accurate once it does.

## Test plan

- `ruff format --check airbyte` and `ruff check airbyte` pass.
- Rendered each of the six modules through pdoc directly and asserted the warning appears in the generated HTML:
  ```
  ok airbyte.agents / .connectors / .models / .organizations / .workspaces / airbyte.mcp.agents
  ```


Link to Devin session: https://app.devin.ai/sessions/57a0c3e7b98f4c52a9c09a5cd721ee3a
Open in Devin Desktop: https://app.devin.ai/desktop/session/57a0c3e7b98f4c52a9c09a5cd721ee3a?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent experimental-interface warnings to Airbyte Agents and MCP documentation.
  * Clarified that class names, method signatures, tool arguments, and result formats may change or be removed between minor versions.
  * Documented that MCP Agent tools are hidden by default and require insiders mode or explicit inclusion.
  * Recommended pinning an exact PyAirbyte version when using these experimental interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._