### PR TITLE
feat(mcp): add deferred_auth option to Cloud source and destination deploy tools

### DIFF
--- a/airbyte/cloud/_deferred_auth.py
+++ b/airbyte/cloud/_deferred_auth.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 SECRET_PLACEHOLDER = "__airbyte_placeholder__"
+_UNSET = object()
 
 
 def _schema_secret_paths(schema: Mapping[str, Any], prefix: str = "") -> set[str]:
@@ -143,7 +144,103 @@ def _select_branch(
     return None
 
 
-def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
+def _discriminator_values(schema: Mapping[str, Any]) -> dict[str, Any]:
+    properties = schema.get("properties", {})
+    if not isinstance(properties, Mapping):
+        return {}
+    values: dict[str, Any] = {}
+    for name, child in properties.items():
+        if not isinstance(name, str) or not isinstance(child, Mapping):
+            continue
+        if "const" in child:
+            values[name] = child["const"]
+            continue
+        enum = child.get("enum")
+        if isinstance(enum, list) and len(enum) == 1:
+            values[name] = enum[0]
+    return values
+
+
+def _is_secret_schema(schema: Mapping[str, Any]) -> bool:
+    return any(
+        (
+            schema.get("airbyte_secret") is True,
+            schema.get("writeOnly") is True,
+            schema.get("format") == "password",
+        )
+    )
+
+
+def _default_branch_value(
+    value: Mapping[str, Any],
+    schema: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], dict[str, Any]] | None:
+    for branch_key in ("oneOf", "anyOf"):
+        branches = schema.get(branch_key)
+        if not isinstance(branches, list):
+            continue
+        for branch in branches:
+            if not isinstance(branch, Mapping):
+                continue
+            properties = branch.get("properties", {})
+            if not isinstance(properties, Mapping):
+                continue
+            candidate = dict(value)
+            candidate.update(
+                {
+                    name: expected
+                    for name, expected in _discriminator_values(branch).items()
+                    if name not in candidate
+                }
+            )
+            required = branch.get("required", [])
+            if not isinstance(required, list):
+                required = []
+            satisfiable = True
+            for name in required:
+                if not isinstance(name, str) or name in candidate:
+                    continue
+                child = properties.get(name)
+                if not isinstance(child, Mapping):
+                    satisfiable = False
+                    break
+                if _is_secret_schema(child):
+                    candidate[name] = SECRET_PLACEHOLDER
+                elif "default" in child:
+                    candidate[name] = child["default"]
+                elif isinstance(child.get("oneOf"), list) or isinstance(child.get("anyOf"), list):
+                    nested = _default_branch_value({}, child)
+                    if nested is None:
+                        satisfiable = False
+                        break
+                    _, candidate[name] = nested
+                else:
+                    satisfiable = False
+                    break
+            if satisfiable:
+                return branch, candidate
+    return None
+
+
+def _is_required_container(
+    schema: Mapping[str, Any],
+    name: str,
+    child: Mapping[str, Any],
+) -> bool:
+    required = schema.get("required")
+    return (
+        isinstance(required, list)
+        and name in required
+        and any(key in child for key in ("properties", "allOf", "oneOf", "anyOf"))
+    )
+
+
+def _stub_missing_secrets(  # noqa: PLR0912
+    value: object,
+    schema: Mapping[str, Any],
+    *,
+    _allow_default_branch: bool = False,
+) -> object:
     """Fill missing secret fields with placeholder values.
 
     Missing secret properties receive placeholder values so required secret
@@ -152,18 +249,30 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
     """
     items = schema.get("items")
     if isinstance(value, list) and isinstance(items, Mapping):
-        return [_stub_missing_secrets(item, items) for item in value]
+        return [
+            _stub_missing_secrets(item, items, _allow_default_branch=_allow_default_branch)
+            for item in value
+        ]
     for branch_key in ("oneOf", "anyOf"):
         branches = schema.get(branch_key)
         if isinstance(branches, list) and isinstance(value, Mapping):
             branch = _select_branch(branches, value)
             if branch is not None:
                 value = _stub_missing_secrets(value, branch)
+            elif _allow_default_branch:
+                default_branch = _default_branch_value(value, {branch_key: branches})
+                if default_branch is not None:
+                    branch, value = default_branch
+                    value = _stub_missing_secrets(value, branch)
     all_of = schema.get("allOf")
     if isinstance(all_of, list):
         for branch in all_of:
             if isinstance(branch, Mapping):
-                value = _stub_missing_secrets(value, branch)
+                value = _stub_missing_secrets(
+                    value,
+                    branch,
+                    _allow_default_branch=_allow_default_branch,
+                )
     properties = schema.get("properties")
     if not isinstance(properties, Mapping) or not isinstance(value, Mapping):
         return value
@@ -180,15 +289,20 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
             if name not in result or result[name] is None:
                 result[name] = SECRET_PLACEHOLDER
         elif name in result:
-            result[name] = _stub_missing_secrets(result[name], child)
-        elif (
-            isinstance(schema.get("required"), list)
-            and name in schema["required"]
-            and ("properties" in child or "allOf" in child)
-            and _schema_secret_paths(child)
-        ):
-            materialized = _stub_missing_secrets({}, child)
-            if isinstance(materialized, dict) and materialized:
+            result[name] = _stub_missing_secrets(
+                result[name],
+                child,
+                _allow_default_branch=(
+                    isinstance(schema.get("required"), list) and name in schema["required"]
+                ),
+            )
+        elif _is_required_container(schema, name, child):
+            materialized = _stub_missing_secrets(
+                {},
+                child,
+                _allow_default_branch=True,
+            )
+            if isinstance(materialized, Mapping) and materialized:
                 result[name] = materialized
     return result
 

