### PR TITLE
 fix: propagate config to declarative executor, allow config rewrites, use POSIX container paths

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import warnings
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, cast
@@ -113,6 +114,39 @@ class DeclarativeExecutor(Executor):
         """Not applicable."""
         return []  # N/A
 
+    def _load_config_from_args(self, args: list[str]) -> None:
+        """Merge the config passed as `--config <path>` into the executor config.
+
+        `ConcurrentDeclarativeSource` resolves `{{ config[...] }}` interpolations
+        against the config it is constructed with. Without this, the source is
+        built with an effectively empty config and every interpolation fails, e.g.
+        `'dict object' has no attribute 'api_key'`, or `SelectiveAuthenticator`
+        raising "The path from `authenticator_selection_path` is not found in the
+        config."
+
+        Injected component keys already in `_config_dict` take precedence, so
+        `__injected_components_py` is never overwritten by user config.
+        """
+        if "--config" not in args:
+            return
+
+        config_index = args.index("--config") + 1
+        if config_index >= len(args):
+            return
+
+        try:
+            config_path = Path(args[config_index])
+            user_config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # A malformed or unreadable config is reported downstream by the
+            # entrypoint with a much better error message than we could give here.
+            return
+
+        if isinstance(user_config, dict):
+            merged: dict[str, Any] = dict(user_config)
+            merged.update(self._config_dict)
+            self._config_dict = merged
+
     def execute(
         self,
         args: list[str],
@@ -122,6 +156,7 @@ class DeclarativeExecutor(Executor):
     ) -> Iterator[str]:
         """Execute the declarative source."""
         _ = stdin, suppress_stderr  # Not used
+        self._load_config_from_args(args)
         source_entrypoint = AirbyteEntrypoint(self.declarative_source)
 
         mapped_args: list[str] = self.map_cli_args(args)

--- a/airbyte/_executors/docker.py
+++ b/airbyte/_executors/docker.py
@@ -5,7 +5,7 @@ import logging
 import shutil
 import subprocess
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from airbyte import exceptions as exc
 from airbyte._executors.base import Executor
@@ -91,7 +91,15 @@ class DockerExecutor(Executor):
                             f"Found file input path `{arg}` "
                             f"relative to container-mapped volume: {local_volume}"
                         )
-                        mapped_path = Path(container_path) / Path(arg).relative_to(local_volume)
+                        # Container paths must be POSIX. `Path()` returns a
+                        # WindowsPath on Windows hosts, which stringifies with
+                        # backslash separators that the Linux container cannot
+                        # open. `PurePosixPath` keeps the separators correct on
+                        # every host OS.
+                        mapped_path = (
+                            PurePosixPath(container_path)
+                            / Path(arg).relative_to(local_volume).as_posix()
+                        )
                         logger.debug(f"Mapping `{arg}` -> `{mapped_path}`")
                         new_args.append(str(mapped_path))
                         break

--- a/airbyte/_util/temp_files.py
+++ b/airbyte/_util/temp_files.py
@@ -37,8 +37,23 @@ def as_temp_files(files_contents: list[dict | str]) -> Generator[list[str], Any,
                 json.dumps(content) if isinstance(content, dict) else content,
             )
             temp_file.flush()
-            # Grant "read" permission to all users
-            Path(temp_file.name).chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            # Grant read AND write permission to all users.
+            #
+            # Write access is required because connectors that declare
+            # `config_migrations` in their manifest (e.g. `source-slack`) rewrite
+            # the config file in place via
+            # `ConcurrentDeclarativeSource._migrate_and_transform_config()`.
+            # When the file is mounted into a container running as a different
+            # uid, a read-only file raises
+            # `PermissionError: [Errno 13] Permission denied`.
+            Path(temp_file.name).chmod(
+                stat.S_IRUSR
+                | stat.S_IRGRP
+                | stat.S_IROTH
+                | stat.S_IWUSR
+                | stat.S_IWGRP
+                | stat.S_IWOTH
+            )
 
             # Don't close the file yet (breaks Windows)
             # temp_file.close()

