### PR TITLE
fix: pass connector config to declarative sources

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import warnings
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, cast
@@ -82,9 +83,37 @@ class DeclarativeExecutor(Executor):
         self.reported_version: str | None = self._manifest_dict.get("version", None)
         self._config_dict = config_dict
 
-    @property
-    def declarative_source(self) -> ConcurrentDeclarativeSource:
-        """Get the declarative source object.
+    def _config_from_args(self, args: list[str]) -> dict[str, Any]:
+        """Read the connector config from the `--config <path>` CLI arg.
+
+        Returns an empty dict when the arg is absent (as for `spec`) or when the
+        referenced file cannot be read. Argument parsing and validation remain the
+        responsibility of the CDK entrypoint.
+        """
+        if "--config" not in args:
+            return {}
+
+        config_index = args.index("--config") + 1
+        if config_index >= len(args):
+            return {}
+
+        config_path = Path(args[config_index])
+        if not config_path.is_file():
+            return {}
+
+        try:
+            return cast(
+                "dict[str, Any]",
+                json.loads(config_path.read_text(encoding="utf-8")),
+            )
+        except (OSError, ValueError):
+            return {}
+
+    def _build_declarative_source(
+        self,
+        config: dict[str, Any] | None = None,
+    ) -> ConcurrentDeclarativeSource:
+        """Build the declarative source, merging `config` over any injected components.
 
         Notes:
         1. Since Sep 2025, the declarative source class used is `ConcurrentDeclarativeSource`.
@@ -94,9 +123,14 @@ class DeclarativeExecutor(Executor):
            avoid any issues with re-using the same object.
         """
         return ConcurrentDeclarativeSource(
-            config=self._config_dict,
+            config={**self._config_dict, **(config or {})},
             source_config=self._manifest_dict,
         )
+
+    @property
+    def declarative_source(self) -> ConcurrentDeclarativeSource:
+        """The declarative source object, without connector config applied."""
+        return self._build_declarative_source()
 
     def get_installed_version(
         self,
@@ -122,7 +156,12 @@ class DeclarativeExecutor(Executor):
     ) -> Iterator[str]:
         """Execute the declarative source."""
         _ = stdin, suppress_stderr  # Not used
-        source_entrypoint = AirbyteEntrypoint(self.declarative_source)
+        # The declarative source resolves `{{ config[...] }}` interpolations when it is
+        # constructed, so the connector config has to be supplied here rather than left
+        # for the entrypoint to read later.
+        source_entrypoint = AirbyteEntrypoint(
+            self._build_declarative_source(self._config_from_args(args))
+        )
 
         mapped_args: list[str] = self.map_cli_args(args)
         parsed_args: Namespace = source_entrypoint.parse_args(mapped_args)

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Unit tests for `DeclarativeExecutor` config handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from airbyte._executors.declarative import DeclarativeExecutor
+
+MINIMAL_MANIFEST: dict[str, Any] = {
+    "version": "0.1.0",
+    "type": "DeclarativeSource",
+    "check": {"type": "CheckStream", "stream_names": []},
+    "streams": [],
+}
+
+
+@pytest.fixture
+def executor() -> DeclarativeExecutor:
+    return DeclarativeExecutor(name="source-test", manifest=dict(MINIMAL_MANIFEST))
+
+
+def _write_config(tmp_path: Path, config: dict[str, Any]) -> str:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    return str(config_path)
+
+
+def test_config_from_args_reads_the_config_file(
+    executor: DeclarativeExecutor,
+    tmp_path: Path,
+) -> None:
+    """The connector config must be read back from the `--config` arg.
+
+    Regression test: the executor previously built the declarative source with an
+    empty config, so manifest interpolations such as `{{ config["client_id"] }}`
+    resolved to empty strings and connectors failed to authenticate.
+    """
+    config = {"client_id": "abc", "client_secret": "shh"}
+    args = ["check", "--config", _write_config(tmp_path, config)]
+
+    assert executor._config_from_args(args) == config
+
+
+def test_config_from_args_without_config_flag(executor: DeclarativeExecutor) -> None:
+    """`spec` takes no config, so there is nothing to read."""
+    assert executor._config_from_args(["spec"]) == {}
+
+
+def test_config_from_args_with_missing_file(executor: DeclarativeExecutor) -> None:
+    """A missing config path is tolerated rather than raising."""
+    assert (
+        executor._config_from_args(["check", "--config", "does_not_exist.json"]) == {}
+    )
+
+
+def test_declarative_source_receives_connector_config(
+    executor: DeclarativeExecutor,
+    tmp_path: Path,
+    mocker: Any,
+) -> None:
+    """The config read from args must reach the underlying CDK source."""
+    captured: dict[str, Any] = {}
+
+    def _capture(*_args: Any, **kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    mocker.patch(
+        "airbyte._executors.declarative.ConcurrentDeclarativeSource",
+        side_effect=_capture,
+    )
+
+    config = {"client_id": "abc"}
+    executor._build_declarative_source(config)
+
+    assert captured["config"]["client_id"] == "abc"
+
+
+def test_injected_components_are_preserved(tmp_path: Path, mocker: Any) -> None:
+    """Connector config must merge with, not replace, injected components."""
+    captured: dict[str, Any] = {}
+
+    def _capture(*_args: Any, **kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    mocker.patch(
+        "airbyte._executors.declarative.ConcurrentDeclarativeSource",
+        side_effect=_capture,
+    )
+
+    executor = DeclarativeExecutor(
+        name="source-test",
+        manifest=dict(MINIMAL_MANIFEST),
+        components_py="# components",
+    )
+    executor._build_declarative_source({"client_id": "abc"})
+
+    assert captured["config"]["client_id"] == "abc"
+    assert captured["config"]["__injected_components_py"] == "# components"


### PR DESCRIPTION
`DeclarativeExecutor` initialized `_config_dict` to an empty dict and never populated it from the connector config. `execute()` then built the CDK source via `ConcurrentDeclarativeSource(config=self._config_dict, ...)`, so any manifest interpolation of `{{ config[...] }}` resolved against an empty mapping.

Manifest-only connectors that template credentials into their authenticator therefore failed to authenticate. For example, `source-google-calendar` interpolates `client_id`, `client_secret` and `refresh_token` into an `OAuthAuthenticator`, and every sync failed with:

    Stream colors is not available: OAuth access token refresh request failed.

The credentials were valid; they simply never reached the source.

The declarative source resolves interpolations at construction time, so the config must be supplied then rather than left for the entrypoint to read later. `execute()` now reads the config from the `--config` argument it was invoked with and merges it over any injected components, which keeps `components.py` injection working.

`_config_dict` is left untouched, and the public `declarative_source` property is retained with its previous no-config behavior.

Verified against a live `source-google-calendar` sync, which now succeeds where it previously failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading connector configuration from a JSON file supplied through the command line.
  * Runtime configuration is now combined with injected components when creating declarative sources.
  * Declarative source construction can use a configurable builder.

* **Bug Fixes**
  * Improved handling of missing, unreadable, invalid, or incomplete configuration arguments.
  * Commands that do not require configuration continue to run without one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->