--- a/airbyte/cloud/_deferred_auth.py
+++ b/airbyte/cloud/_deferred_auth.py
@@ -79,7 +79,7 @@ def _select_branch(
                 if isinstance(enum, list) and len(enum) == 1:
                     discriminators[name] = enum[0]
         if discriminators and all(
-            value.get(name) == expected for name, expected in discriminators.items()
+            name in value and value[name] == expected for name, expected in discriminators.items()
         ):
             return branch
     return None

--- a/airbyte/cloud/_deferred_auth.py
+++ b/airbyte/cloud/_deferred_auth.py
@@ -8,7 +8,6 @@ from typing import Any
 
 
 SECRET_PLACEHOLDER = "__airbyte_placeholder__"
-_UNSET = object()
 
 
 def _schema_secret_paths(schema: Mapping[str, Any], prefix: str = "") -> set[str]:

--- a/airbyte/cloud/_deferred_auth.py
+++ b/airbyte/cloud/_deferred_auth.py
@@ -58,6 +58,64 @@ def _paths_present(value: object, prefix: str = "") -> set[str]:
     return paths
 
 
+def _supplied_secret_paths(
+    value: object,
+    schema: Mapping[str, Any],
+    prefix: str = "",
+) -> set[str]:
+    """Return secret paths with non-null values supplied in a configuration."""
+    paths: set[str] = set()
+    if (
+        prefix
+        and value is not None
+        and any(
+            (
+                schema.get("airbyte_secret") is True,
+                schema.get("writeOnly") is True,
+                schema.get("format") == "password",
+            )
+        )
+    ):
+        paths.add(prefix)
+
+    items = schema.get("items")
+    if isinstance(value, list) and isinstance(items, Mapping):
+        for item in value:
+            paths.update(_supplied_secret_paths(item, items, prefix))
+
+    if isinstance(value, Mapping):
+        for branch_key in ("oneOf", "anyOf"):
+            branches = schema.get(branch_key)
+            if not isinstance(branches, list):
+                continue
+            branch = _select_branch(branches, value)
+            selected_branches = (
+                [branch]
+                if branch is not None
+                else [candidate for candidate in branches if isinstance(candidate, Mapping)]
+            )
+            for candidate in selected_branches:
+                paths.update(_supplied_secret_paths(value, candidate, prefix))
+
+        all_of = schema.get("allOf")
+        if isinstance(all_of, list):
+            for branch in all_of:
+                if isinstance(branch, Mapping):
+                    paths.update(_supplied_secret_paths(value, branch, prefix))
+
+        properties = schema.get("properties")
+        if isinstance(properties, Mapping):
+            for name, child in properties.items():
+                if not isinstance(name, str) or not isinstance(child, Mapping):
+                    continue
+                if name not in value:
+                    continue
+                child_prefix = f"{prefix}.{name}" if prefix else name
+                paths.update(_supplied_secret_paths(value[name], child, child_prefix))
+
+    return paths
+
+
 def _select_branch(
     branches: list[Any],
     value: Mapping[str, Any],
@@ -123,6 +181,15 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
                 result[name] = SECRET_PLACEHOLDER
         elif name in result:
             result[name] = _stub_missing_secrets(result[name], child)
+        elif (
+            isinstance(schema.get("required"), list)
+            and name in schema["required"]
+            and ("properties" in child or "allOf" in child)
+            and _schema_secret_paths(child)
+        ):
+            materialized = _stub_missing_secrets({}, child)
+            if isinstance(materialized, dict) and materialized:
+                result[name] = materialized
     return result
 
 
@@ -131,5 +198,6 @@ __all__ = [
     "_paths_present",
     "_schema_secret_paths",
     "_select_branch",
+    "_supplied_secret_paths",
     "_stub_missing_secrets",
 ]

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -45,7 +45,13 @@ import yaml
 from airbyte import exceptions as exc
 from airbyte._util import api_util, text_util
 from airbyte._util.api_util import get_web_url_root
+from airbyte._util.registry_spec import get_connector_spec_from_registry
 from airbyte.cloud._credentials import _AirbyteCredentials
+from airbyte.cloud._deferred_auth import (
+    _paths_present,
+    _schema_secret_paths,
+    _stub_missing_secrets,
+)
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
 from airbyte.cloud.connectors import (
@@ -372,6 +378,7 @@ class CloudWorkspace:
         *,
         unique: bool = True,
         random_name_suffix: bool = False,
+        deferred_auth: bool = False,
     ) -> CloudSource:
         """Deploy a source to the workspace.
 
@@ -383,9 +390,32 @@ class CloudWorkspace:
             unique: Whether to require a unique name. If `True`, duplicate names
                 are not allowed. Defaults to `True`.
             random_name_suffix: Whether to append a random suffix to the name.
+            deferred_auth: Whether to create the source without working credentials so
+                the user can complete authentication in the Cloud UI.
         """
         source_config_dict = source._hydrated_config.copy()  # noqa: SLF001 (non-public API)
         source_config_dict["sourceType"] = source.name.replace("source-", "")
+        if deferred_auth:
+            spec_schema = get_connector_spec_from_registry(source.name, platform="cloud")
+            if spec_schema is None:
+                spec_schema = get_connector_spec_from_registry(
+                    source.name,
+                    platform="oss",
+                )
+            if spec_schema is None:
+                raise exc.PyAirbyteInputError(
+                    message=f"Could not fetch a configuration schema for '{source.name}'."
+                )
+            secret_fields = _schema_secret_paths(spec_schema)
+            supplied_secrets = _paths_present(source_config_dict).intersection(secret_fields) - {
+                "sourceType"
+            }
+            if supplied_secrets:
+                raise exc.PyAirbyteInputError(
+                    message="Secret values cannot be provided in config.",
+                    context={"secret_fields": sorted(supplied_secrets)},
+                )
+            source_config_dict = dict(_stub_missing_secrets(source_config_dict, spec_schema))
 
         if random_name_suffix:
             name += f" (ID: {text_util.generate_random_suffix()})"
@@ -419,6 +449,7 @@ class CloudWorkspace:
         *,
         unique: bool = True,
         random_name_suffix: bool = False,
+        deferred_auth: bool = False,
     ) -> CloudDestination:
         """Deploy a destination to the workspace.
 
@@ -431,12 +462,46 @@ class CloudWorkspace:
             unique: Whether to require a unique name. If `True`, duplicate names
                 are not allowed. Defaults to `True`.
             random_name_suffix: Whether to append a random suffix to the name.
+            deferred_auth: Whether to create the destination without working credentials so
+                the user can complete authentication in the Cloud UI.
         """
         if isinstance(destination, Destination):
             destination_conf_dict = destination._hydrated_config.copy()  # noqa: SLF001 (non-public API)
             destination_conf_dict["destinationType"] = destination.name.replace("destination-", "")
             # raise ValueError(destination_conf_dict)
+            if deferred_auth:
+                spec_schema = get_connector_spec_from_registry(
+                    destination.name,
+                    platform="cloud",
+                )
+                if spec_schema is None:
+                    spec_schema = get_connector_spec_from_registry(
+                        destination.name,
+                        platform="oss",
+                    )
+                if spec_schema is None:
+                    raise exc.PyAirbyteInputError(
+                        message=(
+                            f"Could not fetch a configuration schema for '{destination.name}'."
+                        )
+                    )
+                secret_fields = _schema_secret_paths(spec_schema)
+                supplied_secrets = _paths_present(destination_conf_dict).intersection(
+                    secret_fields
+                ) - {"destinationType"}
+                if supplied_secrets:
+                    raise exc.PyAirbyteInputError(
+                        message="Secret values cannot be provided in config.",
+                        context={"secret_fields": sorted(supplied_secrets)},
+                    )
+                destination_conf_dict = dict(
+                    _stub_missing_secrets(destination_conf_dict, spec_schema)
+                )
         else:
+            if deferred_auth:
+                raise exc.PyAirbyteInputError(
+                    message="deferred_auth requires a Destination object."
+                )
             destination_conf_dict = destination.copy()
             if "destinationType" not in destination_conf_dict:
                 raise exc.PyAirbyteInputError(

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -393,7 +393,10 @@ class CloudWorkspace:
             deferred_auth: Whether to create the source without working credentials so
                 the user can complete authentication in the Cloud UI.
         """
-        source_config_dict = source._hydrated_config.copy()  # noqa: SLF001 (non-public API)
+        if deferred_auth:
+            source_config_dict = source.get_config().copy()
+        else:
+            source_config_dict = source._hydrated_config.copy()  # noqa: SLF001 (non-public API)
         source_config_dict["sourceType"] = source.name.replace("source-", "")
         if deferred_auth:
             spec_schema = get_connector_spec_from_registry(source.name, platform="cloud")
@@ -469,7 +472,10 @@ class CloudWorkspace:
                 the user can complete authentication in the Cloud UI.
         """
         if isinstance(destination, Destination):
-            destination_conf_dict = destination._hydrated_config.copy()  # noqa: SLF001 (non-public API)
+            if deferred_auth:
+                destination_conf_dict = destination.get_config().copy()
+            else:
+                destination_conf_dict = destination._hydrated_config.copy()  # noqa: SLF001 (non-public API)
             destination_conf_dict["destinationType"] = destination.name.replace("destination-", "")
             # raise ValueError(destination_conf_dict)
             if deferred_auth:

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -48,9 +48,8 @@ from airbyte._util.api_util import get_web_url_root
 from airbyte._util.registry_spec import get_connector_spec_from_registry
 from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud._deferred_auth import (
-    _paths_present,
-    _schema_secret_paths,
     _stub_missing_secrets,
+    _supplied_secret_paths,
 )
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
@@ -409,8 +408,7 @@ class CloudWorkspace:
                 raise exc.PyAirbyteInputError(
                     message=f"Could not fetch a configuration schema for '{source.name}'."
                 )
-            secret_fields = _schema_secret_paths(spec_schema)
-            supplied_secrets = _paths_present(source_config_dict).intersection(secret_fields) - {
+            supplied_secrets = _supplied_secret_paths(source_config_dict, spec_schema) - {
                 "sourceType"
             }
             if supplied_secrets:
@@ -494,9 +492,9 @@ class CloudWorkspace:
                             f"Could not fetch a configuration schema for '{destination.name}'."
                         )
                     )
-                secret_fields = _schema_secret_paths(spec_schema)
-                supplied_secrets = _paths_present(destination_conf_dict).intersection(
-                    secret_fields
+                supplied_secrets = _supplied_secret_paths(
+                    destination_conf_dict,
+                    spec_schema,
                 ) - {"destinationType"}
                 if supplied_secrets:
                     raise exc.PyAirbyteInputError(

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import yaml
 
@@ -415,7 +415,10 @@ class CloudWorkspace:
                     message="Secret values cannot be provided in config.",
                     context={"secret_fields": sorted(supplied_secrets)},
                 )
-            source_config_dict = dict(_stub_missing_secrets(source_config_dict, spec_schema))
+            source_config_dict = cast(
+                dict[str, Any],
+                _stub_missing_secrets(source_config_dict, spec_schema),
+            )
 
         if random_name_suffix:
             name += f" (ID: {text_util.generate_random_suffix()})"
@@ -494,8 +497,8 @@ class CloudWorkspace:
                         message="Secret values cannot be provided in config.",
                         context={"secret_fields": sorted(supplied_secrets)},
                     )
-                destination_conf_dict = dict(
-                    _stub_missing_secrets(destination_conf_dict, spec_schema)
+                destination_conf_dict = cast(
+                    dict[str, Any], _stub_missing_secrets(destination_conf_dict, spec_schema)
                 )
         else:
             if deferred_auth:

--- a/airbyte/mcp/_deferred_auth.py
+++ b/airbyte/mcp/_deferred_auth.py
@@ -119,7 +119,7 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
             or child.get("format") == "password"
         )
         if is_secret:
-            if not result.get(name):
+            if name not in result or result[name] is None:
                 result[name] = SECRET_PLACEHOLDER
         elif name in result:
             result[name] = _stub_missing_secrets(result[name], child)

--- a/airbyte/mcp/_deferred_auth.py
+++ b/airbyte/mcp/_deferred_auth.py
@@ -92,12 +92,15 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
     fields are present in the configuration sent to the Cloud API at source
     create time.
     """
+    items = schema.get("items")
+    if isinstance(value, list) and isinstance(items, Mapping):
+        return [_stub_missing_secrets(item, items) for item in value]
     for branch_key in ("oneOf", "anyOf"):
         branches = schema.get(branch_key)
         if isinstance(branches, list) and isinstance(value, Mapping):
             branch = _select_branch(branches, value)
             if branch is not None:
-                return _stub_missing_secrets(value, branch)
+                value = _stub_missing_secrets(value, branch)
     all_of = schema.get("allOf")
     if isinstance(all_of, list):
         for branch in all_of:

--- a/airbyte/mcp/_deferred_auth.py
+++ b/airbyte/mcp/_deferred_auth.py
@@ -72,7 +72,7 @@ def _select_branch(
         for name, child in properties.items():
             if not isinstance(child, Mapping):
                 continue
-            if child.get("const") is not None:
+            if "const" in child:
                 discriminators[name] = child["const"]
             else:
                 enum = child.get("enum")
@@ -88,8 +88,9 @@ def _select_branch(
 def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
     """Fill missing secret fields with placeholder values.
 
-    Missing secret properties receive placeholder values so Cloud schema
-    validation passes at source create time.
+    Missing secret properties receive placeholder values so required secret
+    fields are present in the configuration sent to the Cloud API at source
+    create time.
     """
     for branch_key in ("oneOf", "anyOf"):
         branches = schema.get(branch_key)
@@ -97,6 +98,11 @@ def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
             branch = _select_branch(branches, value)
             if branch is not None:
                 return _stub_missing_secrets(value, branch)
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for branch in all_of:
+            if isinstance(branch, Mapping):
+                value = _stub_missing_secrets(value, branch)
     properties = schema.get("properties")
     if not isinstance(properties, Mapping) or not isinstance(value, Mapping):
         return value

--- a/airbyte/mcp/_deferred_auth.py
+++ b/airbyte/mcp/_deferred_auth.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Helpers for deferred Cloud connector authentication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+SECRET_PLACEHOLDER = "__airbyte_placeholder__"
+
+
+def _schema_secret_paths(schema: Mapping[str, Any], prefix: str = "") -> set[str]:
+    paths: set[str] = set()
+    if prefix and any(
+        (
+            schema.get("airbyte_secret") is True,
+            schema.get("writeOnly") is True,
+            schema.get("format") == "password",
+        )
+    ):
+        paths.add(prefix)
+    properties = schema.get("properties", {})
+    if isinstance(properties, Mapping):
+        for name, child in properties.items():
+            if not isinstance(name, str) or not isinstance(child, Mapping):
+                continue
+            path = f"{prefix}.{name}" if prefix else name
+            paths.update(_schema_secret_paths(child, path))
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        paths.update(_schema_secret_paths(items, prefix))
+    for branch_key in ("oneOf", "anyOf", "allOf"):
+        branches = schema.get(branch_key, [])
+        if not isinstance(branches, list):
+            continue
+        for branch in branches:
+            if isinstance(branch, Mapping):
+                paths.update(_schema_secret_paths(branch, prefix))
+    return paths
+
+
+def _paths_present(value: object, prefix: str = "") -> set[str]:
+    if isinstance(value, (list, tuple)):
+        paths: set[str] = set()
+        for item in value:
+            paths.update(_paths_present(item, prefix))
+        return paths
+    if not isinstance(value, Mapping):
+        return set()
+    paths: set[str] = set()
+    for name, child in value.items():
+        if not isinstance(name, str):
+            continue
+        path = f"{prefix}.{name}" if prefix else name
+        paths.add(path)
+        paths.update(_paths_present(child, path))
+    return paths
+
+
+def _select_branch(
+    branches: list[Any],
+    value: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    for branch in branches:
+        if not isinstance(branch, Mapping):
+            continue
+        properties = branch.get("properties", {})
+        if not isinstance(properties, Mapping):
+            continue
+        discriminators: dict[str, Any] = {}
+        for name, child in properties.items():
+            if not isinstance(child, Mapping):
+                continue
+            if child.get("const") is not None:
+                discriminators[name] = child["const"]
+            else:
+                enum = child.get("enum")
+                if isinstance(enum, list) and len(enum) == 1:
+                    discriminators[name] = enum[0]
+        if discriminators and all(
+            value.get(name) == expected for name, expected in discriminators.items()
+        ):
+            return branch
+    return None
+
+
+def _stub_missing_secrets(value: object, schema: Mapping[str, Any]) -> object:
+    """Fill missing secret fields with placeholder values.
+
+    Missing secret properties receive placeholder values so Cloud schema
+    validation passes at source create time.
+    """
+    for branch_key in ("oneOf", "anyOf"):
+        branches = schema.get(branch_key)
+        if isinstance(branches, list) and isinstance(value, Mapping):
+            branch = _select_branch(branches, value)
+            if branch is not None:
+                return _stub_missing_secrets(value, branch)
+    properties = schema.get("properties")
+    if not isinstance(properties, Mapping) or not isinstance(value, Mapping):
+        return value
+    result: dict[str, Any] = dict(value)
+    for name, child in properties.items():
+        if not isinstance(name, str) or not isinstance(child, Mapping):
+            continue
+        is_secret = (
+            child.get("airbyte_secret") is True
+            or child.get("writeOnly") is True
+            or child.get("format") == "password"
+        )
+        if is_secret:
+            if not result.get(name):
+                result[name] = SECRET_PLACEHOLDER
+        elif name in result:
+            result[name] = _stub_missing_secrets(result[name], child)
+    return result
+
+
+__all__ = [
+    "SECRET_PLACEHOLDER",
+    "_paths_present",
+    "_schema_secret_paths",
+    "_select_branch",
+    "_stub_missing_secrets",
+]

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -22,7 +22,6 @@ from pydantic import BaseModel, Field
 
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
-from airbyte._util.registry_spec import get_connector_spec_from_registry
 from airbyte.cloud.client import (
     CloudClient,
 )
@@ -52,11 +51,6 @@ from airbyte.exceptions import (
     PyAirbyteInputError,
 )
 from airbyte.mcp._arg_resolvers import resolve_connector_config, resolve_list_of_strings
-from airbyte.mcp._deferred_auth import (
-    _paths_present,
-    _schema_secret_paths,
-    _stub_missing_secrets,
-)
 from airbyte.mcp._tool_utils import (
     AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET,
     check_guid_created_in_session,
@@ -118,7 +112,7 @@ def _resolve_deferred_auth_config(
     config: dict | str | None,
     config_secret_name: str | None,
 ) -> dict[str, Any]:
-    """Resolve and stub a connector configuration for deferred Cloud authentication."""
+    """Resolve a connector configuration for deferred Cloud authentication."""
     if config_secret_name is not None:
         raise PyAirbyteInputError(
             message="config_secret_name cannot be used with deferred_auth.",
@@ -148,32 +142,7 @@ def _resolve_deferred_auth_config(
             context={"connector_name": connector_name},
         )
 
-    spec_schema = get_connector_spec_from_registry(
-        connector_name,
-        platform="cloud",
-    )
-    if spec_schema is None:
-        spec_schema = get_connector_spec_from_registry(
-            connector_name,
-            platform="oss",
-        )
-    if spec_schema is None:
-        raise PyAirbyteInputError(
-            message=f"Could not fetch a configuration schema for '{connector_name}'.",
-            context={"connector_name": connector_name},
-        )
-
-    secret_fields = sorted(_schema_secret_paths(spec_schema))
-    supplied_secrets = sorted(_paths_present(config_dict).intersection(secret_fields))
-    if supplied_secrets:
-        raise PyAirbyteInputError(
-            message="Secret values cannot be provided in config.",
-            context={"secret_fields": supplied_secrets},
-        )
-    return cast(
-        dict[str, Any],
-        _stub_missing_secrets(config_dict, spec_schema),
-    )
+    return config_dict
 
 
 class CloudSourceResult(BaseModel):
@@ -538,6 +507,7 @@ def deploy_source_to_cloud(
         name=source_name,
         source=source,
         unique=unique,
+        deferred_auth=deferred_auth,
     )
 
     register_guid_created_in_session(deployed_source.connector_id)
@@ -639,6 +609,7 @@ def deploy_destination_to_cloud(
         name=destination_name,
         destination=destination,
         unique=unique,
+        deferred_auth=deferred_auth,
     )
 
     register_guid_created_in_session(deployed_destination.connector_id)

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -130,7 +130,7 @@ def _resolve_deferred_auth_config(
             ) from error
         if not isinstance(parsed_config, dict):
             raise PyAirbyteInputError(
-                message="config must be an object.",
+                message="config must be a JSON object.",
                 context={"connector_name": connector_name},
             )
         config_dict = parsed_config
@@ -138,7 +138,7 @@ def _resolve_deferred_auth_config(
         config_dict = config
     else:
         raise PyAirbyteInputError(
-            message="config must be an object.",
+            message="config must be a JSON object.",
             context={"connector_name": connector_name},
         )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -113,6 +113,69 @@ def _get_connector_check_message(check_result: CheckResult) -> str | None:
     )
 
 
+def _resolve_deferred_auth_config(
+    connector_name: str,
+    config: dict | str | None,
+    config_secret_name: str | None,
+) -> dict[str, Any]:
+    """Resolve and stub a connector configuration for deferred Cloud authentication."""
+    if config_secret_name is not None:
+        raise PyAirbyteInputError(
+            message="config_secret_name cannot be used with deferred_auth.",
+            context={"connector_name": connector_name},
+        )
+    if config is None:
+        config_dict: dict[str, Any] = {}
+    elif isinstance(config, str):
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError as error:
+            raise PyAirbyteInputError(
+                message="config must be a JSON object.",
+                context={"connector_name": connector_name},
+            ) from error
+        if not isinstance(parsed_config, dict):
+            raise PyAirbyteInputError(
+                message="config must be an object.",
+                context={"connector_name": connector_name},
+            )
+        config_dict = parsed_config
+    elif isinstance(config, dict):
+        config_dict = config
+    else:
+        raise PyAirbyteInputError(
+            message="config must be an object.",
+            context={"connector_name": connector_name},
+        )
+
+    spec_schema = get_connector_spec_from_registry(
+        connector_name,
+        platform="cloud",
+    )
+    if spec_schema is None:
+        spec_schema = get_connector_spec_from_registry(
+            connector_name,
+            platform="oss",
+        )
+    if spec_schema is None:
+        raise PyAirbyteInputError(
+            message=f"Could not fetch a configuration schema for '{connector_name}'.",
+            context={"connector_name": connector_name},
+        )
+
+    secret_fields = sorted(_schema_secret_paths(spec_schema))
+    supplied_secrets = sorted(_paths_present(config_dict).intersection(secret_fields))
+    if supplied_secrets:
+        raise PyAirbyteInputError(
+            message="Secret values cannot be provided in config.",
+            context={"secret_fields": supplied_secrets},
+        )
+    return cast(
+        dict[str, Any],
+        _stub_missing_secrets(config_dict, spec_schema),
+    )
+
+
 class CloudSourceResult(BaseModel):
     """Information about a deployed source connector in Airbyte Cloud."""
 
@@ -445,60 +508,10 @@ def deploy_source_to_cloud(
     """Deploy a source connector to Airbyte Cloud."""
     deferred_note = ""
     if deferred_auth:
-        if config_secret_name is not None:
-            raise PyAirbyteInputError(
-                message="config_secret_name cannot be used with deferred_auth.",
-                context={"connector_name": source_connector_name},
-            )
-        if config is None:
-            config_dict: dict[str, Any] = {}
-        elif isinstance(config, str):
-            try:
-                parsed_config = json.loads(config)
-            except json.JSONDecodeError as error:
-                raise PyAirbyteInputError(
-                    message="config must be a JSON object.",
-                    context={"connector_name": source_connector_name},
-                ) from error
-            if not isinstance(parsed_config, dict):
-                raise PyAirbyteInputError(
-                    message="config must be an object.",
-                    context={"connector_name": source_connector_name},
-                )
-            config_dict = parsed_config
-        elif isinstance(config, dict):
-            config_dict = config
-        else:
-            raise PyAirbyteInputError(
-                message="config must be an object.",
-                context={"connector_name": source_connector_name},
-            )
-
-        spec_schema = get_connector_spec_from_registry(
+        config_dict = _resolve_deferred_auth_config(
             source_connector_name,
-            platform="cloud",
-        )
-        if spec_schema is None:
-            spec_schema = get_connector_spec_from_registry(
-                source_connector_name,
-                platform="oss",
-            )
-        if spec_schema is None:
-            raise PyAirbyteInputError(
-                message=(f"Could not fetch a configuration schema for '{source_connector_name}'."),
-                context={"connector_name": source_connector_name},
-            )
-
-        secret_fields = sorted(_schema_secret_paths(spec_schema))
-        supplied_secrets = sorted(_paths_present(config_dict).intersection(secret_fields))
-        if supplied_secrets:
-            raise PyAirbyteInputError(
-                message="Secret values cannot be provided in config.",
-                context={"secret_fields": supplied_secrets},
-            )
-        config_dict = cast(
-            dict[str, Any],
-            _stub_missing_secrets(config_dict, spec_schema),
+            config,
+            config_secret_name,
         )
         source = get_source(source_connector_name, no_executor=True)
         source.set_config(config_dict, validate=False)
@@ -578,18 +591,48 @@ def deploy_destination_to_cloud(
             default=True,
         ),
     ],
+    deferred_auth: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, create the destination without secrets: secret fields must "
+                "NOT be provided and are stubbed with placeholders; the user completes "
+                "authentication in the Airbyte Cloud UI at the returned URL."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Deploy a destination connector to Airbyte Cloud."""
-    destination = get_destination(
-        destination_connector_name,
-        no_executor=True,
-    )
-    config_dict = resolve_connector_config(
-        config=config,
-        config_secret_name=config_secret_name,
-        config_spec_jsonschema=destination.config_spec,
-    )
-    destination.set_config(config_dict, validate=True)
+    deferred_note = ""
+    if deferred_auth:
+        config_dict = _resolve_deferred_auth_config(
+            destination_connector_name,
+            config,
+            config_secret_name,
+        )
+        destination = get_destination(
+            destination_connector_name,
+            no_executor=True,
+        )
+        destination.set_config(config_dict, validate=False)
+        deferred_note = (
+            " NOTE: Destination created without working credentials (deferred auth). "
+            "The user must open the URL in Airbyte Cloud and enter credentials to "
+            "complete setup. Ask the user to confirm when done, or poll the "
+            "destination's check status."
+        )
+    else:
+        destination = get_destination(
+            destination_connector_name,
+            no_executor=True,
+        )
+        config_dict = resolve_connector_config(
+            config=config,
+            config_secret_name=config_secret_name,
+            config_spec_jsonschema=destination.config_spec,
+        )
+        destination.set_config(config_dict, validate=True)
 
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     deployed_destination = workspace.deploy_destination(
@@ -602,6 +645,7 @@ def deploy_destination_to_cloud(
     return (
         f"Successfully deployed destination '{destination_name}' "
         f"with ID: {deployed_destination.connector_id}"
+        f"{deferred_note}"
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -10,6 +10,7 @@
 # tool / helper definitions as a redundant "API Documentation" list.
 __all__: list[str] = []
 
+import json
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
@@ -21,6 +22,7 @@ from pydantic import BaseModel, Field
 
 from airbyte import cloud, get_destination, get_source
 from airbyte._util import api_util
+from airbyte._util.registry_spec import get_connector_spec_from_registry
 from airbyte.cloud.client import (
     CloudClient,
 )
@@ -50,6 +52,11 @@ from airbyte.exceptions import (
     PyAirbyteInputError,
 )
 from airbyte.mcp._arg_resolvers import resolve_connector_config, resolve_list_of_strings
+from airbyte.mcp._deferred_auth import (
+    _paths_present,
+    _schema_secret_paths,
+    _stub_missing_secrets,
+)
 from airbyte.mcp._tool_utils import (
     AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET,
     check_guid_created_in_session,
@@ -115,6 +122,21 @@ class CloudSourceResult(BaseModel):
     """Display name of the source."""
     url: str
     """Web URL for managing this source in Airbyte Cloud."""
+
+
+class DeferredAuthSourceResult(BaseModel):
+    """Information about a source awaiting authentication in Airbyte Cloud."""
+
+    id: str
+    """The source ID."""
+    name: str
+    """Display name of the source."""
+    url: str
+    """Web URL for managing this source in Airbyte Cloud."""
+    non_secret_config: dict[str, Any]
+    """The non-secret configuration supplied when creating the source."""
+    note: str
+    """Instructions for completing authentication in Airbyte Cloud."""
 
 
 class CloudDestinationResult(BaseModel):
@@ -447,6 +469,108 @@ def deploy_source_to_cloud(
     return (
         f"Successfully deployed source '{source_name}' with ID '{deployed_source.connector_id}'"
         f" and URL: {deployed_source.connector_url}"
+    )
+
+
+@mcp_tool(
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
+def create_source_with_deferred_auth(
+    ctx: Context,
+    source_name: Annotated[
+        str,
+        Field(description="The name to use when creating the source."),
+    ],
+    source_connector_name: Annotated[
+        str,
+        Field(description="The name of the source connector (e.g., 'source-github')."),
+    ],
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ] = None,
+    config: Annotated[
+        dict | str | None,
+        Field(
+            description=(
+                "Non-secret connector configuration. Secret fields must NOT be "
+                "provided; they are stubbed with placeholders and completed by "
+                "the user in the Cloud UI."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> DeferredAuthSourceResult:
+    """Create a source for deferred authentication in the Cloud UI.
+
+    This create-only workflow never passes secrets through the agent. The user
+    finishes authentication directly in Airbyte Cloud.
+    """
+    if config is None:
+        config = {}
+    if isinstance(config, str):
+        try:
+            config = json.loads(config)
+        except json.JSONDecodeError as error:
+            raise PyAirbyteInputError(
+                message="config must be a JSON object.",
+                context={"connector_name": source_connector_name},
+            ) from error
+    if not isinstance(config, dict):
+        raise PyAirbyteInputError(
+            message="config must be an object.",
+            context={"connector_name": source_connector_name},
+        )
+
+    spec_schema = get_connector_spec_from_registry(
+        source_connector_name,
+        platform="cloud",
+    )
+    if spec_schema is None:
+        spec_schema = get_connector_spec_from_registry(
+            source_connector_name,
+            platform="oss",
+        )
+    if spec_schema is None:
+        raise PyAirbyteInputError(
+            message=(f"Could not fetch a configuration schema for '{source_connector_name}'."),
+            context={"connector_name": source_connector_name},
+        )
+
+    secret_fields = sorted(_schema_secret_paths(spec_schema))
+    supplied_secrets = sorted(_paths_present(config).intersection(secret_fields))
+    if supplied_secrets:
+        raise PyAirbyteInputError(
+            message="Secret values cannot be provided in config.",
+            context={"secret_fields": supplied_secrets},
+        )
+
+    stubbed = cast(dict[str, Any], _stub_missing_secrets(config, spec_schema))
+    workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
+    source = get_source(source_connector_name, no_executor=True)
+    source.set_config(stubbed, validate=False)
+    deployed_source = workspace.deploy_source(
+        name=source_name,
+        source=source,
+        unique=True,
+    )
+    register_guid_created_in_session(deployed_source.connector_id)
+    return DeferredAuthSourceResult(
+        id=deployed_source.connector_id,
+        name=source_name,
+        url=deployed_source.connector_url,
+        non_secret_config=config,
+        note=(
+            "Source created without working credentials. The user must open the URL "
+            "in Airbyte Cloud and complete authentication (enter secrets or use the "
+            "OAuth button). Ask the user to confirm when done, or poll the source's "
+            "check status."
+        ),
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -644,7 +644,8 @@ def deploy_destination_to_cloud(
     register_guid_created_in_session(deployed_destination.connector_id)
     return (
         f"Successfully deployed destination '{destination_name}' "
-        f"with ID: {deployed_destination.connector_id}"
+        f"with ID '{deployed_destination.connector_id}' "
+        f"and URL: {deployed_destination.connector_url}"
         f"{deferred_note}"
     )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -124,21 +124,6 @@ class CloudSourceResult(BaseModel):
     """Web URL for managing this source in Airbyte Cloud."""
 
 
-class DeferredAuthSourceResult(BaseModel):
-    """Information about a source awaiting authentication in Airbyte Cloud."""
-
-    id: str
-    """The source ID."""
-    name: str
-    """Display name of the source."""
-    url: str
-    """Web URL for managing this source in Airbyte Cloud."""
-    non_secret_config: dict[str, Any]
-    """The non-secret configuration supplied when creating the source."""
-    note: str
-    """Instructions for completing authentication in Airbyte Cloud."""
-
-
 class CloudDestinationResult(BaseModel):
     """Information about a deployed destination connector in Airbyte Cloud."""
 
@@ -445,18 +430,95 @@ def deploy_source_to_cloud(
             default=True,
         ),
     ],
+    deferred_auth: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, create the source without secrets: secret fields must NOT "
+                "be provided and are stubbed with placeholders; the user completes "
+                "authentication in the Airbyte Cloud UI at the returned URL."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Deploy a source connector to Airbyte Cloud."""
-    source = get_source(
-        source_connector_name,
-        no_executor=True,
-    )
-    config_dict = resolve_connector_config(
-        config=config,
-        config_secret_name=config_secret_name,
-        config_spec_jsonschema=source.config_spec,
-    )
-    source.set_config(config_dict, validate=True)
+    deferred_note = ""
+    if deferred_auth:
+        if config_secret_name is not None:
+            raise PyAirbyteInputError(
+                message="config_secret_name cannot be used with deferred_auth.",
+                context={"connector_name": source_connector_name},
+            )
+        if config is None:
+            config_dict: dict[str, Any] = {}
+        elif isinstance(config, str):
+            try:
+                parsed_config = json.loads(config)
+            except json.JSONDecodeError as error:
+                raise PyAirbyteInputError(
+                    message="config must be a JSON object.",
+                    context={"connector_name": source_connector_name},
+                ) from error
+            if not isinstance(parsed_config, dict):
+                raise PyAirbyteInputError(
+                    message="config must be an object.",
+                    context={"connector_name": source_connector_name},
+                )
+            config_dict = parsed_config
+        elif isinstance(config, dict):
+            config_dict = config
+        else:
+            raise PyAirbyteInputError(
+                message="config must be an object.",
+                context={"connector_name": source_connector_name},
+            )
+
+        spec_schema = get_connector_spec_from_registry(
+            source_connector_name,
+            platform="cloud",
+        )
+        if spec_schema is None:
+            spec_schema = get_connector_spec_from_registry(
+                source_connector_name,
+                platform="oss",
+            )
+        if spec_schema is None:
+            raise PyAirbyteInputError(
+                message=(f"Could not fetch a configuration schema for '{source_connector_name}'."),
+                context={"connector_name": source_connector_name},
+            )
+
+        secret_fields = sorted(_schema_secret_paths(spec_schema))
+        supplied_secrets = sorted(_paths_present(config_dict).intersection(secret_fields))
+        if supplied_secrets:
+            raise PyAirbyteInputError(
+                message="Secret values cannot be provided in config.",
+                context={"secret_fields": supplied_secrets},
+            )
+        config_dict = cast(
+            dict[str, Any],
+            _stub_missing_secrets(config_dict, spec_schema),
+        )
+        source = get_source(source_connector_name, no_executor=True)
+        source.set_config(config_dict, validate=False)
+        deferred_note = (
+            " NOTE: Source created without working credentials (deferred auth). "
+            "The user must open the URL in Airbyte Cloud and complete authentication "
+            "(enter secrets or use the OAuth button). Ask the user to confirm when "
+            "done, or poll the source's check status."
+        )
+    else:
+        source = get_source(
+            source_connector_name,
+            no_executor=True,
+        )
+        config_dict = resolve_connector_config(
+            config=config,
+            config_secret_name=config_secret_name,
+            config_spec_jsonschema=source.config_spec,
+        )
+        source.set_config(config_dict, validate=True)
 
     workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
     deployed_source = workspace.deploy_source(
@@ -469,108 +531,7 @@ def deploy_source_to_cloud(
     return (
         f"Successfully deployed source '{source_name}' with ID '{deployed_source.connector_id}'"
         f" and URL: {deployed_source.connector_url}"
-    )
-
-
-@mcp_tool(
-    open_world=True,
-    extra_help_text=CLOUD_AUTH_TIP_TEXT,
-)
-def create_source_with_deferred_auth(
-    ctx: Context,
-    source_name: Annotated[
-        str,
-        Field(description="The name to use when creating the source."),
-    ],
-    source_connector_name: Annotated[
-        str,
-        Field(description="The name of the source connector (e.g., 'source-github')."),
-    ],
-    *,
-    workspace_id: Annotated[
-        str | None,
-        Field(
-            description=WORKSPACE_ID_TIP_TEXT,
-            default=None,
-        ),
-    ] = None,
-    config: Annotated[
-        dict | str | None,
-        Field(
-            description=(
-                "Non-secret connector configuration. Secret fields must NOT be "
-                "provided; they are stubbed with placeholders and completed by "
-                "the user in the Cloud UI."
-            ),
-            default=None,
-        ),
-    ] = None,
-) -> DeferredAuthSourceResult:
-    """Create a source for deferred authentication in the Cloud UI.
-
-    This create-only workflow never passes secrets through the agent. The user
-    finishes authentication directly in Airbyte Cloud.
-    """
-    if config is None:
-        config = {}
-    if isinstance(config, str):
-        try:
-            config = json.loads(config)
-        except json.JSONDecodeError as error:
-            raise PyAirbyteInputError(
-                message="config must be a JSON object.",
-                context={"connector_name": source_connector_name},
-            ) from error
-    if not isinstance(config, dict):
-        raise PyAirbyteInputError(
-            message="config must be an object.",
-            context={"connector_name": source_connector_name},
-        )
-
-    spec_schema = get_connector_spec_from_registry(
-        source_connector_name,
-        platform="cloud",
-    )
-    if spec_schema is None:
-        spec_schema = get_connector_spec_from_registry(
-            source_connector_name,
-            platform="oss",
-        )
-    if spec_schema is None:
-        raise PyAirbyteInputError(
-            message=(f"Could not fetch a configuration schema for '{source_connector_name}'."),
-            context={"connector_name": source_connector_name},
-        )
-
-    secret_fields = sorted(_schema_secret_paths(spec_schema))
-    supplied_secrets = sorted(_paths_present(config).intersection(secret_fields))
-    if supplied_secrets:
-        raise PyAirbyteInputError(
-            message="Secret values cannot be provided in config.",
-            context={"secret_fields": supplied_secrets},
-        )
-
-    stubbed = cast(dict[str, Any], _stub_missing_secrets(config, spec_schema))
-    workspace: CloudWorkspace = _get_cloud_workspace(ctx, workspace_id)
-    source = get_source(source_connector_name, no_executor=True)
-    source.set_config(stubbed, validate=False)
-    deployed_source = workspace.deploy_source(
-        name=source_name,
-        source=source,
-        unique=True,
-    )
-    register_guid_created_in_session(deployed_source.connector_id)
-    return DeferredAuthSourceResult(
-        id=deployed_source.connector_id,
-        name=source_name,
-        url=deployed_source.connector_url,
-        non_secret_config=config,
-        note=(
-            "Source created without working credentials. The user must open the URL "
-            "in Airbyte Cloud and complete authentication (enter secrets or use the "
-            "OAuth button). Ask the user to confirm when done, or poll the source's "
-            "check status."
-        ),
+        f"{deferred_note}"
     )
 
 

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import jsonschema
 import pytest
+import requests
 
 from airbyte._util.registry_spec import get_connector_spec_from_registry
 from airbyte.cloud._deferred_auth import (
@@ -36,7 +37,7 @@ def _certified_source_names() -> list[str]:
                 and metadata.support_level == "certified"
             )
         ]
-    except Exception:
+    except (requests.exceptions.RequestException, OSError):
         return []
 
 
@@ -53,15 +54,21 @@ def _cached_spec(connector_name: str) -> dict[str, Any] | None:
     )
     if cache_path.exists():
         try:
-            return json.loads(cache_path.read_text(encoding="utf-8"))
+            cached_spec = json.loads(cache_path.read_text(encoding="utf-8"))
+            if isinstance(cached_spec, dict):
+                return cached_spec
         except (OSError, json.JSONDecodeError):
             pass
 
-    spec = get_connector_spec_from_registry(
-        connector_name,
-        version=version,
-        platform="oss",
-    )
+    spec = None
+    for platform in ("cloud", "oss"):
+        spec = get_connector_spec_from_registry(
+            connector_name,
+            version=version,
+            platform=platform,
+        )
+        if spec is not None:
+            break
     if spec is None:
         return None
 
@@ -198,12 +205,21 @@ if not _CERTIFIED_SOURCE_NAMES:
 
 @pytest.mark.parametrize(
     "connector_name",
-    [pytest.param(name, id=name) for name in _CERTIFIED_SOURCE_NAMES],
+    [
+        pytest.param(
+            name,
+            id=name,
+            marks=pytest.mark.xfail(
+                reason=EXPECTED_FAILURES[name],
+                strict=False,
+            ),
+        )
+        if name in EXPECTED_FAILURES
+        else pytest.param(name, id=name)
+        for name in _CERTIFIED_SOURCE_NAMES
+    ],
 )
 def test_stubbed_config_passes_registry_schema(connector_name: str) -> None:
-    if connector_name in EXPECTED_FAILURES:
-        pytest.xfail(EXPECTED_FAILURES[connector_name])
-
     spec = _cached_spec(connector_name)
     if spec is None:
         pytest.skip(f"no spec available for {connector_name}")

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +13,10 @@ import jsonschema
 import pytest
 
 from airbyte._util.registry_spec import get_connector_spec_from_registry
-from airbyte.cloud._deferred_auth import _stub_missing_secrets
+from airbyte.cloud._deferred_auth import (
+    _schema_secret_paths,
+    _stub_missing_secrets,
+)
 from airbyte.registry import (
     InstallType,
     get_available_connectors,
@@ -66,161 +70,125 @@ def _cached_spec(connector_name: str) -> dict[str, Any] | None:
     return spec
 
 
+_UNSET = object()
+
+
+def _matches_type(value: Any, schema: Mapping[str, Any]) -> bool:
+    schema_type = schema.get("type")
+    if schema_type is None:
+        return True
+    if isinstance(schema_type, list):
+        return any(_matches_type(value, {"type": item}) for item in schema_type)
+    if schema_type == "string":
+        return isinstance(value, str)
+    if schema_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if schema_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if schema_type == "boolean":
+        return isinstance(value, bool)
+    if schema_type == "array":
+        return isinstance(value, list)
+    if schema_type == "object":
+        return isinstance(value, Mapping)
+    return True
+
+
+def _synthesize_value(schema: Mapping[str, Any]) -> Any:
+    for key in ("default", "const"):
+        if key in schema and _matches_type(schema[key], schema):
+            return schema[key]
+
+    if isinstance(schema.get("oneOf"), list) or isinstance(schema.get("anyOf"), list):
+        return _UNSET
+
+    examples = schema.get("examples")
+    if isinstance(examples, list) and examples and _matches_type(examples[0], schema):
+        return examples[0]
+
+    enum = schema.get("enum")
+    if isinstance(enum, list) and enum and _matches_type(enum[0], schema):
+        return enum[0]
+
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        pattern = schema.get("pattern")
+        if pattern:
+            return _UNSET
+        schema_format = schema.get("format")
+        if schema_format == "date":
+            return "2024-01-01"
+        if schema_format == "date-time":
+            return "2024-01-01T00:00:00Z"
+        return "x"
+    if schema_type in ("integer", "number"):
+        minimum = schema.get("minimum")
+        return minimum if isinstance(minimum, (int, float)) else 1
+    if schema_type == "boolean":
+        return False
+    if schema_type == "array":
+        items = schema.get("items")
+        if isinstance(items, Mapping):
+            item = _synthesize_value(items)
+            if item is not _UNSET:
+                return [item]
+        return _UNSET
+    if schema_type == "object" or "properties" in schema or "allOf" in schema:
+        return _fill_required_non_secrets(schema)
+    return _UNSET
+
+
+def _fill_required_non_secrets(schema: Mapping[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if isinstance(properties, Mapping) and isinstance(required, list):
+        for name in required:
+            if not isinstance(name, str):
+                continue
+            child = properties.get(name)
+            if not isinstance(child, Mapping):
+                continue
+            if name in _schema_secret_paths(child, name):
+                continue
+            value = _synthesize_value(child)
+            if value is not _UNSET:
+                result[name] = value
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for branch in all_of:
+            if isinstance(branch, Mapping):
+                result.update(_fill_required_non_secrets(branch))
+    return result
+
+
 EXPECTED_FAILURES: dict[str, str] = {
-    "source-amazon-seller-partner": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "aws_environment"
-    ),
-    "source-amplitude": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-azure-blob-storage": (
-        "requires non-secret configuration not inferable from an empty config: streams"
-    ),
-    "source-chargebee": (
-        "requires non-secret configuration not inferable from an empty config: site"
-    ),
-    "source-db2-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
+    "source-azure-blob-storage": "requires choosing an unselectable credentials or stream format branch",
+    "source-db2-enterprise": "requires choosing an unselectable encryption branch",
     "source-facebook-marketing": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "account_ids"
+        "required account IDs have a regex-constrained array item with no example"
     ),
-    "source-file": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "dataset_name"
-    ),
-    "source-freshdesk": (
-        "requires non-secret configuration not inferable from an empty config: domain"
-    ),
-    "source-gcs": (
-        "requires non-secret configuration not inferable from an empty config: streams"
-    ),
-    "source-github": "requires choosing a credentials oneOf branch",
-    "source-gitlab": "requires choosing a credentials oneOf branch",
-    "source-google-ads": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "credentials.client_id"
-    ),
-    "source-google-analytics-data-api": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "property_ids"
-    ),
-    "source-google-drive": (
-        "requires non-secret configuration not inferable from an empty config: streams"
-    ),
-    "source-google-search-console": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "site_urls"
-    ),
-    "source-google-sheets": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "spreadsheet_id"
-    ),
-    "source-harvest": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "replication_start_date"
-    ),
-    "source-hubspot": "requires choosing a credentials oneOf branch",
-    "source-intercom": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-jira": "requires choosing a credentials oneOf branch",
-    "source-linkedin-ads": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-mongodb-v2": "requires choosing a database_config oneOf branch",
-    "source-mssql": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-mysql": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-netsuite-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-oracle-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-paypal-transaction": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-postgres": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-s3": (
-        "requires non-secret configuration not inferable from an empty config: streams"
-    ),
-    "source-salesforce": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "client_id"
-    ),
-    "source-sap-hana-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-sendgrid": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-sentry": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "organization"
-    ),
-    "source-service-now": (
-        "requires non-secret configuration not inferable from an empty config: base_url"
-    ),
-    "source-sharepoint-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: streams"
-    ),
-    "source-sharepoint-lists-enterprise": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "tenant_id"
-    ),
-    "source-shopify": (
-        "requires non-secret configuration not inferable from an empty config: shop"
-    ),
-    "source-slack": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-snowflake": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-stripe": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "account_id"
-    ),
-    "source-twilio": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-typeform": "requires choosing a credentials oneOf branch",
-    "source-woocommerce": (
-        "requires non-secret configuration not inferable from an empty config: shop"
-    ),
-    "source-workday": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-workday-rest": (
-        "requires non-secret configuration not inferable from an empty config: host"
-    ),
-    "source-zendesk-chat": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "start_date"
-    ),
-    "source-zendesk-support": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "subdomain"
-    ),
-    "source-zendesk-talk": (
-        "requires non-secret configuration not inferable from an empty config: "
-        "subdomain"
-    ),
+    "source-file": "requires choosing an unselectable provider branch",
+    "source-gcs": "requires choosing an unselectable credentials or stream format branch",
+    "source-github": "requires choosing an unselectable credentials branch",
+    "source-gitlab": "requires choosing an unselectable credentials branch",
+    "source-google-drive": "requires choosing an unselectable credentials or stream format branch",
+    "source-google-search-console": "requires choosing an unselectable authorization branch",
+    "source-google-sheets": "requires choosing an unselectable credentials branch",
+    "source-hubspot": "requires choosing an unselectable credentials branch",
+    "source-jira": "requires choosing an unselectable credentials branch",
+    "source-mongodb-v2": "requires choosing an unselectable database_config branch",
+    "source-mssql": "requires choosing an unselectable replication_method branch",
+    "source-mysql": "requires choosing an unselectable replication_method branch",
+    "source-netsuite-enterprise": "requires choosing an unselectable authentication_method branch",
+    "source-oracle-enterprise": "requires choosing an unselectable connection_data branch",
+    "source-postgres": "requires choosing an unselectable tunnel_method branch",
+    "source-s3": "requires choosing an unselectable stream format branch",
+    "source-sap-hana-enterprise": "requires choosing an unselectable encryption branch",
+    "source-sendgrid": "required start_date has a regex pattern with no example",
+    "source-sharepoint-enterprise": "requires choosing an unselectable credentials or stream format branch",
+    "source-typeform": "requires choosing an unselectable credentials branch",
 }
 
 _CERTIFIED_SOURCE_NAMES = _certified_source_names()
@@ -228,7 +196,10 @@ if not _CERTIFIED_SOURCE_NAMES:
     pytest.skip("registry unreachable", allow_module_level=True)
 
 
-@pytest.mark.parametrize("connector_name", _CERTIFIED_SOURCE_NAMES)
+@pytest.mark.parametrize(
+    "connector_name",
+    [pytest.param(name, id=name) for name in _CERTIFIED_SOURCE_NAMES],
+)
 def test_stubbed_config_passes_registry_schema(connector_name: str) -> None:
     if connector_name in EXPECTED_FAILURES:
         pytest.xfail(EXPECTED_FAILURES[connector_name])
@@ -237,5 +208,6 @@ def test_stubbed_config_passes_registry_schema(connector_name: str) -> None:
     if spec is None:
         pytest.skip(f"no spec available for {connector_name}")
 
-    config = _stub_missing_secrets({}, spec)
+    config = _fill_required_non_secrets(spec)
+    config = _stub_missing_secrets(config, spec)
     jsonschema.validate(instance=config, schema=spec)

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
@@ -78,6 +79,16 @@ def _cached_spec(connector_name: str) -> dict[str, Any] | None:
 
 
 _UNSET = object()
+_PATTERN_CANDIDATES = (
+    "2024-01-01T00:00:00Z",
+    "2024-01-01",
+    "2024-01-01T00:00:00.000Z",
+    "0",
+    "1",
+    "x",
+    "a1",
+    "https://example.com",
+)
 
 
 def _matches_type(value: Any, schema: Mapping[str, Any]) -> bool:
@@ -101,13 +112,87 @@ def _matches_type(value: Any, schema: Mapping[str, Any]) -> bool:
     return True
 
 
+def _discriminator_values(schema: Mapping[str, Any]) -> dict[str, Any]:
+    properties = schema.get("properties", {})
+    if not isinstance(properties, Mapping):
+        return {}
+    values: dict[str, Any] = {}
+    for name, child in properties.items():
+        if not isinstance(name, str) or not isinstance(child, Mapping):
+            continue
+        if "const" in child and _matches_type(child["const"], child):
+            values[name] = child["const"]
+        else:
+            enum = child.get("enum")
+            if (
+                isinstance(enum, list)
+                and len(enum) == 1
+                and _matches_type(enum[0], child)
+            ):
+                values[name] = enum[0]
+    return values
+
+
+def _fill_required_non_secrets_result(
+    schema: Mapping[str, Any],
+) -> dict[str, Any] | object:
+    result: dict[str, Any] = {}
+    for branch_key in ("oneOf", "anyOf"):
+        branches = schema.get(branch_key)
+        if not isinstance(branches, list):
+            continue
+        selected: dict[str, Any] | object = _UNSET
+        for branch in branches:
+            if not isinstance(branch, Mapping):
+                continue
+            candidate = _fill_required_non_secrets_result(branch)
+            if candidate is not _UNSET:
+                selected = candidate
+                break
+        if selected is _UNSET:
+            return _UNSET
+        result.update(selected)
+
+    result.update({
+        name: value
+        for name, value in _discriminator_values(schema).items()
+        if name not in result
+    })
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if isinstance(properties, Mapping) and isinstance(required, list):
+        for name in required:
+            if not isinstance(name, str):
+                continue
+            child = properties.get(name)
+            if not isinstance(child, Mapping):
+                return _UNSET
+            if name in _schema_secret_paths(child, name):
+                continue
+            value = _synthesize_value(child)
+            if value is _UNSET:
+                return _UNSET
+            result[name] = value
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for branch in all_of:
+            if not isinstance(branch, Mapping):
+                continue
+            candidate = _fill_required_non_secrets_result(branch)
+            if candidate is _UNSET:
+                return _UNSET
+            result.update(candidate)
+    return result
+
+
 def _synthesize_value(schema: Mapping[str, Any]) -> Any:
     for key in ("default", "const"):
         if key in schema and _matches_type(schema[key], schema):
             return schema[key]
 
     if isinstance(schema.get("oneOf"), list) or isinstance(schema.get("anyOf"), list):
-        return _UNSET
+        return _fill_required_non_secrets_result(schema)
 
     examples = schema.get("examples")
     if isinstance(examples, list) and examples and _matches_type(examples[0], schema):
@@ -121,6 +206,12 @@ def _synthesize_value(schema: Mapping[str, Any]) -> Any:
     if schema_type == "string":
         pattern = schema.get("pattern")
         if pattern:
+            try:
+                for candidate in _PATTERN_CANDIDATES:
+                    if re.fullmatch(pattern, candidate):
+                        return candidate
+            except re.error:
+                pass
             return _UNSET
         schema_format = schema.get("format")
         if schema_format == "date":
@@ -136,67 +227,29 @@ def _synthesize_value(schema: Mapping[str, Any]) -> Any:
     if schema_type == "array":
         items = schema.get("items")
         if isinstance(items, Mapping):
+            examples = schema.get("examples")
+            if (
+                isinstance(examples, list)
+                and examples
+                and _matches_type(examples[0], items)
+            ):
+                return [examples[0]]
             item = _synthesize_value(items)
             if item is not _UNSET:
                 return [item]
         return _UNSET
     if schema_type == "object" or "properties" in schema or "allOf" in schema:
-        return _fill_required_non_secrets(schema)
+        result = _fill_required_non_secrets_result(schema)
+        return result if result is not _UNSET else _UNSET
     return _UNSET
 
 
 def _fill_required_non_secrets(schema: Mapping[str, Any]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    properties = schema.get("properties")
-    required = schema.get("required")
-    if isinstance(properties, Mapping) and isinstance(required, list):
-        for name in required:
-            if not isinstance(name, str):
-                continue
-            child = properties.get(name)
-            if not isinstance(child, Mapping):
-                continue
-            if name in _schema_secret_paths(child, name):
-                continue
-            value = _synthesize_value(child)
-            if value is not _UNSET:
-                result[name] = value
-
-    all_of = schema.get("allOf")
-    if isinstance(all_of, list):
-        for branch in all_of:
-            if isinstance(branch, Mapping):
-                result.update(_fill_required_non_secrets(branch))
-    return result
+    result = _fill_required_non_secrets_result(schema)
+    return result if result is not _UNSET else {}
 
 
-EXPECTED_FAILURES: dict[str, str] = {
-    "source-azure-blob-storage": "requires choosing an unselectable credentials or stream format branch",
-    "source-db2-enterprise": "requires choosing an unselectable encryption branch",
-    "source-facebook-marketing": (
-        "required account IDs have a regex-constrained array item with no example"
-    ),
-    "source-file": "requires choosing an unselectable provider branch",
-    "source-gcs": "requires choosing an unselectable credentials or stream format branch",
-    "source-github": "requires choosing an unselectable credentials branch",
-    "source-gitlab": "requires choosing an unselectable credentials branch",
-    "source-google-drive": "requires choosing an unselectable credentials or stream format branch",
-    "source-google-search-console": "requires choosing an unselectable authorization branch",
-    "source-google-sheets": "requires choosing an unselectable credentials branch",
-    "source-hubspot": "requires choosing an unselectable credentials branch",
-    "source-jira": "requires choosing an unselectable credentials branch",
-    "source-mongodb-v2": "requires choosing an unselectable database_config branch",
-    "source-mssql": "requires choosing an unselectable replication_method branch",
-    "source-mysql": "requires choosing an unselectable replication_method branch",
-    "source-netsuite-enterprise": "requires choosing an unselectable authentication_method branch",
-    "source-oracle-enterprise": "requires choosing an unselectable connection_data branch",
-    "source-postgres": "requires choosing an unselectable tunnel_method branch",
-    "source-s3": "requires choosing an unselectable stream format branch",
-    "source-sap-hana-enterprise": "requires choosing an unselectable encryption branch",
-    "source-sendgrid": "required start_date has a regex pattern with no example",
-    "source-sharepoint-enterprise": "requires choosing an unselectable credentials or stream format branch",
-    "source-typeform": "requires choosing an unselectable credentials branch",
-}
+EXPECTED_FAILURES: dict[str, str] = {}
 
 _CERTIFIED_SOURCE_NAMES = _certified_source_names()
 if not _CERTIFIED_SOURCE_NAMES:

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Validate deferred-auth placeholder configurations against registry schemas."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+from airbyte._util.registry_spec import get_connector_spec_from_registry
+from airbyte.cloud._deferred_auth import _stub_missing_secrets
+from airbyte.registry import (
+    InstallType,
+    get_available_connectors,
+    get_connector_metadata,
+)
+
+
+def _certified_source_names() -> list[str]:
+    try:
+        connector_names = get_available_connectors(InstallType.ANY)
+        return [
+            name
+            for name in connector_names
+            if name.startswith("source-")
+            and (
+                (metadata := get_connector_metadata(name)) is not None
+                and metadata.support_level == "certified"
+            )
+        ]
+    except Exception:
+        return []
+
+
+def _cached_spec(connector_name: str) -> dict[str, Any] | None:
+    metadata = get_connector_metadata(connector_name)
+    if metadata is None or metadata.latest_available_version is None:
+        return None
+
+    version = metadata.latest_available_version
+    cache_path = (
+        Path(tempfile.gettempdir())
+        / "pyairbyte-registry-spec-cache"
+        / f"{connector_name}-{version}.json"
+    )
+    if cache_path.exists():
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    spec = get_connector_spec_from_registry(
+        connector_name,
+        version=version,
+        platform="oss",
+    )
+    if spec is None:
+        return None
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(spec), encoding="utf-8")
+    return spec
+
+
+EXPECTED_FAILURES: dict[str, str] = {
+    "source-amazon-seller-partner": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "aws_environment"
+    ),
+    "source-amplitude": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-azure-blob-storage": (
+        "requires non-secret configuration not inferable from an empty config: streams"
+    ),
+    "source-chargebee": (
+        "requires non-secret configuration not inferable from an empty config: site"
+    ),
+    "source-db2-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-facebook-marketing": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "account_ids"
+    ),
+    "source-file": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "dataset_name"
+    ),
+    "source-freshdesk": (
+        "requires non-secret configuration not inferable from an empty config: domain"
+    ),
+    "source-gcs": (
+        "requires non-secret configuration not inferable from an empty config: streams"
+    ),
+    "source-github": "requires choosing a credentials oneOf branch",
+    "source-gitlab": "requires choosing a credentials oneOf branch",
+    "source-google-ads": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "credentials.client_id"
+    ),
+    "source-google-analytics-data-api": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "property_ids"
+    ),
+    "source-google-drive": (
+        "requires non-secret configuration not inferable from an empty config: streams"
+    ),
+    "source-google-search-console": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "site_urls"
+    ),
+    "source-google-sheets": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "spreadsheet_id"
+    ),
+    "source-harvest": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "replication_start_date"
+    ),
+    "source-hubspot": "requires choosing a credentials oneOf branch",
+    "source-intercom": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-jira": "requires choosing a credentials oneOf branch",
+    "source-linkedin-ads": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-mongodb-v2": "requires choosing a database_config oneOf branch",
+    "source-mssql": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-mysql": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-netsuite-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-oracle-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-paypal-transaction": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-postgres": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-s3": (
+        "requires non-secret configuration not inferable from an empty config: streams"
+    ),
+    "source-salesforce": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "client_id"
+    ),
+    "source-sap-hana-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-sendgrid": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-sentry": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "organization"
+    ),
+    "source-service-now": (
+        "requires non-secret configuration not inferable from an empty config: base_url"
+    ),
+    "source-sharepoint-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: streams"
+    ),
+    "source-sharepoint-lists-enterprise": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "tenant_id"
+    ),
+    "source-shopify": (
+        "requires non-secret configuration not inferable from an empty config: shop"
+    ),
+    "source-slack": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-snowflake": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-stripe": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "account_id"
+    ),
+    "source-twilio": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-typeform": "requires choosing a credentials oneOf branch",
+    "source-woocommerce": (
+        "requires non-secret configuration not inferable from an empty config: shop"
+    ),
+    "source-workday": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-workday-rest": (
+        "requires non-secret configuration not inferable from an empty config: host"
+    ),
+    "source-zendesk-chat": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "start_date"
+    ),
+    "source-zendesk-support": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "subdomain"
+    ),
+    "source-zendesk-talk": (
+        "requires non-secret configuration not inferable from an empty config: "
+        "subdomain"
+    ),
+}
+
+_CERTIFIED_SOURCE_NAMES = _certified_source_names()
+if not _CERTIFIED_SOURCE_NAMES:
+    pytest.skip("registry unreachable", allow_module_level=True)
+
+
+@pytest.mark.parametrize("connector_name", _CERTIFIED_SOURCE_NAMES)
+def test_stubbed_config_passes_registry_schema(connector_name: str) -> None:
+    if connector_name in EXPECTED_FAILURES:
+        pytest.xfail(EXPECTED_FAILURES[connector_name])
+
+    spec = _cached_spec(connector_name)
+    if spec is None:
+        pytest.skip(f"no spec available for {connector_name}")
+
+    config = _stub_missing_secrets({}, spec)
+    jsonschema.validate(instance=config, schema=spec)

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -58,7 +58,7 @@ def _cached_spec(connector_name: str) -> dict[str, Any] | None:
             if isinstance(cached_spec, dict):
                 return cached_spec
         except (OSError, json.JSONDecodeError):
-            pass
+            pass  # Unreadable or corrupt cache entry; fall through to refetch.
 
     spec = None
     for platform in ("cloud", "oss"):

--- a/tests/unit_tests/test_deferred_auth_registry_specs.py
+++ b/tests/unit_tests/test_deferred_auth_registry_specs.py
@@ -211,7 +211,7 @@ def _synthesize_value(schema: Mapping[str, Any]) -> Any:
                     if re.fullmatch(pattern, candidate):
                         return candidate
             except re.error:
-                pass
+                pass  # Unsupported regex syntax; leave the value unsynthesized.
             return _UNSET
         schema_format = schema.get("format")
         if schema_format == "date":

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -81,11 +81,15 @@ def test_deferred_auth_rejects_secret_config(
     with pytest.raises(
         PyAirbyteInputError, match="Secret values cannot be provided in config"
     ):
-        cloud_mcp.create_source_with_deferred_auth(
+        cloud_mcp.deploy_source_to_cloud(
             object(),
             "Google Sheets",
             "source-google-sheets",
+            workspace_id=None,
             config={"credentials": {"auth_type": "Client", "client_id": "secret"}},
+            config_secret_name=None,
+            unique=True,
+            deferred_auth=True,
         )
 
 
@@ -105,19 +109,27 @@ def test_deferred_auth_accepts_json_config_and_rejects_invalid_json(
         ),
     )
     with pytest.raises(AirbyteMissingWorkspaceContextError):
-        cloud_mcp.create_source_with_deferred_auth(
+        cloud_mcp.deploy_source_to_cloud(
             object(),
             "Google Sheets",
             "source-google-sheets",
+            workspace_id=None,
             config='{"spreadsheet_id":"sheet-id"}',
+            config_secret_name=None,
+            unique=True,
+            deferred_auth=True,
         )
 
     with pytest.raises(PyAirbyteInputError, match="config must be a JSON object"):
-        cloud_mcp.create_source_with_deferred_auth(
+        cloud_mcp.deploy_source_to_cloud(
             object(),
             "Google Sheets",
             "source-google-sheets",
+            workspace_id=None,
             config="{",
+            config_secret_name=None,
+            unique=True,
+            deferred_auth=True,
         )
 
 
@@ -205,12 +217,15 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
     )
     monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
 
-    result = cloud_mcp.create_source_with_deferred_auth(
+    result = cloud_mcp.deploy_source_to_cloud(
         object(),
         "Google Sheets",
         "source-google-sheets",
         config=config,
         workspace_id="ws",
+        config_secret_name=None,
+        unique=True,
+        deferred_auth=True,
     )
 
     assert captured["config"] == {
@@ -225,16 +240,83 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
     assert captured["validate"] is False
     assert captured["name"] == "Google Sheets"
     assert captured["unique"] is True
-    assert result.id == "source-id"
-    assert result.name == "Google Sheets"
-    assert result.url == "https://cloud.airbyte.com/workspaces/ws/source/source-id"
-    assert result.non_secret_config == config
-    assert "complete authentication" in result.note
-    serialized = result.model_dump_json()
+    assert result.startswith(
+        "Successfully deployed source 'Google Sheets' with ID 'source-id'"
+    )
+    assert "Source created without working credentials (deferred auth)." in result
+    assert SECRET_PLACEHOLDER not in result
+    serialized = json.dumps(result)
     assert "__airbyte_placeholder__" not in serialized
     assert "client-secret" not in serialized
     assert "bearer-token" not in serialized
-    assert json.loads(serialized)["non_secret_config"] == config
+
+
+def test_deferred_auth_rejects_config_secret_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+
+    with pytest.raises(
+        PyAirbyteInputError,
+        match="config_secret_name cannot be used with deferred_auth",
+    ):
+        cloud_mcp.deploy_source_to_cloud(
+            object(),
+            "Google Sheets",
+            "source-google-sheets",
+            workspace_id=None,
+            config=None,
+            config_secret_name="source-config",
+            unique=True,
+            deferred_auth=True,
+        )
+
+
+def test_deploy_source_without_deferred_auth_has_no_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Source:
+        config_spec: dict[str, Any] = {}
+
+        def set_config(self, value: dict[str, Any], *, validate: bool) -> None:
+            assert value == {}
+            assert validate is True
+
+    class Workspace:
+        def deploy_source(self, *, name: str, source: Source, unique: bool) -> Any:
+            assert name == "Source"
+            assert unique is True
+            return type(
+                "DeployedSource",
+                (),
+                {
+                    "connector_id": "source-id",
+                    "connector_url": "https://cloud.airbyte.com/source/source-id",
+                },
+            )()
+
+    monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: Workspace(),
+    )
+
+    result = cloud_mcp.deploy_source_to_cloud(
+        object(),
+        "Source",
+        "source-faker",
+        workspace_id=None,
+        config=None,
+        config_secret_name=None,
+        unique=True,
+    )
+
+    assert "deferred auth" not in result
 
 
 def test_deferred_auth_requires_workspace_context(
@@ -248,8 +330,13 @@ def test_deferred_auth_requires_workspace_context(
     monkeypatch.setattr(cloud_mcp, "get_mcp_config", lambda *args, **kwargs: None)
 
     with pytest.raises(AirbyteMissingWorkspaceContextError):
-        cloud_mcp.create_source_with_deferred_auth(
+        cloud_mcp.deploy_source_to_cloud(
             object(),
             "Google Sheets",
             "source-google-sheets",
+            workspace_id=None,
+            config=None,
+            config_secret_name=None,
+            unique=True,
+            deferred_auth=True,
         )

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -753,6 +753,20 @@ def test_deferred_auth_rejects_destination_secret_config(
         )
 
 
+def test_deferred_auth_rejects_dict_destination() -> None:
+    workspace = _workspace()
+
+    with pytest.raises(
+        PyAirbyteInputError, match="deferred_auth requires a Destination object"
+    ):
+        workspace.deploy_destination(
+            name="Postgres",
+            destination={"some": "dict", "destinationType": "postgres"},
+            unique=False,
+            deferred_auth=True,
+        )
+
+
 def test_deferred_auth_rejects_destination_config_secret_name() -> None:
     with pytest.raises(
         PyAirbyteInputError,

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -8,13 +8,16 @@ from typing import Any
 
 import pytest
 
-from airbyte.exceptions import AirbyteMissingWorkspaceContextError, PyAirbyteInputError
-from airbyte.mcp import cloud as cloud_mcp
-from airbyte.mcp._deferred_auth import (
+from airbyte.cloud import workspaces as cloud_workspaces
+from airbyte.cloud._deferred_auth import (
     SECRET_PLACEHOLDER,
     _schema_secret_paths,
     _stub_missing_secrets,
 )
+from airbyte.destinations.base import Destination as DestinationBase
+from airbyte.exceptions import AirbyteMissingWorkspaceContextError, PyAirbyteInputError
+from airbyte.mcp import cloud as cloud_mcp
+from airbyte.sources.base import Source as SourceBase
 
 
 def _google_sheets_schema() -> dict[str, Any]:
@@ -69,11 +72,28 @@ def _enum_auth_schema() -> dict[str, Any]:
     }
 
 
+def _workspace() -> cloud_workspaces.CloudWorkspace:
+    workspace = object.__new__(cloud_workspaces.CloudWorkspace)
+    workspace.api_root = "https://api.airbyte.com"
+    workspace.workspace_id = "workspace-id"
+    workspace.client_id = None
+    workspace.client_secret = None
+    workspace.bearer_token = None
+    return workspace
+
+
 def test_deferred_auth_rejects_secret_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    source = object.__new__(SourceBase)
+    source._name = "source-google-sheets"  # noqa: SLF001
+    source._config_dict = {  # noqa: SLF001
+        "credentials": {"auth_type": "Client", "client_id": "secret"}
+    }
+    workspace = _workspace()
+
     monkeypatch.setattr(
-        cloud_mcp,
+        cloud_workspaces,
         "get_connector_spec_from_registry",
         lambda *args, **kwargs: _google_sheets_schema(),
     )
@@ -81,14 +101,10 @@ def test_deferred_auth_rejects_secret_config(
     with pytest.raises(
         PyAirbyteInputError, match="Secret values cannot be provided in config"
     ):
-        cloud_mcp.deploy_source_to_cloud(
-            object(),
-            "Google Sheets",
-            "source-google-sheets",
-            workspace_id=None,
-            config={"credentials": {"auth_type": "Client", "client_id": "secret"}},
-            config_secret_name=None,
-            unique=True,
+        workspace.deploy_source(
+            name="Google Sheets",
+            source=source,
+            unique=False,
             deferred_auth=True,
         )
 
@@ -101,11 +117,6 @@ def test_deferred_auth_accepts_json_config_and_rejects_invalid_json(
             assert value == {"spreadsheet_id": "sheet-id"}
             assert validate is False
 
-    monkeypatch.setattr(
-        cloud_mcp,
-        "get_connector_spec_from_registry",
-        lambda *args, **kwargs: _google_sheets_schema(),
-    )
     monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
     monkeypatch.setattr(
         cloud_mcp,
@@ -164,6 +175,21 @@ def test_stub_missing_secrets_matches_null_const_branch() -> None:
         "auth_type": None,
         "client_id": SECRET_PLACEHOLDER,
     }
+
+
+def test_stub_missing_secrets_does_not_match_omitted_null_const() -> None:
+    schema = {
+        "oneOf": [
+            {
+                "properties": {
+                    "auth_type": {"const": None},
+                    "client_id": {"airbyte_secret": True},
+                }
+            }
+        ]
+    }
+
+    assert _stub_missing_secrets({}, schema) == {}
 
 
 def test_stub_missing_secrets_handles_all_of() -> None:
@@ -274,6 +300,48 @@ def test_schema_secret_paths_include_nested_branch_secrets() -> None:
     }
 
 
+def test_workspace_deferred_auth_stubs_source_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = object.__new__(SourceBase)
+    source._name = "source-google-sheets"  # noqa: SLF001
+    source._config_dict = {  # noqa: SLF001
+        "credentials": {"auth_type": "Client"}
+    }
+    workspace = _workspace()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+
+    def create_source(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return type("SourceResponse", (), {"source_id": "source-id"})()
+
+    monkeypatch.setattr(cloud_workspaces.api_util, "create_source", create_source)
+
+    deployed = workspace.deploy_source(
+        name="Google Sheets",
+        source=source,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    assert captured["config"] == {
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": SECRET_PLACEHOLDER,
+            "client_secret": SECRET_PLACEHOLDER,
+            "refresh_token": SECRET_PLACEHOLDER,
+        },
+        "sourceType": "google-sheets",
+    }
+    assert deployed.connector_id == "source-id"
+
+
 def test_deferred_auth_creates_source_with_safe_confirmation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -286,10 +354,18 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
             captured["validate"] = validate
 
     class Workspace:
-        def deploy_source(self, *, name: str, source: Source, unique: bool) -> Any:
+        def deploy_source(
+            self,
+            *,
+            name: str,
+            source: Source,
+            unique: bool,
+            deferred_auth: bool,
+        ) -> Any:
             captured["name"] = name
             captured["source"] = source
             captured["unique"] = unique
+            captured["deferred_auth"] = deferred_auth
             return type(
                 "DeployedSource",
                 (),
@@ -299,11 +375,6 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
                 },
             )()
 
-    monkeypatch.setattr(
-        cloud_mcp,
-        "get_connector_spec_from_registry",
-        lambda *args, **kwargs: _google_sheets_schema(),
-    )
     monkeypatch.setattr(
         cloud_mcp,
         "_get_cloud_workspace",
@@ -322,18 +393,11 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
         deferred_auth=True,
     )
 
-    assert captured["config"] == {
-        "credentials": {
-            "auth_type": "Client",
-            "client_id": SECRET_PLACEHOLDER,
-            "client_secret": SECRET_PLACEHOLDER,
-            "refresh_token": SECRET_PLACEHOLDER,
-        },
-        "spreadsheet_id": "sheet-id",
-    }
+    assert captured["config"] == config
     assert captured["validate"] is False
     assert captured["name"] == "Google Sheets"
     assert captured["unique"] is True
+    assert captured["deferred_auth"] is True
     assert result.startswith(
         "Successfully deployed source 'Google Sheets' with ID 'source-id'"
     )
@@ -345,15 +409,7 @@ def test_deferred_auth_creates_source_with_safe_confirmation(
     assert "bearer-token" not in serialized
 
 
-def test_deferred_auth_rejects_config_secret_name(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        cloud_mcp,
-        "get_connector_spec_from_registry",
-        lambda *args, **kwargs: _google_sheets_schema(),
-    )
-
+def test_deferred_auth_rejects_config_secret_name() -> None:
     with pytest.raises(
         PyAirbyteInputError,
         match="config_secret_name cannot be used with deferred_auth",
@@ -373,8 +429,15 @@ def test_deferred_auth_rejects_config_secret_name(
 def test_deferred_auth_rejects_destination_secret_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    destination = object.__new__(DestinationBase)
+    destination._name = "destination-postgres"  # noqa: SLF001
+    destination._config_dict = {  # noqa: SLF001
+        "credentials": {"auth_type": "Client", "client_id": "secret"}
+    }
+    workspace = _workspace()
+
     monkeypatch.setattr(
-        cloud_mcp,
+        cloud_workspaces,
         "get_connector_spec_from_registry",
         lambda *args, **kwargs: _google_sheets_schema(),
     )
@@ -382,14 +445,10 @@ def test_deferred_auth_rejects_destination_secret_config(
     with pytest.raises(
         PyAirbyteInputError, match="Secret values cannot be provided in config"
     ):
-        cloud_mcp.deploy_destination_to_cloud(
-            object(),
-            "Postgres",
-            "destination-postgres",
-            workspace_id=None,
-            config={"credentials": {"auth_type": "Client", "client_id": "secret"}},
-            config_secret_name=None,
-            unique=True,
+        workspace.deploy_destination(
+            name="Postgres",
+            destination=destination,
+            unique=False,
             deferred_auth=True,
         )
 
@@ -429,10 +488,12 @@ def test_deferred_auth_creates_destination_with_safe_confirmation(
             name: str,
             destination: Destination,
             unique: bool,
+            deferred_auth: bool,
         ) -> Any:
             captured["name"] = name
             captured["destination"] = destination
             captured["unique"] = unique
+            captured["deferred_auth"] = deferred_auth
             return type(
                 "DeployedDestination",
                 (),
@@ -442,11 +503,6 @@ def test_deferred_auth_creates_destination_with_safe_confirmation(
                 },
             )()
 
-    monkeypatch.setattr(
-        cloud_mcp,
-        "get_connector_spec_from_registry",
-        lambda *args, **kwargs: _google_sheets_schema(),
-    )
     monkeypatch.setattr(
         cloud_mcp,
         "_get_cloud_workspace",
@@ -469,18 +525,11 @@ def test_deferred_auth_creates_destination_with_safe_confirmation(
         deferred_auth=True,
     )
 
-    assert captured["config"] == {
-        "credentials": {
-            "auth_type": "Client",
-            "client_id": SECRET_PLACEHOLDER,
-            "client_secret": SECRET_PLACEHOLDER,
-            "refresh_token": SECRET_PLACEHOLDER,
-        },
-        "database": "warehouse",
-    }
+    assert captured["config"] == config
     assert captured["validate"] is False
     assert captured["name"] == "Postgres"
     assert captured["unique"] is True
+    assert captured["deferred_auth"] is True
     assert result.startswith(
         "Successfully deployed destination 'Postgres' with ID 'destination-id' "
         "and URL: https://cloud.airbyte.com/destinations/destination-id"
@@ -503,9 +552,17 @@ def test_deploy_source_without_deferred_auth_has_no_note(
             assert validate is True
 
     class Workspace:
-        def deploy_source(self, *, name: str, source: Source, unique: bool) -> Any:
+        def deploy_source(
+            self,
+            *,
+            name: str,
+            source: Source,
+            unique: bool,
+            deferred_auth: bool,
+        ) -> Any:
             assert name == "Source"
             assert unique is True
+            assert deferred_auth is False
             return type(
                 "DeployedSource",
                 (),
@@ -538,11 +595,12 @@ def test_deploy_source_without_deferred_auth_has_no_note(
 def test_deferred_auth_requires_workspace_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        cloud_mcp,
-        "get_connector_spec_from_registry",
-        lambda *args, **kwargs: _google_sheets_schema(),
-    )
+    class Source:
+        def set_config(self, value: dict[str, Any], *, validate: bool) -> None:
+            assert value == {}
+            assert validate is False
+
+    monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
     monkeypatch.setattr(cloud_mcp, "get_mcp_config", lambda *args, **kwargs: None)
 
     with pytest.raises(AirbyteMissingWorkspaceContextError):

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from airbyte import _connector_base
 from airbyte.cloud import workspaces as cloud_workspaces
 from airbyte.cloud._deferred_auth import (
     SECRET_PLACEHOLDER,
@@ -300,7 +301,7 @@ def test_schema_secret_paths_include_nested_branch_secrets() -> None:
     }
 
 
-def test_workspace_deferred_auth_stubs_source_config(
+def test_workspace_deferred_auth_stubs_source_config_without_hydration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = object.__new__(SourceBase)
@@ -311,6 +312,10 @@ def test_workspace_deferred_auth_stubs_source_config(
     workspace = _workspace()
     captured: dict[str, Any] = {}
 
+    def fail_hydration(value: object) -> object:
+        raise AssertionError("deferred auth should not hydrate connector secrets")
+
+    monkeypatch.setattr(_connector_base, "hydrate_secrets", fail_hydration)
     monkeypatch.setattr(
         cloud_workspaces,
         "get_connector_spec_from_registry",

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -354,6 +354,124 @@ def test_deferred_auth_rejects_config_secret_name(
         )
 
 
+def test_deferred_auth_rejects_destination_secret_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+
+    with pytest.raises(
+        PyAirbyteInputError, match="Secret values cannot be provided in config"
+    ):
+        cloud_mcp.deploy_destination_to_cloud(
+            object(),
+            "Postgres",
+            "destination-postgres",
+            workspace_id=None,
+            config={"credentials": {"auth_type": "Client", "client_id": "secret"}},
+            config_secret_name=None,
+            unique=True,
+            deferred_auth=True,
+        )
+
+
+def test_deferred_auth_rejects_destination_config_secret_name() -> None:
+    with pytest.raises(
+        PyAirbyteInputError,
+        match="config_secret_name cannot be used with deferred_auth",
+    ):
+        cloud_mcp.deploy_destination_to_cloud(
+            object(),
+            "Postgres",
+            "destination-postgres",
+            workspace_id=None,
+            config=None,
+            config_secret_name="destination-config",
+            unique=True,
+            deferred_auth=True,
+        )
+
+
+def test_deferred_auth_creates_destination_with_safe_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = {"credentials": {"auth_type": "Client"}, "database": "warehouse"}
+    captured: dict[str, Any] = {}
+
+    class Destination:
+        def set_config(self, value: dict[str, Any], *, validate: bool) -> None:
+            captured["config"] = value
+            captured["validate"] = validate
+
+    class Workspace:
+        def deploy_destination(
+            self,
+            *,
+            name: str,
+            destination: Destination,
+            unique: bool,
+        ) -> Any:
+            captured["name"] = name
+            captured["destination"] = destination
+            captured["unique"] = unique
+            return type(
+                "DeployedDestination",
+                (),
+                {"connector_id": "destination-id"},
+            )()
+
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: Workspace(),
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_destination",
+        lambda *args, **kwargs: Destination(),
+    )
+
+    result = cloud_mcp.deploy_destination_to_cloud(
+        object(),
+        "Postgres",
+        "destination-postgres",
+        config=config,
+        workspace_id="ws",
+        config_secret_name=None,
+        unique=True,
+        deferred_auth=True,
+    )
+
+    assert captured["config"] == {
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": SECRET_PLACEHOLDER,
+            "client_secret": SECRET_PLACEHOLDER,
+            "refresh_token": SECRET_PLACEHOLDER,
+        },
+        "database": "warehouse",
+    }
+    assert captured["validate"] is False
+    assert captured["name"] == "Postgres"
+    assert captured["unique"] is True
+    assert result.startswith(
+        "Successfully deployed destination 'Postgres' with ID: destination-id"
+    )
+    assert "Destination created without working credentials (deferred auth)." in result
+    assert SECRET_PLACEHOLDER not in result
+    assert "__airbyte_placeholder__" not in json.dumps(result)
+    assert "client-secret" not in result
+    assert "bearer-token" not in result
+
+
 def test_deploy_source_without_deferred_auth_has_no_note(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Tests for deferred Cloud connector authentication."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from airbyte.exceptions import AirbyteMissingWorkspaceContextError, PyAirbyteInputError
+from airbyte.mcp import cloud as cloud_mcp
+from airbyte.mcp._deferred_auth import (
+    SECRET_PLACEHOLDER,
+    _schema_secret_paths,
+    _stub_missing_secrets,
+)
+
+
+def _google_sheets_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "spreadsheet_id": {"type": "string"},
+            "credentials": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "auth_type": {"const": "Client"},
+                            "client_id": {
+                                "type": "string",
+                                "airbyte_secret": True,
+                            },
+                            "client_secret": {
+                                "type": "string",
+                                "airbyte_secret": True,
+                            },
+                            "refresh_token": {
+                                "type": "string",
+                                "airbyte_secret": True,
+                            },
+                        },
+                    }
+                ]
+            },
+        },
+    }
+
+
+def _enum_auth_schema() -> dict[str, Any]:
+    return {
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "auth_type": {"enum": ["Client"]},
+                    "client_id": {"type": "string", "airbyte_secret": True},
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "auth_type": {"enum": ["Service"]},
+                    "service_account": {"type": "string", "airbyte_secret": True},
+                },
+            },
+        ]
+    }
+
+
+def test_deferred_auth_rejects_secret_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+
+    with pytest.raises(
+        PyAirbyteInputError, match="Secret values cannot be provided in config"
+    ):
+        cloud_mcp.create_source_with_deferred_auth(
+            object(),
+            "Google Sheets",
+            "source-google-sheets",
+            config={"credentials": {"auth_type": "Client", "client_id": "secret"}},
+        )
+
+
+def test_deferred_auth_accepts_json_config_and_rejects_invalid_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: (_ for _ in ()).throw(
+            AirbyteMissingWorkspaceContextError()
+        ),
+    )
+    with pytest.raises(AirbyteMissingWorkspaceContextError):
+        cloud_mcp.create_source_with_deferred_auth(
+            object(),
+            "Google Sheets",
+            "source-google-sheets",
+            config='{"spreadsheet_id":"sheet-id"}',
+        )
+
+    with pytest.raises(PyAirbyteInputError, match="config must be a JSON object"):
+        cloud_mcp.create_source_with_deferred_auth(
+            object(),
+            "Google Sheets",
+            "source-google-sheets",
+            config="{",
+        )
+
+
+def test_stub_missing_secrets_matches_single_value_enum_branch() -> None:
+    result = _stub_missing_secrets({"auth_type": "Client"}, _enum_auth_schema())
+
+    assert result == {
+        "auth_type": "Client",
+        "client_id": SECRET_PLACEHOLDER,
+    }
+
+
+def test_stub_missing_secrets_leaves_unknown_branch_unchanged() -> None:
+    schema = _enum_auth_schema()
+    value = {"auth_type": "Unknown"}
+
+    assert _stub_missing_secrets(value, schema) == value
+
+
+def test_stub_missing_secrets_preserves_present_secret() -> None:
+    result = _stub_missing_secrets(
+        {
+            "spreadsheet_id": "sheet-id",
+            "credentials": {
+                "auth_type": "Client",
+                "client_id": "already-present",
+            },
+        },
+        _google_sheets_schema(),
+    )
+
+    assert result == {
+        "spreadsheet_id": "sheet-id",
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": "already-present",
+            "client_secret": SECRET_PLACEHOLDER,
+            "refresh_token": SECRET_PLACEHOLDER,
+        },
+    }
+
+
+def test_schema_secret_paths_include_nested_branch_secrets() -> None:
+    assert _schema_secret_paths(_google_sheets_schema()) == {
+        "credentials.client_id",
+        "credentials.client_secret",
+        "credentials.refresh_token",
+    }
+
+
+def test_deferred_auth_creates_source_with_safe_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = {"credentials": {"auth_type": "Client"}, "spreadsheet_id": "sheet-id"}
+    captured: dict[str, Any] = {}
+
+    class Source:
+        def set_config(self, value: dict[str, Any], *, validate: bool) -> None:
+            captured["config"] = value
+            captured["validate"] = validate
+
+    class Workspace:
+        def deploy_source(self, *, name: str, source: Source, unique: bool) -> Any:
+            captured["name"] = name
+            captured["source"] = source
+            captured["unique"] = unique
+            return type(
+                "DeployedSource",
+                (),
+                {
+                    "connector_id": "source-id",
+                    "connector_url": "https://cloud.airbyte.com/workspaces/ws/source/source-id",
+                },
+            )()
+
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id=None: Workspace(),
+    )
+    monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
+
+    result = cloud_mcp.create_source_with_deferred_auth(
+        object(),
+        "Google Sheets",
+        "source-google-sheets",
+        config=config,
+        workspace_id="ws",
+    )
+
+    assert captured["config"] == {
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": SECRET_PLACEHOLDER,
+            "client_secret": SECRET_PLACEHOLDER,
+            "refresh_token": SECRET_PLACEHOLDER,
+        },
+        "spreadsheet_id": "sheet-id",
+    }
+    assert captured["validate"] is False
+    assert captured["name"] == "Google Sheets"
+    assert captured["unique"] is True
+    assert result.id == "source-id"
+    assert result.name == "Google Sheets"
+    assert result.url == "https://cloud.airbyte.com/workspaces/ws/source/source-id"
+    assert result.non_secret_config == config
+    assert "complete authentication" in result.note
+    serialized = result.model_dump_json()
+    assert "__airbyte_placeholder__" not in serialized
+    assert "client-secret" not in serialized
+    assert "bearer-token" not in serialized
+    assert json.loads(serialized)["non_secret_config"] == config
+
+
+def test_deferred_auth_requires_workspace_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cloud_mcp,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(cloud_mcp, "get_mcp_config", lambda *args, **kwargs: None)
+
+    with pytest.raises(AirbyteMissingWorkspaceContextError):
+        cloud_mcp.create_source_with_deferred_auth(
+            object(),
+            "Google Sheets",
+            "source-google-sheets",
+        )

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -335,7 +335,7 @@ def test_stub_missing_secrets_materializes_required_secret_container() -> None:
     }
 
 
-def test_stub_missing_secrets_does_not_materialize_unselected_auth_container() -> None:
+def test_stub_missing_secrets_materializes_default_auth_container() -> None:
     schema = {
         "required": ["credentials"],
         "properties": {
@@ -358,7 +358,172 @@ def test_stub_missing_secrets_does_not_materialize_unselected_auth_container() -
         },
     }
 
-    assert _stub_missing_secrets({}, schema) == {}
+    assert _stub_missing_secrets({}, schema) == {
+        "credentials": {
+            "auth_type": "token",
+            "token": SECRET_PLACEHOLDER,
+        }
+    }
+
+
+def test_stub_missing_secrets_defaults_to_first_tunnel_branch() -> None:
+    schema = {
+        "required": ["tunnel_method"],
+        "properties": {
+            "tunnel_method": {
+                "oneOf": [
+                    {
+                        "required": ["tunnel_method"],
+                        "properties": {
+                            "tunnel_method": {"const": "NO_TUNNEL"},
+                        },
+                    },
+                    {
+                        "required": ["tunnel_method", "tunnel_host"],
+                        "properties": {
+                            "tunnel_method": {"const": "SSH_KEY_AUTH"},
+                            "tunnel_host": {"type": "string"},
+                        },
+                    },
+                ]
+            }
+        },
+    }
+
+    assert _stub_missing_secrets({}, schema) == {
+        "tunnel_method": {"tunnel_method": "NO_TUNNEL"}
+    }
+
+
+def test_stub_missing_secrets_defaults_github_credentials_branch() -> None:
+    schema = {
+        "required": ["credentials"],
+        "properties": {
+            "credentials": {
+                "oneOf": [
+                    {
+                        "required": ["access_token"],
+                        "properties": {
+                            "option_title": {"const": "OAuth Credentials"},
+                            "access_token": {
+                                "type": "string",
+                                "airbyte_secret": True,
+                            },
+                        },
+                    },
+                    {
+                        "required": ["personal_access_token"],
+                        "properties": {
+                            "option_title": {"const": "PAT Credentials"},
+                            "personal_access_token": {
+                                "type": "string",
+                                "airbyte_secret": True,
+                            },
+                        },
+                    },
+                ]
+            }
+        },
+    }
+
+    assert _stub_missing_secrets({}, schema) == {
+        "credentials": {
+            "option_title": "OAuth Credentials",
+            "access_token": SECRET_PLACEHOLDER,
+        }
+    }
+
+
+def test_stub_missing_secrets_preserves_selected_branch() -> None:
+    schema = {
+        "oneOf": [
+            {
+                "required": ["auth_type", "first_secret"],
+                "properties": {
+                    "auth_type": {"const": "first"},
+                    "first_secret": {"airbyte_secret": True},
+                },
+            },
+            {
+                "required": ["auth_type", "second_secret"],
+                "properties": {
+                    "auth_type": {"const": "second"},
+                    "second_secret": {"airbyte_secret": True},
+                },
+            },
+        ]
+    }
+
+    assert _stub_missing_secrets({"auth_type": "second"}, schema) == {
+        "auth_type": "second",
+        "second_secret": SECRET_PLACEHOLDER,
+    }
+
+
+def test_stub_missing_secrets_skips_unsatisfiable_default_branch() -> None:
+    schema = {
+        "required": ["credentials"],
+        "properties": {
+            "credentials": {
+                "oneOf": [
+                    {
+                        "required": ["auth_type", "host"],
+                        "properties": {
+                            "auth_type": {"const": "first"},
+                            "host": {"type": "string"},
+                        },
+                    },
+                    {
+                        "required": ["auth_type", "token"],
+                        "properties": {
+                            "auth_type": {"const": "second"},
+                            "token": {"airbyte_secret": True},
+                        },
+                    },
+                ]
+            }
+        },
+    }
+
+    assert _stub_missing_secrets({}, schema) == {
+        "credentials": {
+            "auth_type": "second",
+            "token": SECRET_PLACEHOLDER,
+        }
+    }
+
+
+def test_stub_missing_secrets_defaults_single_value_enum_branch() -> None:
+    schema = {
+        "required": ["credentials"],
+        "properties": {
+            "credentials": {
+                "oneOf": [
+                    {
+                        "required": ["auth_type", "token"],
+                        "properties": {
+                            "auth_type": {"enum": ["token"]},
+                            "token": {"airbyte_secret": True},
+                        },
+                    },
+                    {
+                        "required": ["auth_type", "api_key"],
+                        "properties": {
+                            "auth_type": {"enum": ["api_key"]},
+                            "api_key": {"airbyte_secret": True},
+                        },
+                    },
+                ]
+            }
+        },
+    }
+
+    assert _stub_missing_secrets({}, schema) == {
+        "credentials": {
+            "auth_type": "token",
+            "token": SECRET_PLACEHOLDER,
+        }
+    }
 
 
 def test_supplied_secret_paths_follow_selected_branch() -> None:

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -420,7 +420,10 @@ def test_deferred_auth_creates_destination_with_safe_confirmation(
             return type(
                 "DeployedDestination",
                 (),
-                {"connector_id": "destination-id"},
+                {
+                    "connector_id": "destination-id",
+                    "connector_url": "https://cloud.airbyte.com/destinations/destination-id",
+                },
             )()
 
     monkeypatch.setattr(
@@ -463,7 +466,8 @@ def test_deferred_auth_creates_destination_with_safe_confirmation(
     assert captured["name"] == "Postgres"
     assert captured["unique"] is True
     assert result.startswith(
-        "Successfully deployed destination 'Postgres' with ID: destination-id"
+        "Successfully deployed destination 'Postgres' with ID 'destination-id' "
+        "and URL: https://cloud.airbyte.com/destinations/destination-id"
     )
     assert "Destination created without working credentials (deferred auth)." in result
     assert SECRET_PLACEHOLDER not in result

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -174,6 +174,52 @@ def test_stub_missing_secrets_handles_all_of() -> None:
     assert _stub_missing_secrets({}, schema) == {"api_key": SECRET_PLACEHOLDER}
 
 
+def test_stub_missing_secrets_handles_arrays() -> None:
+    schema = {
+        "properties": {
+            "credentials": {
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "api_key": {"airbyte_secret": True},
+                    }
+                },
+            }
+        }
+    }
+
+    assert _stub_missing_secrets({"credentials": [{}]}, schema) == {
+        "credentials": [{"api_key": SECRET_PLACEHOLDER}]
+    }
+
+
+def test_stub_missing_secrets_stubs_selected_branch_and_parent_properties() -> None:
+    schema = {
+        "properties": {
+            "api_key": {"airbyte_secret": True},
+            "credentials": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "auth_type": {"const": "Client"},
+                            "client_id": {"airbyte_secret": True},
+                        }
+                    }
+                ]
+            },
+        }
+    }
+    value = {"credentials": {"auth_type": "Client"}}
+
+    assert _stub_missing_secrets(value, schema) == {
+        "api_key": SECRET_PLACEHOLDER,
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": SECRET_PLACEHOLDER,
+        },
+    }
+
+
 def test_stub_missing_secrets_leaves_unknown_branch_unchanged() -> None:
     schema = _enum_auth_schema()
     value = {"auth_type": "Unknown"}

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -13,6 +13,7 @@ from airbyte.cloud import workspaces as cloud_workspaces
 from airbyte.cloud._deferred_auth import (
     SECRET_PLACEHOLDER,
     _schema_secret_paths,
+    _supplied_secret_paths,
     _stub_missing_secrets,
 )
 from airbyte.destinations.base import Destination as DestinationBase
@@ -68,6 +69,41 @@ def _enum_auth_schema() -> dict[str, Any]:
                     "auth_type": {"enum": ["Service"]},
                     "service_account": {"type": "string", "airbyte_secret": True},
                 },
+            },
+        ]
+    }
+
+
+def _required_credentials_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["credentials"],
+        "properties": {
+            "credentials": {
+                "type": "object",
+                "required": ["api_key"],
+                "properties": {
+                    "api_key": {"type": "string", "airbyte_secret": True},
+                },
+            }
+        },
+    }
+
+
+def _branch_token_schema() -> dict[str, Any]:
+    return {
+        "oneOf": [
+            {
+                "properties": {
+                    "auth_type": {"const": "token"},
+                    "token": {"type": "string", "airbyte_secret": True},
+                }
+            },
+            {
+                "properties": {
+                    "auth_type": {"const": "oauth"},
+                    "token": {"type": "string"},
+                }
             },
         ]
     }
@@ -293,6 +329,52 @@ def test_stub_missing_secrets_preserves_empty_secret_value() -> None:
     assert _stub_missing_secrets({"api_key": ""}, schema) == {"api_key": ""}
 
 
+def test_stub_missing_secrets_materializes_required_secret_container() -> None:
+    assert _stub_missing_secrets({}, _required_credentials_schema()) == {
+        "credentials": {"api_key": SECRET_PLACEHOLDER}
+    }
+
+
+def test_stub_missing_secrets_does_not_materialize_unselected_auth_container() -> None:
+    schema = {
+        "required": ["credentials"],
+        "properties": {
+            "credentials": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "auth_type": {"const": "token"},
+                            "token": {"airbyte_secret": True},
+                        }
+                    },
+                    {
+                        "properties": {
+                            "auth_type": {"const": "oauth"},
+                            "access_token": {"airbyte_secret": True},
+                        }
+                    },
+                ]
+            }
+        },
+    }
+
+    assert _stub_missing_secrets({}, schema) == {}
+
+
+def test_supplied_secret_paths_follow_selected_branch() -> None:
+    assert (
+        _supplied_secret_paths(
+            {"auth_type": "oauth", "token": "non-secret"},
+            _branch_token_schema(),
+        )
+        == set()
+    )
+    assert _supplied_secret_paths(
+        {"auth_type": "token", "token": "secret"},
+        _branch_token_schema(),
+    ) == {"token"}
+
+
 def test_schema_secret_paths_include_nested_branch_secrets() -> None:
     assert _schema_secret_paths(_google_sheets_schema()) == {
         "credentials.client_id",
@@ -345,6 +427,219 @@ def test_workspace_deferred_auth_stubs_source_config_without_hydration(
         "sourceType": "google-sheets",
     }
     assert deployed.connector_id == "source-id"
+
+
+def test_workspace_deferred_auth_materializes_required_source_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = object.__new__(SourceBase)
+    source._name = "source-google-ads"  # noqa: SLF001
+    source._config_dict = {}  # noqa: SLF001
+    workspace = _workspace()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _required_credentials_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_source",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or type("SourceResponse", (), {"source_id": "source-id"})()
+        ),
+    )
+
+    workspace.deploy_source(
+        name="Google Ads",
+        source=source,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    assert captured["config"] == {
+        "credentials": {"api_key": SECRET_PLACEHOLDER},
+        "sourceType": "google-ads",
+    }
+
+
+def test_workspace_deferred_auth_materializes_required_destination_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = object.__new__(DestinationBase)
+    destination._name = "destination-google-ads"  # noqa: SLF001
+    destination._config_dict = {}  # noqa: SLF001
+    workspace = _workspace()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _required_credentials_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_destination",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or type("DestinationResponse", (), {"destination_id": "destination-id"})()
+        ),
+    )
+
+    workspace.deploy_destination(
+        name="Google Ads",
+        destination=destination,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    assert captured["config"] == {
+        "credentials": {"api_key": SECRET_PLACEHOLDER},
+        "destinationType": "google-ads",
+    }
+
+
+def test_workspace_deferred_auth_replaces_null_source_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = object.__new__(SourceBase)
+    source._name = "source-google-sheets"  # noqa: SLF001
+    source._config_dict = {  # noqa: SLF001
+        "credentials": {"auth_type": "Client", "client_id": None}
+    }
+    workspace = _workspace()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_source",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or type("SourceResponse", (), {"source_id": "source-id"})()
+        ),
+    )
+
+    workspace.deploy_source(
+        name="Google Sheets",
+        source=source,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    assert captured["config"]["credentials"]["client_id"] == SECRET_PLACEHOLDER
+
+
+def test_workspace_deferred_auth_replaces_null_destination_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = object.__new__(DestinationBase)
+    destination._name = "destination-google-sheets"  # noqa: SLF001
+    destination._config_dict = {  # noqa: SLF001
+        "credentials": {"auth_type": "Client", "client_id": None}
+    }
+    workspace = _workspace()
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _google_sheets_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_destination",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or type("DestinationResponse", (), {"destination_id": "destination-id"})()
+        ),
+    )
+
+    workspace.deploy_destination(
+        name="Google Sheets",
+        destination=destination,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    assert captured["config"]["credentials"]["client_id"] == SECRET_PLACEHOLDER
+
+
+def test_workspace_deferred_auth_rejects_secrets_only_in_selected_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = object.__new__(SourceBase)
+    source._name = "source-branch-test"  # noqa: SLF001
+    source._config_dict = {"auth_type": "oauth", "token": "non-secret"}  # noqa: SLF001
+    destination = object.__new__(DestinationBase)
+    destination._name = "destination-branch-test"  # noqa: SLF001
+    destination._config_dict = {  # noqa: SLF001
+        "auth_type": "oauth",
+        "token": "non-secret",
+    }
+    workspace = _workspace()
+    response = type(
+        "Response", (), {"source_id": "source-id", "destination_id": "destination-id"}
+    )()
+
+    monkeypatch.setattr(
+        cloud_workspaces,
+        "get_connector_spec_from_registry",
+        lambda *args, **kwargs: _branch_token_schema(),
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_source",
+        lambda **kwargs: response,
+    )
+    monkeypatch.setattr(
+        cloud_workspaces.api_util,
+        "create_destination",
+        lambda **kwargs: response,
+    )
+
+    workspace.deploy_source(
+        name="Branch source",
+        source=source,
+        unique=False,
+        deferred_auth=True,
+    )
+    workspace.deploy_destination(
+        name="Branch destination",
+        destination=destination,
+        unique=False,
+        deferred_auth=True,
+    )
+
+    source._config_dict = {"auth_type": "token", "token": "secret"}  # noqa: SLF001
+    destination._config_dict = {  # noqa: SLF001
+        "auth_type": "token",
+        "token": "secret",
+    }
+    with pytest.raises(
+        PyAirbyteInputError, match="Secret values cannot be provided in config"
+    ):
+        workspace.deploy_source(
+            name="Branch source",
+            source=source,
+            unique=False,
+            deferred_auth=True,
+        )
+    with pytest.raises(
+        PyAirbyteInputError, match="Secret values cannot be provided in config"
+    ):
+        workspace.deploy_destination(
+            name="Branch destination",
+            destination=destination,
+            unique=False,
+            deferred_auth=True,
+        )
 
 
 def test_deferred_auth_creates_source_with_safe_confirmation(

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -96,11 +96,17 @@ def test_deferred_auth_rejects_secret_config(
 def test_deferred_auth_accepts_json_config_and_rejects_invalid_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    class Source:
+        def set_config(self, value: dict[str, Any], *, validate: bool) -> None:
+            assert value == {"spreadsheet_id": "sheet-id"}
+            assert validate is False
+
     monkeypatch.setattr(
         cloud_mcp,
         "get_connector_spec_from_registry",
         lambda *args, **kwargs: _google_sheets_schema(),
     )
+    monkeypatch.setattr(cloud_mcp, "get_source", lambda *args, **kwargs: Source())
     monkeypatch.setattr(
         cloud_mcp,
         "_get_cloud_workspace",
@@ -248,6 +254,16 @@ def test_stub_missing_secrets_preserves_present_secret() -> None:
             "refresh_token": SECRET_PLACEHOLDER,
         },
     }
+
+
+def test_stub_missing_secrets_preserves_empty_secret_value() -> None:
+    schema = {
+        "properties": {
+            "api_key": {"airbyte_secret": True},
+        }
+    }
+
+    assert _stub_missing_secrets({"api_key": ""}, schema) == {"api_key": ""}
 
 
 def test_schema_secret_paths_include_nested_branch_secrets() -> None:

--- a/tests/unit_tests/test_mcp_deferred_auth.py
+++ b/tests/unit_tests/test_mcp_deferred_auth.py
@@ -142,6 +142,38 @@ def test_stub_missing_secrets_matches_single_value_enum_branch() -> None:
     }
 
 
+def test_stub_missing_secrets_matches_null_const_branch() -> None:
+    schema = {
+        "oneOf": [
+            {
+                "properties": {
+                    "auth_type": {"const": None},
+                    "client_id": {"airbyte_secret": True},
+                }
+            }
+        ]
+    }
+
+    assert _stub_missing_secrets({"auth_type": None}, schema) == {
+        "auth_type": None,
+        "client_id": SECRET_PLACEHOLDER,
+    }
+
+
+def test_stub_missing_secrets_handles_all_of() -> None:
+    schema = {
+        "allOf": [
+            {
+                "properties": {
+                    "api_key": {"airbyte_secret": True},
+                }
+            }
+        ]
+    }
+
+    assert _stub_missing_secrets({}, schema) == {"api_key": SECRET_PLACEHOLDER}
+
+
 def test_stub_missing_secrets_leaves_unknown_branch_unchanged() -> None:
     schema = _enum_auth_schema()
     value = {"auth_type": "Unknown"}


### PR DESCRIPTION
## Summary

Adds a `deferred_auth: bool = False` input to both `deploy_source_to_cloud` and `deploy_destination_to_cloud` (Cloud MCP tools), backed by the same option on the public `CloudWorkspace.deploy_source()` / `deploy_destination()` API. When true, the connector is created **without** working credentials: the caller supplies only non-secret config, secret fields are stubbed with `SECRET_PLACEHOLDER`, and the user completes authentication in the Airbyte Cloud UI at the returned URL (typed secrets or the Cloud OAuth button). Secrets never enter model-visible MCP context.

Layering: the heavy lifting lives in the public API, not the MCP layer.
- `CloudWorkspace.deploy_source(..., deferred_auth=True)` / `deploy_destination(..., deferred_auth=True)` (`airbyte/cloud/workspaces.py`): fetch the connector spec from the registry (cloud → oss fallback), reject any supplied value on a secret-marked path (`airbyte_secret`, `writeOnly`, `format: password`) with `"Secret values cannot be provided in config."`, stub missing secret fields, then create via the existing Cloud API path (uniqueness, GUID). `deferred_auth` on a dict-form destination is rejected (requires a `Destination` object).
- Schema helpers in new `airbyte/cloud/_deferred_auth.py`: `_stub_missing_secrets` handles nested `properties`, `oneOf`/`anyOf` discriminator branch selection (incl. `const: null`, requiring the discriminator key to be present), `allOf` composition, and array `items`; present-but-falsy values are preserved (only missing/`None` get placeholders).
- The MCP tools stay thin: JSON-string/dict config coercion, rejecting `config_secret_name` with deferred auth, `set_config(..., validate=False)`, forwarding `deferred_auth`, and appending a "finish auth in the Cloud UI" note to the success string. This also makes deferred auth usable from plain PyAirbyte code.

### Deterministic default branch selection

Cloud validates the config against the connector spec on create, so a required `oneOf`/`anyOf` container (auth method, tunnel method, replication method, file format) must be present even when the agent never picked a branch. Rather than failing, `_stub_missing_secrets` now selects a **default branch deterministically**: the first branch *in spec order* whose every `required` name can be satisfied without inventing data — i.e. each one is a discriminator (`const` / single-value `enum` → set it), a secret (→ placeholder), has a schema `default`, was already supplied by the caller, or is itself a satisfiable nested branch. Unsatisfiable branches are skipped, so a branch needing a real hostname falls through to the next candidate.

```
credentials: oneOf[ {OAuth: access_token*}, {PAT: personal_access_token*} ]
config = {}   ->   {"credentials": {"option_title": "OAuth Credentials",
                                    "access_token": "__airbyte_placeholder__"}}
config = {"credentials": {"option_title": "PAT Credentials"}}  ->  PAT branch (caller wins)
```

First-in-spec-order matches what the Cloud UI preselects, and the user can switch branches there when finishing auth. A caller-supplied discriminator always wins — defaulting applies only when no branch is selected.

When `deferred_auth=False` (default), behavior is unchanged. `deploy_destination_to_cloud`'s success string now also includes the connector URL (previously ID only).

The created connector is intentionally unhealthy until the user completes authentication in the Cloud UI — this is the accepted design (create-first, authenticate-later), which avoids any secret handoff through the agent, forms, tokens, or OAuth callbacks.

## Test plan

- `tests/unit_tests/test_mcp_deferred_auth.py` (34 tests): workspace-level secret rejection and stubbing, JSON-string config, branch selection (`const`, single-value `enum`, `const: null`, omitted null discriminator), default-branch selection (first satisfiable, unsatisfiable-branch skip, caller-selected branch preserved, enum discriminator), `allOf`, array items, parent+branch composition, falsy-value preservation, safe output (no placeholders leaked), unchanged non-deferred behavior.
- `tests/unit_tests/test_deferred_auth_registry_specs.py`: one parameterized case per certified source connector, fetched live from the public connector registry (cloud spec, oss fallback; cached under a temp dir). Each case synthesizes the required non-secret values an agent would supply, runs `_stub_missing_secrets`, and validates the result with `jsonschema.validate` — the same check the Cloud API performs on create. **59 passed, 0 xfailed** (previously 23 xfailed); ~10s cold, ~1s warm.
- `uv run ruff format --check airbyte tests`, `uv run ruff check airbyte tests`, `uv run mypy airbyte/mcp airbyte/cloud`.

Related: extracted from the broader POC in https://github.com/airbytehq/PyAirbyte/pull/1137.


Link to Devin session: https://app.devin.ai/sessions/b89b8fd2ac844a2ca3667d257d0fba8c
Open in Devin Desktop: https://app.devin.ai/desktop/session/b89b8fd2ac844a2ca3667d257d0fba8c?variant=devin
Requested by: @aaronsteers