--- a/tests/unit_tests/test_executor_config_and_paths.py
+++ b/tests/unit_tests/test_executor_config_and_paths.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Regression tests for executor config propagation and container path mapping."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from airbyte._executors.declarative import DeclarativeExecutor
+from airbyte._executors.docker import DockerExecutor
+from airbyte._util.temp_files import as_temp_files
+
+
+MINIMAL_MANIFEST = {
+    "version": "4.6.2",
+    "type": "DeclarativeSource",
+    "check": {"type": "CheckStream", "stream_names": []},
+    "streams": [],
+    "spec": {
+        "type": "Spec",
+        "connection_specification": {
+            "type": "object",
+            "properties": {"api_key": {"type": "string"}},
+        },
+    },
+}
+
+
+class TestDeclarativeExecutorConfig:
+    """`{{ config[...] }}` cannot resolve unless the executor sees the real config."""
+
+    def test_config_from_args_is_merged(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps({"api_key": "secret-value"}), encoding="utf-8"
+        )
+
+        executor = DeclarativeExecutor(name="source-test", manifest=MINIMAL_MANIFEST)
+        assert "api_key" not in executor._config_dict
+
+        executor._load_config_from_args(["check", "--config", str(config_file)])
+
+        assert executor._config_dict["api_key"] == "secret-value"
+
+    def test_injected_components_are_not_overwritten(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps({"api_key": "x", "__injected_components_py": "MALICIOUS"}),
+            encoding="utf-8",
+        )
+
+        executor = DeclarativeExecutor(
+            name="source-test",
+            manifest=MINIMAL_MANIFEST,
+            components_py="# real components",
+        )
+        executor._load_config_from_args(["check", "--config", str(config_file)])
+
+        assert executor._config_dict["__injected_components_py"] == "# real components"
+        assert executor._config_dict["api_key"] == "x"
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["spec"],  # no --config at all
+            ["check", "--config"],  # --config with no value
+        ],
+    )
+    def test_missing_config_arg_is_a_noop(self, args: list[str]) -> None:
+        executor = DeclarativeExecutor(name="source-test", manifest=MINIMAL_MANIFEST)
+        before = dict(executor._config_dict)
+        executor._load_config_from_args(args)
+        assert executor._config_dict == before
+
+    def test_unreadable_config_does_not_raise(self, tmp_path: Path) -> None:
+        executor = DeclarativeExecutor(name="source-test", manifest=MINIMAL_MANIFEST)
+        executor._load_config_from_args([
+            "check",
+            "--config",
+            str(tmp_path / "nope.json"),
+        ])
+        # The entrypoint reports the real error; the executor must not mask it.
+        assert "api_key" not in executor._config_dict
+
+
+class TestTempFilePermissions:
+    """Connectors declaring `config_migrations` rewrite the config file in place."""
+
+    def test_temp_files_are_writable(self) -> None:
+        with as_temp_files([{"api_key": "x"}]) as [path]:
+            mode = os.stat(path).st_mode
+            assert mode & stat.S_IWUSR, "owner cannot write"
+            assert mode & stat.S_IROTH, "other cannot read"
+            if os.name != "nt":
+                assert mode & stat.S_IWOTH, "container uid cannot write"
+
+    def test_temp_file_can_actually_be_rewritten(self) -> None:
+        with as_temp_files([{"api_key": "x"}]) as [path]:
+            Path(path).write_text(json.dumps({"api_key": "migrated"}), encoding="utf-8")
+            assert (
+                json.loads(Path(path).read_text(encoding="utf-8"))["api_key"]
+                == "migrated"
+            )
+
+
+class TestDockerPathMapping:
+    """Container paths must be POSIX regardless of the host OS."""
+
+    def test_mapped_path_is_posix(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{}", encoding="utf-8")
+
+        executor = DockerExecutor(
+            name="source-test",
+            image_name_full="airbyte/source-test:latest",
+            executable=["docker", "run", "airbyte/source-test:latest"],
+            volumes={tmp_path: "/airbyte/tmp"},
+        )
+        mapped = executor.map_cli_args(["check", "--config", str(config_file)])
+
+        container_path = mapped[-1]
+        assert "\\" not in container_path, f"backslash leaked into {container_path!r}"
+        assert container_path == str(PurePosixPath("/airbyte/tmp/config.json"))
+
+    def test_non_path_args_pass_through(self, tmp_path: Path) -> None:
+        executor = DockerExecutor(
+            name="source-test",
+            image_name_full="airbyte/source-test:latest",
+            executable=["docker", "run", "airbyte/source-test:latest"],
+            volumes={tmp_path: "/airbyte/tmp"},
+        )
+        assert executor.map_cli_args(["read", "--catalog"]) == ["read", "--catalog"]


### PR DESCRIPTION
## What

Three independent defects in the executor layer, each with a regression test.
All three were found while building a production ingestion pipeline on PyAirbyte
with six connectors; the fixes are running there now.

## 1. `DeclarativeExecutor` never passes the user config to the source

`DeclarativeExecutor.declarative_source` constructs `ConcurrentDeclarativeSource`
with `self._config_dict`, which only ever contains injected component keys — never
the user's config. Every `{{ config[...] }}` interpolation in a manifest therefore
resolves against an effectively empty dict.

The config *is* supplied, as `--config <path>` to `execute()`, but only after the
source object has already been built.

**Symptoms**

- `'dict object' has no attribute 'api_key'` for any authenticated manifest source
- `The path from 'authenticator_selection_path' is not found in the config.` for any
  connector using `SelectiveAuthenticator` — `source-gmail`, `source-hubspot`,
  `source-slack`, `source-google-search-console`,
  `source-google-analytics-data-api`, `source-jira`, `source-zendesk-support`,
  `source-linkedin-ads`

In practice this makes `source_manifest=` unusable for any source that needs
credentials, and forces `docker_image=True` on a large set of otherwise
manifest-only connectors.

**Fix** — read the `--config` file in `execute()` and merge it into `_config_dict`
before the source is constructed. `declarative_source` is a property that re-reads
`_config_dict` on each access, so this is sufficient. Keys already present keep
precedence, so `__injected_components_py` cannot be overridden by user config.

## 2. Temp config files are read-only, breaking `config_migrations`

`as_temp_files()` wrote config files as `0444`. Connectors that declare
`config_migrations` rewrite the config file in place via
`ConcurrentDeclarativeSource._migrate_and_transform_config()`, which then raises:

```
PermissionError: [Errno 13] Permission denied: '/airbyte/tmp/tmpXXXX.json'
```

Reproducible with `source-slack`, whose manifest migrates the legacy
`{"api_key": ...}` shape to `{"credentials": {...}}`.

**Fix** — grant write as well as read.

## 3. Container paths are built as Windows paths on Windows hosts

`DockerExecutor.map_cli_args()` built the in-container path with
`Path(container_path) / ...`. On a Windows host that is a `WindowsPath`, which
stringifies with backslash separators, so the Linux container receives something
like `\airbyte\tmp\config.json` and fails with `FileNotFoundError`.

**Fix** — use `PurePosixPath`, which is correct on every host OS.

## Tests

`tests/unit_tests/test_executor_config_and_paths.py` — 9 tests covering:

- config from `--config` is merged into the executor config
- injected components are not overwritten by user config
- missing or malformed `--config` is a no-op rather than an error
- temp config files are writable, and can actually be rewritten in place
- mapped container paths contain no backslashes on any host
- non-path CLI args pass through unchanged

## Verification

```
9 passed        (new tests)
598 passed      (existing tests/unit_tests)
ruff check      All checks passed
ruff format     4 files already formatted
```

One pre-existing failure in `tests/unit_tests/test_progress.py::test_get_time_str`
is unrelated to this change: `_to_time_str()` renders local time while the test uses
`freeze_time`, so it fails on any non-UTC machine (`assert '05:30:00' == '00:00:00'`
on a `+05:30` host). Happy to fix that separately if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Declarative executions can now load settings from readable JSON configuration files.
  * Configuration values preserve settings provided directly by the execution environment.

* **Bug Fixes**
  * Container-mounted paths now use consistent POSIX formatting across host operating systems.
  * Temporary configuration files can be updated when accessed by another container user.
  * Invalid, missing, or unsupported configuration files no longer interrupt execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->