### PR TITLE
feat(agents): rename describe to inspect and surface docs_skill_id

### DIFF
--- a/airbyte/agents/__init__.py
+++ b/airbyte/agents/__init__.py
@@ -67,7 +67,7 @@ organization = agents.AgentOrganization.from_env()
 for workspace in organization.list_workspaces():
     print(workspace.workspace_id, workspace.name)
 
-print(connector.describe().source_definition_name)
+print(connector.inspect().source_definition_name)
 ```
 
 Convert between the Cloud and Agents domains:

--- a/airbyte/agents/connectors.py
+++ b/airbyte/agents/connectors.py
@@ -151,10 +151,10 @@ class AgentConnector:
     def name(self) -> str | None:
         """The connector name, fetched from the Agents API if not already known."""
         if self._name is None:
-            self._name = self.describe().name
+            self._name = self.inspect().name
         return self._name
 
-    def describe(self, *, force_refresh: bool = False) -> AgentConnectorDetails:
+    def inspect(self, *, force_refresh: bool = False) -> AgentConnectorDetails:
         """Return connector metadata from the Agents API `inspect` endpoint.
 
         The result is cached; pass `force_refresh=True` to fetch it again.
@@ -186,7 +186,7 @@ class AgentConnector:
         """Execute a single action against one entity type on this connector.
 
         `entity_type` and `action` are connector-specific, for example `issues` and `list`.
-        Use `describe()` to see what a connector supports.
+        Use `inspect()` to see what a connector supports.
 
         `api_args` holds connector-specific arguments passed through to the connector, for
         example `{"repository": "airbytehq/PyAirbyte"}`. All other arguments are interpreted

--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -97,6 +97,9 @@ class AgentConnectorDetails(BaseModel):
     source_definition_name: str | None = None
     """The name of the underlying Airbyte source definition, for example `GitHub`."""
 
+    docs_skill_id: str | None = None
+    """Skill ID to pass to `read_skill_docs` for this connector's usage docs."""
+
     context_store_readiness: AgentContextStoreReadiness | None = None
     """Context Store readiness information, when reported."""
 

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -67,7 +67,7 @@ AGENTS_AUTH_TIP_TEXT = (
     f"headers. For local or stdio connections, set the `{CLOUD_BEARER_TOKEN_ENV_VAR}` "
     f"environment variable, or both `{CLOUD_CLIENT_ID_ENV_VAR}` and "
     f"`{CLOUD_CLIENT_SECRET_ENV_VAR}`. Call `list_agent_connectors` to discover connector "
-    f"IDs, then `describe_agent_connector` to learn which entities a connector supports, "
+    f"IDs, then `inspect_agent_connector` to learn which entities a connector supports, "
     f"before calling `execute_agent_connector`."
 )
 WORKSPACE_ID_TIP_TEXT = (
@@ -154,6 +154,7 @@ class AgentConnectorDetailsResult(BaseModel):
     source_definition_name: str | None = None
     """The name of the underlying source definition, for example `GitHub`."""
 
+    docs_skill_id: str | None = None
     context_store_entities: list[str]
     """Entities this connector can cache in the Context Store.
 
@@ -403,7 +404,7 @@ def list_agent_connectors(
     open_world=True,
     extra_help_text=AGENTS_AUTH_TIP_TEXT,
 )
-def describe_agent_connector(
+def inspect_agent_connector(
     ctx: Context,
     connector_id: Annotated[
         str,
@@ -418,13 +419,13 @@ def describe_agent_connector(
         ),
     ],
 ) -> AgentConnectorDetailsResult:
-    """Describe an Airbyte Agents connector, including its Context Store entities.
+    """Inspect an Airbyte Agents connector: metadata, Context Store readiness, warnings, and its `docs_skill_id`.
 
     Call this before `execute_agent_connector` to learn what the connector exposes. The
     connector must belong to the given workspace.
     """
     try:
-        details = _get_agent_connector(ctx, connector_id, workspace_id).describe()
+        details = _get_agent_connector(ctx, connector_id, workspace_id).inspect()
     except AirbyteError as error:
         message = _agents_access_message(error)
         if message is None:
@@ -441,6 +442,7 @@ def describe_agent_connector(
         connector_name=details.name,
         workspace_id=details.workspace_id,
         source_definition_name=details.source_definition_name,
+        docs_skill_id=details.docs_skill_id,
         context_store_entities=details.context_store_entities,
         warnings=[str(warning) for warning in details.warnings],
     )
@@ -463,7 +465,7 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
         Field(
             description=(
                 "The type of entity to act on, for example 'issues'. Call "
-                "`describe_agent_connector` to see the entity types a connector supports."
+                "`inspect_agent_connector` to see the entity types a connector supports."
             ),
         ),
     ],
@@ -526,8 +528,8 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
 
     This tool only accepts read actions, so it stays available in read-only mode. Use
     `execute_agent_connector` for actions that create, update, or delete data. Entity types
-    are connector-specific, so call `describe_agent_connector` first. The connector must
-    belong to the given workspace.
+    are connector-specific, so call `inspect_agent_connector`. The connector must belong
+    to the given workspace.
     """
     return _execute(
         ctx,
@@ -560,7 +562,7 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
         Field(
             description=(
                 "The type of entity to act on, for example 'issues'. Call "
-                "`describe_agent_connector` to see the entity types a connector supports."
+                "`inspect_agent_connector` to see the entity types a connector supports."
             ),
         ),
     ],
@@ -633,7 +635,7 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
 
     Prefer `execute_agent_connector_ro` when only reading, since it is available in
     read-only mode. Entity types and actions are connector-specific, so call
-    `describe_agent_connector` first. The connector must belong to the given workspace.
+    `inspect_agent_connector`. The connector must belong to the given workspace.
     """
     return _execute(
         ctx,

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -419,9 +419,10 @@ def inspect_agent_connector(
         ),
     ],
 ) -> AgentConnectorDetailsResult:
-    """Inspect an Airbyte Agents connector: metadata, Context Store readiness, warnings, and its `docs_skill_id`.
+    """Inspect an Airbyte Agents connector: metadata, readiness, warnings, and `docs_skill_id`.
 
-    Call this before `execute_agent_connector` to learn what the connector exposes. The
+    Includes Context Store readiness. Call this before `execute_agent_connector` to learn
+    what the connector exposes. The
     connector must belong to the given workspace.
     """
     try:

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -155,6 +155,8 @@ class AgentConnectorDetailsResult(BaseModel):
     """The name of the underlying source definition, for example `GitHub`."""
 
     docs_skill_id: str | None = None
+    """Skill ID for this connector's usage docs, when reported by the Agents API."""
+
     context_store_entities: list[str]
     """Entities this connector can cache in the Context Store.
 
@@ -421,8 +423,7 @@ def inspect_agent_connector(
 ) -> AgentConnectorDetailsResult:
     """Inspect an Airbyte Agents connector: metadata, readiness, warnings, and `docs_skill_id`.
 
-    Includes Context Store readiness. Call this before `execute_agent_connector` to learn
-    what the connector exposes. The
+    Call this before `execute_agent_connector` to learn what the connector exposes. The
     connector must belong to the given workspace.
     """
     try:
@@ -529,8 +530,8 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
 
     This tool only accepts read actions, so it stays available in read-only mode. Use
     `execute_agent_connector` for actions that create, update, or delete data. Entity types
-    are connector-specific, so call `inspect_agent_connector`. The connector must belong
-    to the given workspace.
+    are connector-specific, so call `inspect_agent_connector` first. The connector must
+    belong to the given workspace.
     """
     return _execute(
         ctx,
@@ -636,7 +637,7 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
 
     Prefer `execute_agent_connector_ro` when only reading, since it is available in
     read-only mode. Entity types and actions are connector-specific, so call
-    `inspect_agent_connector`. The connector must belong to the given workspace.
+    `inspect_agent_connector` first. The connector must belong to the given workspace.
     """
     return _execute(
         ctx,

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -33,6 +33,7 @@ INSPECT_RESPONSE: dict[str, Any] = {
     "name": "GitHub",
     "workspace_id": "workspace-id",
     "source_definition_name": "GitHub",
+    "docs_skill_id": "connector:github",
     "context_store_readiness": {
         "supported_context_store_entities": [
             {"entity": "issues", "suggested": True},
@@ -333,20 +334,21 @@ def test_entities(
         assert result.entities == expectation
 
 
-def test_describe(captured_requests: list[dict[str, Any]]) -> None:
-    """`describe()` parses the inspect response and caches it."""
+def test_inspect(captured_requests: list[dict[str, Any]]) -> None:
+    """`inspect()` parses the inspect response and caches it."""
     connector = _connector()
-    details = connector.describe()
+    details = connector.inspect()
 
     assert details.name == "GitHub"
     assert details.source_definition_name == "GitHub"
+    assert details.docs_skill_id == "connector:github"
     assert details.context_store_entities == ["issues", "repositories"]
     assert connector.name == "GitHub"
 
-    connector.describe()
+    connector.inspect()
     assert len(captured_requests) == 1
 
-    connector.describe(force_refresh=True)
+    connector.inspect(force_refresh=True)
     assert len(captured_requests) == 2
 
 

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -89,7 +89,7 @@ class _RaisingConnector:
         """Raise the configured error."""
         raise self._error
 
-    def describe(self) -> Any:  # noqa: ANN401
+    def inspect(self) -> Any:  # noqa: ANN401
         """Raise the configured error."""
         raise self._error
 
@@ -234,18 +234,19 @@ def test_read_only_tool_action_type_excludes_writes() -> None:
     assert "download" not in set(agents_mcp.get_args(agents_mcp.AgentAction))
 
 
-def test_describe_tool_reports_context_store_entities(
+def test_inspect_tool_reports_context_store_entities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify `describe_agent_connector` surfaces entities and warnings."""
+    """Verify `inspect_agent_connector` surfaces entities, docs, and warnings."""
 
-    class _DescribableConnector:
-        def describe(self) -> AgentConnectorDetails:
+    class _InspectableConnector:
+        def inspect(self) -> AgentConnectorDetails:
             return AgentConnectorDetails(
                 connector_id="connector-id",
                 name="GitHub",
                 workspace_id="workspace-id",
                 source_definition_name="GitHub",
+                docs_skill_id="connector:github",
                 context_store_readiness=AgentContextStoreReadiness(
                     supported_context_store_entities=[
                         AgentContextStoreEntity(entity="issues")
@@ -257,16 +258,17 @@ def test_describe_tool_reports_context_store_entities(
     monkeypatch.setattr(
         agents_mcp,
         "_get_agent_connector",
-        lambda ctx, connector_id, workspace_id=None: _DescribableConnector(),
+        lambda ctx, connector_id, workspace_id=None: _InspectableConnector(),
     )
 
-    result = agents_mcp.describe_agent_connector(
+    result = agents_mcp.inspect_agent_connector(
         ctx=cast(Context, object()),
         connector_id="connector-id",
         workspace_id="workspace-id",
     )
 
     assert result.context_store_entities == ["issues"]
+    assert result.docs_skill_id == "connector:github"
     assert result.warnings == ["Context Store is still syncing."]
 
 
@@ -393,13 +395,13 @@ _ACCESS_FAILURE_CASES = [
     pytest.param(
         "_get_agent_connector",
         _RaisingConnector,
-        lambda: agents_mcp.describe_agent_connector(
+        lambda: agents_mcp.inspect_agent_connector(
             ctx=cast(Context, object()),
             connector_id="connector-id",
             workspace_id="workspace-1",
         ),
         {"context_store_entities": [], "connector_id": "connector-id"},
-        id="describe",
+        id="inspect",
     ),
 ]
 """Each Agents tool, the resolver it fails in, how to call it, and its empty payload."""


### PR DESCRIPTION
## Summary

Aligns the PyAirbyte Agents surface with Sonar's agent-engine-mcp, which is dropping "describe" in favor of `inspect_connector` + skills (per review of the Agents/Cloud-MCP interop proposal). Requested by AJ.

- `AgentConnector.describe()` → `AgentConnector.inspect()` (no alias; the method already called the `/integrations/connectors/{id}/inspect` endpoint).
- MCP tool `describe_agent_connector` → `inspect_agent_connector`; all tool descriptions/tip text updated to reference it.
- `AgentConnectorDetails` and `AgentConnectorDetailsResult` gain `docs_skill_id: str | None`, passed through from the inspect response. This is the handle a follow-up PR will use for skill-docs reading (`read_skill_docs`); that tool is intentionally not in this PR pending signature design.

Resulting Agent MCP tool set: `list_agent_workspaces`, `list_agent_connectors`, `inspect_agent_connector`, `execute_agent_connector_ro`, `execute_agent_connector`.

## Test plan

- `ruff format --check .`, `ruff check .` — pass
- `pytest tests/unit_tests/test_agents.py tests/unit_tests/test_mcp_agents.py` — 99 passed (tests renamed; `docs_skill_id` pass-through asserted in both lib and MCP tests)
- `poe mcp-inspect --tools` confirms the tool list above and no remaining `describe_agent_connector`
- `poe mcp-docs-md` produced no diff in committed generated docs

Link to Devin session: https://app.devin.ai/sessions/b5c7ceffab6c409595db5a6712af4e7c
Open in Devin Desktop: https://app.devin.ai/desktop/session/b5c7ceffab6c409595db5a6712af4e7c?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connector documentation skill identifiers to inspection results.
  * Updated connector metadata access from “describe” to “inspect.”
  * Renamed the connector inspection tool and refreshed related guidance.

* **Bug Fixes**
  * Updated connector name resolution and execution guidance to use the new inspection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->