### PR TITLE
fix: use POSIX paths when mapping CLI args into Docker containers

### DIFF
--- a/airbyte/_executors/docker.py
+++ b/airbyte/_executors/docker.py
@@ -5,7 +5,7 @@ import logging
 import shutil
 import subprocess
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from airbyte import exceptions as exc
 from airbyte._executors.base import Executor
@@ -91,7 +91,12 @@ class DockerExecutor(Executor):
                             f"Found file input path `{arg}` "
                             f"relative to container-mapped volume: {local_volume}"
                         )
-                        mapped_path = Path(container_path) / Path(arg).relative_to(local_volume)
+                        # Containers are always Linux, so build the path with POSIX
+                        # separators regardless of the host platform.
+                        mapped_path = (
+                            PurePosixPath(container_path)
+                            / Path(arg).relative_to(local_volume).as_posix()
+                        )
                         logger.debug(f"Mapping `{arg}` -> `{mapped_path}`")
                         new_args.append(str(mapped_path))
                         break

--- a/tests/unit_tests/test_docker_executor.py
+++ b/tests/unit_tests/test_docker_executor.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Unit tests for the `DockerExecutor` CLI arg mapping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from airbyte._executors.docker import (
+    DEFAULT_AIRBYTE_CONTAINER_TEMP_DIR,
+    DockerExecutor,
+)
+
+
+def _make_executor(local_volume: Path) -> DockerExecutor:
+    return DockerExecutor(
+        name="source-faker",
+        image_name_full="airbyte/source-faker:latest",
+        executable=["docker", "run", "airbyte/source-faker:latest"],
+        volumes={local_volume: DEFAULT_AIRBYTE_CONTAINER_TEMP_DIR},
+    )
+
+
+def test_map_cli_args_emits_posix_container_paths(tmp_path: Path) -> None:
+    r"""Mapped paths must use POSIX separators, since the container is always Linux.
+
+    Regression test: on Windows, joining via `pathlib.Path` produced backslash paths
+    such as `\airbyte\tmp\config.json`, which the connector could not open.
+    """
+    config_file = tmp_path / "config.json"
+    config_file.write_text("{}")
+
+    executor = _make_executor(tmp_path)
+    mapped = executor.map_cli_args(["check", "--config", str(config_file)])
+
+    assert mapped == ["check", "--config", "/airbyte/tmp/config.json"]
+
+
+def test_map_cli_args_maps_nested_paths_with_posix_separators(tmp_path: Path) -> None:
+    """Nested files below the volume root keep POSIX separators in every segment."""
+    nested_dir = tmp_path / "sub" / "dir"
+    nested_dir.mkdir(parents=True)
+    catalog_file = nested_dir / "catalog.json"
+    catalog_file.write_text("{}")
+
+    executor = _make_executor(tmp_path)
+    mapped = executor.map_cli_args([str(catalog_file)])
+
+    assert mapped == ["/airbyte/tmp/sub/dir/catalog.json"]
+
+
+def test_map_cli_args_leaves_non_path_args_untouched(tmp_path: Path) -> None:
+    """Args that are not existing local files pass through unchanged."""
+    executor = _make_executor(tmp_path)
+    args = ["read", "--state", "--catalog"]
+
+    assert executor.map_cli_args(args) == args
+
+
+def test_map_cli_args_passes_through_unmapped_paths(tmp_path: Path) -> None:
+    """A file outside every mapped volume is passed through as-is."""
+    volume_dir = tmp_path / "volume"
+    volume_dir.mkdir()
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text("{}")
+
+    executor = _make_executor(volume_dir)
+    mapped = executor.map_cli_args([str(outside_file)])
+
+    assert mapped == [str(outside_file)]


### PR DESCRIPTION
`DockerExecutor.map_cli_args()` built the in-container path with `pathlib.Path`, which resolves to `WindowsPath` on Windows hosts. Config and catalog paths were therefore passed to the connector as `\airbyte\tmp\<file>.json`, and every Docker-based connector failed on Windows with:

    FileNotFoundError: [Errno 2] No such file or directory:
    '\\airbyte\\tmp\\tmpXXXX.json'

Connector containers are always Linux, so the container-side path is now built with `PurePosixPath` and the volume-relative segment normalized via `as_posix()`. Behavior on macOS/Linux is unchanged.

Adds unit coverage for `map_cli_args()`, including nested paths and pass-through of unmapped/non-path args.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Docker container path handling on host platforms that use backslashes, ensuring mapped paths consistently use POSIX separators.
  - Preserved non-path arguments and correctly handled nested paths and files outside mapped volumes.

- **Tests**
  - Added coverage for container path mapping across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->