### PR TITLE
feat(cloud): use async command API for connector checks

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import base64
 import json
+import time
+import uuid
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1914,7 +1916,7 @@ def _make_config_api_request(
     return response.json()
 
 
-def check_connector(
+def check_connector(  # noqa: PLR0913  # Explicit auth and timeout arguments are part of the API.
     *,
     actor_id: str,
     connector_type: Literal["source", "destination"],
@@ -1924,20 +1926,93 @@ def check_connector(
     workspace_id: str | None = None,
     api_root: str = CLOUD_API_ROOT,
     config_api_root: str | None = None,
+    wait_timeout: int = 300,
 ) -> tuple[bool, str | None]:
-    """Check a source.
+    """Check a connector using the platform command API.
 
-    Raises an exception if the check fails. Uses one of these endpoints:
-
-    - /v1/sources/check_connection: https://github.com/airbytehq/airbyte-platform-internal/blob/10bb92e1745a282e785eedfcbed1ba72654c4e4e/oss/airbyte-api/server-api/src/main/openapi/config.yaml#L1409
-    - /v1/destinations/check_connection: https://github.com/airbytehq/airbyte-platform-internal/blob/10bb92e1745a282e785eedfcbed1ba72654c4e4e/oss/airbyte-api/server-api/src/main/openapi/config.yaml#L1995
+    Uses `runCheckCommand`, `getCommandStatus`, `getCheckCommandOutput`, and `cancelCommand`
+    from the [Config API](https://github.com/airbytehq/airbyte-platform-internal/blob/master/oss/airbyte-api/server-api/src/main/openapi/config.yaml).
     """
-    _ = workspace_id  # Not used (yet)
+    command_id = run_check_command(
+        actor_id=actor_id,
+        workspace_id=workspace_id,
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+    start_time = time.time()
+    while True:
+        status = get_command_status(
+            command_id=command_id,
+            api_root=api_root,
+            config_api_root=config_api_root,
+            client_id=client_id,
+            client_secret=client_secret,
+            bearer_token=bearer_token,
+        )
+        if status not in {"pending", "running"}:
+            break
+        if time.time() - start_time > wait_timeout:
+            raise AirbyteError(
+                message="Check command timed out.",
+                context={
+                    "actor_id": actor_id,
+                    "connector_type": connector_type,
+                    "command_id": command_id,
+                    "timeout": wait_timeout,
+                },
+            )
+        time.sleep(JOB_WAIT_INTERVAL_SECS)
 
-    json_result = _make_config_api_request(
-        path=f"/{connector_type}s/check_connection",
+    if status == "cancelled":
+        return False, "Check command was cancelled."
+
+    output = get_check_command_output(
+        command_id=command_id,
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+    if output.get("status") == "succeeded":
+        return True, None
+    if output.get("status") == "failed":
+        failure_reason = output.get("failureReason") or {}
+        return False, failure_reason.get("externalMessage") or output.get("message")
+
+    raise AirbyteError(
+        context={
+            "actor_id": actor_id,
+            "connector_type": connector_type,
+            "command_id": command_id,
+            "response": output,
+        },
+    )
+
+
+def run_check_command(
+    *,
+    actor_id: str,
+    workspace_id: str | None,
+    command_id: str | None = None,
+    api_root: str = CLOUD_API_ROOT,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> str:
+    """Start an asynchronous connector check command."""
+    if command_id is None:
+        command_id = str(uuid.uuid4())
+    response = _make_config_api_request(
+        path="/commands/run/check",
         json={
-            f"{connector_type}Id": actor_id,
+            "id": command_id,
+            "actor_id": actor_id,
+            "workspace_id": workspace_id,
         },
         api_root=api_root,
         config_api_root=config_api_root,
@@ -1945,20 +2020,83 @@ def check_connector(
         client_secret=client_secret,
         bearer_token=bearer_token,
     )
-    result, message = json_result.get("status"), json_result.get("message")
+    response_id = response.get("id")
+    if not response_id:
+        raise AirbyteError(
+            message="Check command response is missing an ID.",
+            context={"actor_id": actor_id, "response": response},
+        )
+    return response_id
 
-    if result == "succeeded":
-        return True, None
 
-    if result == "failed":
-        return False, message
+def get_command_status(
+    *,
+    command_id: str,
+    api_root: str = CLOUD_API_ROOT,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> str:
+    """Get the status of an asynchronous command."""
+    response = _make_config_api_request(
+        path="/commands/status",
+        json={"id": command_id},
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+    status = response.get("status")
+    if not status:
+        raise AirbyteError(
+            message="Command status response is missing a status.",
+            context={"command_id": command_id, "response": response},
+        )
+    return status
 
-    raise AirbyteError(
-        context={
-            "actor_id": actor_id,
-            "connector_type": connector_type,
-            "response": json_result,
-        },
+
+def get_check_command_output(
+    *,
+    command_id: str,
+    with_logs: bool = False,
+    api_root: str = CLOUD_API_ROOT,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> dict[str, Any]:
+    """Get the output of an asynchronous connector check command."""
+    return _make_config_api_request(
+        path="/commands/output/check",
+        json={"id": command_id, "with_logs": with_logs},
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
+    )
+
+
+def cancel_command(
+    *,
+    command_id: str,
+    api_root: str = CLOUD_API_ROOT,
+    config_api_root: str | None = None,
+    client_id: SecretString | None,
+    client_secret: SecretString | None,
+    bearer_token: SecretString | None,
+) -> None:
+    """Cancel an asynchronous command."""
+    _make_config_api_request(
+        path="/commands/cancel",
+        json={"id": command_id},
+        api_root=api_root,
+        config_api_root=config_api_root,
+        client_id=client_id,
+        client_secret=client_secret,
+        bearer_token=bearer_token,
     )
 
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -29,6 +29,7 @@ from airbyte.constants import CLOUD_API_ROOT, CLOUD_CONFIG_API_ROOT, CLOUD_CONFI
 from airbyte.exceptions import (
     AirbyteConnectionSyncActiveError,
     AirbyteConnectionSyncError,
+    AirbyteConnectorCheckTimeoutError,
     AirbyteError,
     AirbyteMissingResourceError,
     AirbyteMultipleResourcesError,
@@ -1955,14 +1956,10 @@ def check_connector(  # noqa: PLR0913  # Explicit auth and timeout arguments are
         if status not in {"pending", "running"}:
             break
         if time.time() - start_time > wait_timeout:
-            raise AirbyteError(
-                message="Check command timed out.",
-                context={
-                    "actor_id": actor_id,
-                    "connector_type": connector_type,
-                    "command_id": command_id,
-                    "timeout": wait_timeout,
-                },
+            raise AirbyteConnectorCheckTimeoutError(
+                connector_id=actor_id,
+                command_id=command_id,
+                timeout=wait_timeout,
             )
         time.sleep(JOB_WAIT_INTERVAL_SECS)
 

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -1981,6 +1981,7 @@ def check_connector(  # noqa: PLR0913  # Explicit auth and timeout arguments are
         return False, failure_reason.get("externalMessage") or output.get("message")
 
     raise AirbyteError(
+        message="Check command returned an unexpected output status.",
         context={
             "actor_id": actor_id,
             "connector_type": connector_type,

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2005,13 +2005,12 @@ def run_check_command(
     """Start an asynchronous connector check command."""
     if command_id is None:
         command_id = str(uuid.uuid4())
+    request_json: dict[str, Any] = {"id": command_id, "actor_id": actor_id}
+    if workspace_id is not None:
+        request_json["workspace_id"] = workspace_id
     response = _make_config_api_request(
         path="/commands/run/check",
-        json={
-            "id": command_id,
-            "actor_id": actor_id,
-            "workspace_id": workspace_id,
-        },
+        json=request_json,
         api_root=api_root,
         config_api_root=config_api_root,
         client_id=client_id,

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -210,7 +210,12 @@ class CheckResult:
 
     def __str__(self) -> str:
         """Get a string representation of the check result."""
-        return "Success" if self.success else f"Failed: {self.error_message}"
+        if self.success:
+            return "Success"
+        failure_message = (
+            self.error_message or self.internal_error or "No failure message provided."
+        )
+        return f"Failed: {failure_message}"
 
     def __repr__(self) -> str:
         """Get a string representation of the check result."""

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -94,7 +94,7 @@ class CheckResult:
 
     def get_status(self) -> str:
         """Return the latest command status."""
-        if self._status in {"completed", "cancelled"}:
+        if self._status is not None and self._status not in {"pending", "running"}:
             return self._status
         if self.connector is None or self.command_id is None:
             return self._status or "completed"
@@ -111,7 +111,7 @@ class CheckResult:
 
     def is_complete(self) -> bool:
         """Return whether the command has reached a final status."""
-        return self.get_status() in {"completed", "cancelled"}
+        return self.get_status() not in {"pending", "running"}
 
     def wait_for_completion(
         self,
@@ -124,7 +124,7 @@ class CheckResult:
         start_time = time.time()
         while True:
             if self.is_complete():
-                self._refresh_output()
+                self.refresh()
                 if raise_failure and not self:
                     raise ValueError(f"Check failed: {self}")
                 return self
@@ -172,11 +172,14 @@ class CheckResult:
         logs = response.get("logs") or {}
         return logs.get("logLines") or []
 
-    def _refresh_output(self) -> None:
-        """Refresh the check result from the command output."""
+    def refresh(self) -> None:
+        """Refresh success and error fields from the command output."""
         if self.connector is None or self.command_id is None:
             return
-        if self.get_status() == "cancelled":
+        status = self.get_status()
+        if status in {"pending", "running"}:
+            return
+        if status == "cancelled":
             self.success = False
             self.error_message = "Check command was cancelled."
             return
@@ -337,7 +340,7 @@ class CloudConnector(abc.ABC):
         else:
             check_result.get_status()
             if check_result.is_complete():
-                check_result._refresh_output()  # noqa: SLF001
+                check_result.refresh()
 
         if raise_on_error and check_result.is_complete() and not check_result:
             raise ValueError(f"Check failed: {check_result}")

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -27,7 +27,8 @@ workspace = CloudWorkspace(
 cloud_source = workspace.get_source("...")
 
 # Check the source configuration and credentials
-check_result = cloud_source.check()
+check_result = cloud_source.check(wait=False)
+check_result.wait_for_completion()
 if check_result:
     # Truthy if the check was successful
     print("Check successful")
@@ -40,6 +41,7 @@ else:
 from __future__ import annotations
 
 import abc
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -62,11 +64,14 @@ if TYPE_CHECKING:
     from airbyte.cloud.workspaces import CloudWorkspace
 
 
+DEFAULT_CHECK_TIMEOUT_SECONDS = 300
+
+
 @dataclass
 class CheckResult:
     """A cloud check result object."""
 
-    success: bool
+    success: bool = False
     """Whether the check result is valid."""
 
     error_message: str | None = None
@@ -74,6 +79,130 @@ class CheckResult:
 
     internal_error: str | None = None
     """None if the check was able to be run. Otherwise, this will describe the internal failure."""
+
+    command_id: str | None = None
+    """The ID of the asynchronous check command."""
+
+    failure_type: str | None = None
+    """The failure type returned by the check command."""
+
+    connector: CloudConnector | None = None
+    """The connector being checked."""
+
+    _status: str | None = None
+    """The latest command status."""
+
+    def get_status(self) -> str:
+        """Return the latest command status."""
+        if self._status in {"completed", "cancelled"}:
+            return self._status
+        if self.connector is None or self.command_id is None:
+            return self._status or "completed"
+
+        self._status = api_util.get_command_status(
+            command_id=self.command_id,
+            api_root=self.connector.workspace.api_root,
+            config_api_root=self.connector.workspace.config_api_root,
+            client_id=self.connector.workspace.client_id,
+            client_secret=self.connector.workspace.client_secret,
+            bearer_token=self.connector.workspace.bearer_token,
+        )
+        return self._status
+
+    def is_complete(self) -> bool:
+        """Return whether the command has reached a final status."""
+        return self.get_status() in {"completed", "cancelled"}
+
+    def wait_for_completion(
+        self,
+        *,
+        wait_timeout: int = DEFAULT_CHECK_TIMEOUT_SECONDS,
+        raise_timeout: bool = True,
+        raise_failure: bool = False,
+    ) -> CheckResult:
+        """Wait for the check command to finish running."""
+        start_time = time.time()
+        while True:
+            if self.is_complete():
+                self._refresh_output()
+                if raise_failure and not self:
+                    raise ValueError(f"Check failed: {self}")
+                return self
+
+            if time.time() - start_time > wait_timeout:
+                if raise_timeout:
+                    connector_id = self.connector.connector_id if self.connector else None
+                    raise exc.AirbyteConnectorCheckTimeoutError(
+                        connector_id=connector_id,
+                        command_id=self.command_id,
+                        timeout=wait_timeout,
+                    )
+                return self
+
+            time.sleep(api_util.JOB_WAIT_INTERVAL_SECS)
+
+    def cancel(self) -> None:
+        """Cancel the check command."""
+        if self.connector is None or self.command_id is None:
+            raise exc.PyAirbyteInputError(
+                message="A connector and command ID are required to cancel a check."
+            )
+        api_util.cancel_command(
+            command_id=self.command_id,
+            api_root=self.connector.workspace.api_root,
+            config_api_root=self.connector.workspace.config_api_root,
+            client_id=self.connector.workspace.client_id,
+            client_secret=self.connector.workspace.client_secret,
+            bearer_token=self.connector.workspace.bearer_token,
+        )
+
+    def get_logs(self) -> list[str]:
+        """Return the logs from the check command."""
+        if self.connector is None or self.command_id is None or self.get_status() == "cancelled":
+            return []
+        response = api_util.get_check_command_output(
+            command_id=self.command_id,
+            with_logs=True,
+            api_root=self.connector.workspace.api_root,
+            config_api_root=self.connector.workspace.config_api_root,
+            client_id=self.connector.workspace.client_id,
+            client_secret=self.connector.workspace.client_secret,
+            bearer_token=self.connector.workspace.bearer_token,
+        )
+        logs = response.get("logs") or {}
+        return logs.get("logLines") or []
+
+    def _refresh_output(self) -> None:
+        """Refresh the check result from the command output."""
+        if self.connector is None or self.command_id is None:
+            return
+        if self.get_status() == "cancelled":
+            self.success = False
+            self.error_message = "Check command was cancelled."
+            return
+
+        response = api_util.get_check_command_output(
+            command_id=self.command_id,
+            api_root=self.connector.workspace.api_root,
+            config_api_root=self.connector.workspace.config_api_root,
+            client_id=self.connector.workspace.client_id,
+            client_secret=self.connector.workspace.client_secret,
+            bearer_token=self.connector.workspace.bearer_token,
+        )
+        status = response.get("status")
+        failure_reason = response.get("failureReason") or {}
+        self.success = status == "succeeded"
+        self.error_message = (
+            None
+            if self.success
+            else failure_reason.get("externalMessage") or response.get("message")
+        )
+        self.failure_type = failure_reason.get("failureType")
+        self.internal_error = (
+            failure_reason.get("internalMessage")
+            if not self.success and not failure_reason.get("externalMessage")
+            else None
+        )
 
     def __bool__(self) -> bool:
         """Truthy when check was successful."""
@@ -85,10 +214,13 @@ class CheckResult:
 
     def __repr__(self) -> str:
         """Get a string representation of the check result."""
-        return (
+        result = (
             f"CheckResult(success={self.success}, "
             f"error_message={self.error_message or self.internal_error})"
         )
+        if self.command_id:
+            result = result[:-1] + f", command_id={self.command_id!r})"
+        return result
 
 
 class CloudConnector(abc.ABC):
@@ -166,29 +298,43 @@ class CloudConnector(abc.ABC):
         self,
         *,
         raise_on_error: bool = True,
+        wait: bool = True,
+        wait_timeout: int = DEFAULT_CHECK_TIMEOUT_SECONDS,
+        command_id: str | None = None,
     ) -> CheckResult:
         """Check the connector.
 
-        Returns:
-            A `CheckResult` object containing the result. The object is truthy if the check was
-            successful and falsy otherwise. The error message is available in the `error_message`
-            or by converting the object to a string.
+        Runs the check asynchronously via the platform command API. With `wait=True` (default) this
+        blocks until the check completes. With `wait=False` it returns immediately; use
+        `CheckResult.wait_for_completion()` or call `check(command_id=..., wait=False)` to poll.
+        Pass `command_id` to attach to an existing check command instead of starting a new one.
         """
-        result = api_util.check_connector(
-            workspace_id=self.workspace.workspace_id,
-            connector_type=self.connector_type,
-            actor_id=self.connector_id,
-            api_root=self.workspace.api_root,
-            client_id=self.workspace.client_id,
-            client_secret=self.workspace.client_secret,
-            bearer_token=self.workspace.bearer_token,
-            config_api_root=self.workspace.config_api_root,
-        )
+        if command_id is None:
+            command_id = api_util.run_check_command(
+                actor_id=self.connector_id,
+                workspace_id=self.workspace.workspace_id,
+                api_root=self.workspace.api_root,
+                config_api_root=self.workspace.config_api_root,
+                client_id=self.workspace.client_id,
+                client_secret=self.workspace.client_secret,
+                bearer_token=self.workspace.bearer_token,
+            )
         check_result = CheckResult(
-            success=result[0],
-            error_message=result[1],
+            command_id=command_id,
+            connector=self,
         )
-        if raise_on_error and not check_result:
+        if wait:
+            check_result.wait_for_completion(
+                wait_timeout=wait_timeout,
+                raise_timeout=True,
+                raise_failure=False,
+            )
+        else:
+            check_result.get_status()
+            if check_result.is_complete():
+                check_result._refresh_output()  # noqa: SLF001
+
+        if raise_on_error and check_result.is_complete() and not check_result:
             raise ValueError(f"Check failed: {check_result}")
 
         return check_result

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -655,6 +655,20 @@ class AirbyteConnectionSyncTimeoutError(AirbyteConnectionSyncError):
     """The timeout in seconds that was reached."""
 
 
+@dataclass
+class AirbyteConnectorCheckTimeoutError(AirbyteError):
+    """A timeout occurred while waiting for the connector check to complete."""
+
+    connector_id: str | None = None
+    """The connector ID being checked."""
+
+    command_id: str | None = None
+    """The command ID being checked."""
+
+    timeout: int | None = None
+    """The timeout in seconds that was reached."""
+
+
 # Airbyte Resource Errors (General)
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -101,7 +101,7 @@ def _get_connector_check_message(
     status: str,
 ) -> str | None:
     """Return the check failure message, if applicable."""
-    if status != "completed" or check_result.success:
+    if status in {"pending", "running"} or check_result.success:
         return None
     return (
         check_result.error_message

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -95,9 +95,13 @@ def _handle_discovery_permission_error(
     )
 
 
-def _get_connector_check_message(check_result: CheckResult) -> str | None:
+def _get_connector_check_message(
+    check_result: CheckResult,
+    *,
+    status: str,
+) -> str | None:
     """Return the check failure message, if applicable."""
-    if check_result.success:
+    if status != "completed" or check_result.success:
         return None
     return (
         check_result.error_message
@@ -1169,12 +1173,13 @@ def check_cloud_source(
         wait_timeout=wait_timeout,
         command_id=command_id,
     )
+    status = check_result.get_status()
     return ConnectorCheckResult(
         connector_id=source_id,
         connector_type=source.connector_type,
-        status=check_result.get_status(),
+        status=status,
         succeeded=check_result.success,
-        message=_get_connector_check_message(check_result),
+        message=_get_connector_check_message(check_result, status=status),
         command_id=check_result.command_id,
         failure_type=check_result.failure_type,
     )
@@ -1233,12 +1238,13 @@ def check_cloud_destination(
         wait_timeout=wait_timeout,
         command_id=command_id,
     )
+    status = check_result.get_status()
     return ConnectorCheckResult(
         connector_id=destination_id,
         connector_type=destination.connector_type,
-        status=check_result.get_status(),
+        status=status,
         succeeded=check_result.success,
-        message=_get_connector_check_message(check_result),
+        message=_get_connector_check_message(check_result, status=status),
         command_id=check_result.command_id,
         failure_type=check_result.failure_type,
     )

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -318,10 +318,16 @@ class ConnectorCheckResult(BaseModel):
     """The deployed connector ID."""
     connector_type: Literal["source", "destination"]
     """The connector type: 'source' or 'destination'."""
+    status: Literal["pending", "running", "completed", "cancelled"]
+    """The current status of the connector check."""
     succeeded: bool
-    """Whether the connector check succeeded."""
+    """Whether the connector check succeeded, meaningful once `status` is `completed`."""
     message: str | None
-    """The failure message when the check failed, otherwise None."""
+    """The failure message, meaningful once `status` is `completed`; otherwise None."""
+    command_id: str | None = None
+    """The asynchronous check command ID."""
+    failure_type: str | None = None
+    """The failure type returned by the check command."""
 
 
 class SyncJobListResult(BaseModel):
@@ -1130,16 +1136,47 @@ def check_cloud_source(
             default=None,
         ),
     ],
+    wait: Annotated[
+        bool,
+        Field(
+            description="If true (default), block until the check completes. If false, return "
+            "immediately; poll again by passing the returned `command_id`.",
+            default=True,
+        ),
+    ],
+    wait_timeout: Annotated[
+        int,
+        Field(
+            description="Max seconds to wait for the check to complete when `wait` is true.",
+            default=300,
+        ),
+    ],
+    command_id: Annotated[
+        str | None,
+        Field(
+            description="ID of an in-progress check command to poll, instead of starting a new "
+            "check.",
+            default=None,
+        ),
+    ],
 ) -> ConnectorCheckResult:
     """Check the configuration and credentials of a deployed source connector."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     source = workspace.get_source(source_id=source_id)
-    check_result = source.check(raise_on_error=False)
+    check_result = source.check(
+        raise_on_error=False,
+        wait=wait,
+        wait_timeout=wait_timeout,
+        command_id=command_id,
+    )
     return ConnectorCheckResult(
         connector_id=source_id,
         connector_type=source.connector_type,
+        status=check_result.get_status(),
         succeeded=check_result.success,
         message=_get_connector_check_message(check_result),
+        command_id=check_result.command_id,
+        failure_type=check_result.failure_type,
     )
 
 
@@ -1163,16 +1200,47 @@ def check_cloud_destination(
             default=None,
         ),
     ],
+    wait: Annotated[
+        bool,
+        Field(
+            description="If true (default), block until the check completes. If false, return "
+            "immediately; poll again by passing the returned `command_id`.",
+            default=True,
+        ),
+    ],
+    wait_timeout: Annotated[
+        int,
+        Field(
+            description="Max seconds to wait for the check to complete when `wait` is true.",
+            default=300,
+        ),
+    ],
+    command_id: Annotated[
+        str | None,
+        Field(
+            description="ID of an in-progress check command to poll, instead of starting a new "
+            "check.",
+            default=None,
+        ),
+    ],
 ) -> ConnectorCheckResult:
     """Check the configuration and credentials of a deployed destination connector."""
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     destination = workspace.get_destination(destination_id=destination_id)
-    check_result = destination.check(raise_on_error=False)
+    check_result = destination.check(
+        raise_on_error=False,
+        wait=wait,
+        wait_timeout=wait_timeout,
+        command_id=command_id,
+    )
     return ConnectorCheckResult(
         connector_id=destination_id,
         connector_type=destination.connector_type,
+        status=check_result.get_status(),
         succeeded=check_result.success,
         message=_get_connector_check_message(check_result),
+        command_id=check_result.command_id,
+        failure_type=check_result.failure_type,
     )
 
 

--- a/tests/unit_tests/test_cloud_connectors_check.py
+++ b/tests/unit_tests/test_cloud_connectors_check.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 import responses
 
+from airbyte.cloud.connectors import CheckResult
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteConnectorCheckTimeoutError
 
@@ -163,6 +164,13 @@ def test_check_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(ValueError, match="Check failed: Failed: Check failed."):
         _workspace().get_source(CONNECTOR_ID).check()
+
+
+def test_check_result_str_uses_internal_error() -> None:
+    """Verify check result strings include an internal failure message."""
+    result = CheckResult(success=False, internal_error="Check service unavailable")
+
+    assert str(result) == "Failed: Check service unavailable"
 
 
 @responses.activate

--- a/tests/unit_tests/test_cloud_connectors_check.py
+++ b/tests/unit_tests/test_cloud_connectors_check.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for asynchronous Cloud connector checks."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import responses
+
+from airbyte.cloud.workspaces import CloudWorkspace
+from airbyte.exceptions import AirbyteConnectorCheckTimeoutError
+
+
+CONFIG_API_ROOT = "https://cloud.airbyte.com/api/v1"
+CONNECTOR_ID = "connector-id"
+COMMAND_ID = "command-id"
+
+
+def _workspace() -> CloudWorkspace:
+    return CloudWorkspace(
+        workspace_id="workspace-id",
+        bearer_token="token",
+        api_root="https://api.airbyte.com/v1",
+        config_api_root=CONFIG_API_ROOT,
+    )
+
+
+def _register_check_endpoints(
+    statuses: list[str],
+    output: dict[str, Any] | None = None,
+) -> None:
+    responses.add(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/run/check",
+        json={"id": COMMAND_ID},
+    )
+    status_index = 0
+
+    def status_callback(request: Any) -> tuple[int, dict[str, str], str]:
+        nonlocal status_index
+        status = statuses[min(status_index, len(statuses) - 1)]
+        status_index += 1
+        return 200, {}, json.dumps({"id": COMMAND_ID, "status": status})
+
+    responses.add_callback(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/status",
+        callback=status_callback,
+        content_type="application/json",
+    )
+    if output is not None:
+        responses.add(
+            responses.POST,
+            f"{CONFIG_API_ROOT}/commands/output/check",
+            json=output,
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "statuses",
+        "output",
+        "expected_success",
+        "expected_message",
+        "expected_failure_type",
+        "wait",
+    ),
+    [
+        pytest.param(
+            ["pending", "completed"],
+            {"id": COMMAND_ID, "status": "succeeded"},
+            True,
+            None,
+            None,
+            True,
+            id="succeeded",
+        ),
+        pytest.param(
+            ["pending", "completed"],
+            {
+                "id": COMMAND_ID,
+                "status": "failed",
+                "failureReason": {
+                    "externalMessage": "Invalid credentials.",
+                    "failureType": "config_error",
+                },
+            },
+            False,
+            "Invalid credentials.",
+            "config_error",
+            True,
+            id="failed-with-failure-reason",
+        ),
+        pytest.param(
+            ["completed"],
+            {"id": COMMAND_ID, "status": "failed", "message": "Check failed."},
+            False,
+            "Check failed.",
+            None,
+            True,
+            id="failed-with-message",
+        ),
+        pytest.param(
+            ["cancelled"],
+            None,
+            False,
+            "Check command was cancelled.",
+            None,
+            True,
+            id="cancelled",
+        ),
+        pytest.param(
+            ["pending"],
+            None,
+            False,
+            None,
+            None,
+            False,
+            id="without-wait",
+        ),
+    ],
+)
+@responses.activate
+def test_check(
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: list[str],
+    output: dict[str, Any] | None,
+    expected_success: bool,
+    expected_message: str | None,
+    expected_failure_type: str | None,
+    wait: bool,
+) -> None:
+    """Verify Cloud connector checks map asynchronous command results."""
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    _register_check_endpoints(statuses, output)
+
+    result = (
+        _workspace()
+        .get_source(CONNECTOR_ID)
+        .check(
+            raise_on_error=False,
+            wait=wait,
+        )
+    )
+
+    assert result.success is expected_success
+    assert result.error_message == expected_message
+    assert result.failure_type == expected_failure_type
+    assert result.command_id == COMMAND_ID
+    assert result.is_complete() is (wait and statuses[-1] in {"completed", "cancelled"})
+
+
+@responses.activate
+def test_check_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify failed checks raise when requested."""
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    _register_check_endpoints(
+        ["completed"],
+        {"id": COMMAND_ID, "status": "failed", "message": "Check failed."},
+    )
+
+    with pytest.raises(ValueError, match="Check failed: Failed: Check failed."):
+        _workspace().get_source(CONNECTOR_ID).check()
+
+
+@responses.activate
+def test_check_attaches_to_existing_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify checks can attach to a command without starting another."""
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    responses.add(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/status",
+        json={"id": COMMAND_ID, "status": "completed"},
+    )
+    responses.add(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/output/check",
+        json={"id": COMMAND_ID, "status": "succeeded"},
+    )
+
+    result = (
+        _workspace()
+        .get_source(CONNECTOR_ID)
+        .check(
+            command_id=COMMAND_ID,
+            wait=True,
+        )
+    )
+
+    assert result.success
+    assert (
+        len([
+            call
+            for call in responses.calls
+            if "/commands/run/check" in call.request.url
+        ])
+        == 0
+    )
+
+
+@responses.activate
+def test_check_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify checks raise a typed timeout error."""
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    _register_check_endpoints(["pending"])
+
+    with pytest.raises(AirbyteConnectorCheckTimeoutError) as error:
+        _workspace().get_source(CONNECTOR_ID).check(wait_timeout=0)
+
+    assert error.value.connector_id == CONNECTOR_ID
+    assert error.value.command_id == COMMAND_ID
+
+
+@responses.activate
+def test_cancel_and_get_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify check cancellation and log retrieval."""
+    _register_check_endpoints(
+        ["pending"],
+    )
+    responses.add(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/cancel",
+        json={"id": COMMAND_ID},
+    )
+    responses.add(
+        responses.POST,
+        f"{CONFIG_API_ROOT}/commands/output/check",
+        json={
+            "id": COMMAND_ID,
+            "status": "succeeded",
+            "logs": {"logLines": ["line 1", "line 2"]},
+        },
+    )
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    result = _workspace().get_source(CONNECTOR_ID).check(wait=False)
+
+    result.cancel()
+    assert result.get_logs() == ["line 1", "line 2"]
+    assert any("/commands/cancel" in call.request.url for call in responses.calls)

--- a/tests/unit_tests/test_cloud_connectors_check.py
+++ b/tests/unit_tests/test_cloud_connectors_check.py
@@ -222,16 +222,33 @@ def test_check_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @responses.activate
-def test_cancel_and_get_logs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify check cancellation and log retrieval."""
-    _register_check_endpoints(
-        ["pending"],
-    )
+def test_cancel_skips_log_retrieval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify cancelled checks do not request logs."""
+    _register_check_endpoints(["pending", "cancelled"])
     responses.add(
         responses.POST,
         f"{CONFIG_API_ROOT}/commands/cancel",
         json={"id": COMMAND_ID},
     )
+    monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
+    result = (
+        _workspace()
+        .get_source(CONNECTOR_ID)
+        .check(
+            raise_on_error=False,
+            wait=False,
+        )
+    )
+
+    result.cancel()
+    assert result.get_logs() == []
+    assert any("/commands/cancel" in call.request.url for call in responses.calls)
+
+
+@responses.activate
+def test_get_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify check logs are retrieved from command output."""
+    _register_check_endpoints(["completed"])
     responses.add(
         responses.POST,
         f"{CONFIG_API_ROOT}/commands/output/check",
@@ -244,6 +261,4 @@ def test_cancel_and_get_logs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("airbyte.cloud.connectors.time.sleep", lambda _: None)
     result = _workspace().get_source(CONNECTOR_ID).check(wait=False)
 
-    result.cancel()
     assert result.get_logs() == ["line 1", "line 2"]
-    assert any("/commands/cancel" in call.request.url for call in responses.calls)

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -67,6 +67,9 @@ class _CheckableConnectorLike:
     connector_type: str
     result: CheckResult
     received_raise_on_error: bool | None = None
+    received_wait: bool | None = None
+    received_wait_timeout: int | None = None
+    received_command_id: str | None = None
 
     def check(
         self,
@@ -77,8 +80,10 @@ class _CheckableConnectorLike:
         command_id: str | None = None,
     ) -> CheckResult:
         """Capture the error handling option and return the configured result."""
-        _ = (wait, wait_timeout, command_id)
         self.received_raise_on_error = raise_on_error
+        self.received_wait = wait
+        self.received_wait_timeout = wait_timeout
+        self.received_command_id = command_id
         return self.result
 
 
@@ -431,7 +436,7 @@ def test_mcp_cloud_connections_apply_limit_after_status_filter(
             CheckResult(success=False, command_id="cmd-1", _status="pending"),
             "pending",
             False,
-            "Connector check failed without a failure message.",
+            None,
             "cmd-1",
             None,
             False,
@@ -484,6 +489,9 @@ def test_mcp_cloud_connector_checks_map_results(
     assert result.command_id == expected_command_id
     assert result.failure_type == expected_failure_type
     assert connector.received_raise_on_error is False
+    assert connector.received_wait is wait
+    assert connector.received_wait_timeout == 300
+    assert connector.received_command_id == expected_command_id
 
 
 def test_cancel_cloud_sync_returns_cancelled_job(

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -68,8 +68,16 @@ class _CheckableConnectorLike:
     result: CheckResult
     received_raise_on_error: bool | None = None
 
-    def check(self, *, raise_on_error: bool = True) -> CheckResult:
+    def check(
+        self,
+        *,
+        raise_on_error: bool = True,
+        wait: bool = True,
+        wait_timeout: int = 300,
+        command_id: str | None = None,
+    ) -> CheckResult:
         """Capture the error handling option and return the configured result."""
+        _ = (wait, wait_timeout, command_id)
         self.received_raise_on_error = raise_on_error
         return self.result
 
@@ -354,31 +362,80 @@ def test_mcp_cloud_connections_apply_limit_after_status_filter(
     ],
 )
 @pytest.mark.parametrize(
-    ("check_result", "expected_success", "expected_message"),
+    (
+        "check_result",
+        "expected_status",
+        "expected_success",
+        "expected_message",
+        "expected_command_id",
+        "expected_failure_type",
+        "wait",
+    ),
     [
         pytest.param(
             CheckResult(success=True),
+            "completed",
             True,
             None,
+            None,
+            None,
+            True,
             id="success",
         ),
         pytest.param(
             CheckResult(success=False, error_message="Invalid credentials"),
+            "completed",
             False,
             "Invalid credentials",
+            None,
+            None,
+            True,
             id="error-message",
         ),
         pytest.param(
             CheckResult(success=False, internal_error="Check service unavailable"),
+            "completed",
             False,
             "Check service unavailable",
+            None,
+            None,
+            True,
             id="internal-error",
         ),
         pytest.param(
             CheckResult(success=False),
+            "completed",
             False,
             "Connector check failed without a failure message.",
+            None,
+            None,
+            True,
             id="missing-message",
+        ),
+        pytest.param(
+            CheckResult(
+                success=False,
+                error_message="x",
+                failure_type="config_error",
+                command_id="cmd-1",
+            ),
+            "completed",
+            False,
+            "x",
+            "cmd-1",
+            "config_error",
+            True,
+            id="async-failure",
+        ),
+        pytest.param(
+            CheckResult(success=False, command_id="cmd-1", _status="pending"),
+            "pending",
+            False,
+            "Connector check failed without a failure message.",
+            "cmd-1",
+            None,
+            False,
+            id="async-pending",
         ),
     ],
 )
@@ -389,8 +446,12 @@ def test_mcp_cloud_connector_checks_map_results(
     connector_id: str,
     connector_type: str,
     check_result: CheckResult,
+    expected_status: str,
     expected_success: bool,
     expected_message: str | None,
+    expected_command_id: str | None,
+    expected_failure_type: str | None,
+    wait: bool,
 ) -> None:
     """Verify Cloud MCP connector checks map result fields and disable raising."""
     workspace = _ConnectorCheckWorkspace(check_result)
@@ -405,6 +466,9 @@ def test_mcp_cloud_connector_checks_map_results(
         tool(
             ctx=cast(Context, object()),
             workspace_id="workspace-id",
+            wait=wait,
+            wait_timeout=300,
+            command_id=check_result.command_id,
             **{connector_id_parameter: connector_id},
         ),
     )
@@ -414,8 +478,11 @@ def test_mcp_cloud_connector_checks_map_results(
     )
     assert result.connector_id == connector_id
     assert result.connector_type == connector_type
+    assert result.status == expected_status
     assert result.succeeded is expected_success
     assert result.message == expected_message
+    assert result.command_id == expected_command_id
+    assert result.failure_type == expected_failure_type
     assert connector.received_raise_on_error is False
 
 


### PR DESCRIPTION
## Summary

Moves Cloud connector checks off the legacy blocking Config API endpoint (`POST /{sources|destinations}/check_connection`) onto the platform's async command API (`runCheckCommand` → `getCommandStatus` → `getCheckCommandOutput`, plus `cancelCommand`) — the same path the webapp uses. Requested by AJ (@aaronsteers).

Note: this does **not** remove the Config API dependency. The command endpoints live on the same Config API root and are tagged `internal` in the spec; the Public API has no check endpoint at all.

**Core (`airbyte/cloud/connectors.py`)** — mirrors the `run_sync()` / `SyncResult` pattern:

```python
CloudConnector.check(*, raise_on_error=True, wait=True, wait_timeout=300, command_id=None) -> CheckResult
```
- `wait=True` (default) preserves existing blocking behavior.
- `wait=False` returns immediately with `command_id` populated.
- `command_id=...` attaches to an in-progress check instead of starting one.

`CheckResult` becomes a lazy handle (still constructible as before): new fields `command_id`, `failure_type`; new methods `get_status()`, `is_complete()`, `wait_for_completion(wait_timeout, raise_timeout, raise_failure)`, `cancel()`, `get_logs()`. `success`/`error_message` are populated from `/commands/output/check` once complete; `error_message` prefers `failureReason.externalMessage`, `internal_error` gets `internalMessage` when no external message exists. Timeouts raise new `exc.AirbyteConnectorCheckTimeoutError`.

**`api_util.py`**: adds `run_check_command()` (client-generated uuid4 as idempotency key), `get_command_status()`, `get_check_command_output()`, `cancel_command()`. `check_connector()` keeps its signature/return shape but is reimplemented on top of these (gains `wait_timeout`).

**MCP (`airbyte/mcp/cloud.py`)**: `check_cloud_source` / `check_cloud_destination` gain pass-through `wait` (default `True`), `wait_timeout`, `command_id` params. `ConnectorCheckResult` gains `status`, `command_id`, `failure_type`. Deliberate divergences from `run_cloud_sync`: `wait` defaults to `True` (checks take ~15s, and the tool was previously blocking), and polling is folded into the same tool via `command_id` rather than a separate status tool.

## Test plan

- `uv run ruff format . && uv run ruff check . && uv run pyrefly check` — clean.
- `uv run pytest tests/unit_tests/test_cloud_connectors_check.py tests/unit_tests/test_mcp_cloud.py` — 36 passed. New tests mock the four command endpoints and cover success, failure (`externalMessage`/`message`), cancelled, `raise_on_error`, `wait=False`, attaching by `command_id` (no run call made), timeout, `cancel()`, `get_logs()`, and MCP field mapping.
- Live smoke test against the Devin sandbox Cloud workspace: `check()` → succeeded; `check(wait=False)` → `pending` with command ID, then `wait_for_completion()` → succeeded; `check(command_id=..., wait=False)` → `completed`/succeeded.


Link to Devin session: https://app.devin.ai/sessions/adc8a64b563642cbb1aafc3656716715
Open in Devin Desktop: https://app.devin.ai/desktop/session/adc8a64b563642cbb1aafc3656716715?variant=devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector checks support asynchronous execution, status tracking, configurable timeouts, cancellation, and log retrieval.
  * Checks can return immediately or wait for completion, including resuming existing commands.
  * Results include lifecycle status, command identifiers, and failure details.
  * Cloud connector tools support waiting, timeout, and command-tracking options.

* **Bug Fixes**
  * Added dedicated timeout reporting and clearer handling of unexpected check results.
  * Improved status and failure messages for pending, running, and completed checks.

* **Tests**
  * Expanded coverage for successful, failed, cancelled, pending, timed-out, and resumed checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->