### PR TITLE
fix: propagate config to declarative executor, allow config rewrites,…

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -16,6 +16,7 @@ from airbyte_cdk.entrypoint import AirbyteEntrypoint
 from airbyte_cdk.sources.declarative.concurrent_declarative_source import (
     ConcurrentDeclarativeSource,
 )
+from airbyte_cdk.sources.source import Source
 
 from airbyte._executors.base import Executor
 
@@ -23,6 +24,8 @@ from airbyte._executors.base import Executor
 if TYPE_CHECKING:
     from argparse import Namespace
     from collections.abc import Iterator
+
+    from airbyte_cdk.models import AirbyteStateMessage, ConfiguredAirbyteCatalog
 
     from airbyte._message_iterators import AirbyteMessageIterator
 
@@ -110,9 +113,47 @@ class DeclarativeExecutor(Executor):
             return {}
         return loaded
 
+    def _state_from_args(self, args: list[str]) -> list[AirbyteStateMessage] | None:
+        """Read incremental state from the `--state <path>` CLI arg.
+
+        Returns None when the arg is absent or unreadable, matching
+        `_config_from_args`: argument validation belongs to the CDK entrypoint.
+        """
+        path = self._path_from_args(args, "--state")
+        if path is None:
+            return None
+        try:
+            return Source.read_state(str(path))
+        except (OSError, ValueError):
+            return None
+
+    def _catalog_from_args(self, args: list[str]) -> ConfiguredAirbyteCatalog | None:
+        """Read the configured catalog from the `--catalog <path>` CLI arg."""
+        path = self._path_from_args(args, "--catalog")
+        if path is None:
+            return None
+        try:
+            return Source.read_catalog(str(path))
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _path_from_args(args: list[str], flag: str) -> Path | None:
+        """The readable file named by `flag`, or None."""
+        if flag not in args:
+            return None
+        index = args.index(flag) + 1
+        if index >= len(args):
+            return None
+        path = Path(args[index])
+        return path if path.is_file() else None
+
     def _build_declarative_source(
         self,
         config: dict[str, Any] | None = None,
+        *,
+        state: list[AirbyteStateMessage] | None = None,
+        catalog: ConfiguredAirbyteCatalog | None = None,
     ) -> ConcurrentDeclarativeSource:
         """Build the declarative source, merging `config` over any injected components.
 
@@ -126,6 +167,8 @@ class DeclarativeExecutor(Executor):
         return ConcurrentDeclarativeSource(
             config={**self._config_dict, **(config or {})},
             source_config=self._manifest_dict,
+            catalog=catalog,
+            state=state,
         )
 
     @property
@@ -160,8 +203,18 @@ class DeclarativeExecutor(Executor):
         # The declarative source resolves `{{ config[...] }}` interpolations when it is
         # constructed, so the connector config has to be supplied here rather than left
         # for the entrypoint to read later.
+        # State and catalog are constructor arguments for the same reason config is:
+        # `ConcurrentDeclarativeSource` creates its `ConnectorStateManager` in
+        # `__init__` and its cursors in `streams()`, and its `read()` accepts a
+        # `state` argument that it never uses. A source built without state
+        # therefore re-reads every stream from the beginning, so incremental sync
+        # silently degrades to a full refresh for every manifest-based connector.
         source_entrypoint = AirbyteEntrypoint(
-            self._build_declarative_source(self._config_from_args(args))
+            self._build_declarative_source(
+                self._config_from_args(args),
+                state=self._state_from_args(args),
+                catalog=self._catalog_from_args(args),
+            )
         )
 
         mapped_args: list[str] = self.map_cli_args(args)

--- a/airbyte/_util/temp_files.py
+++ b/airbyte/_util/temp_files.py
@@ -38,7 +38,12 @@ def as_temp_files(files_contents: list[dict | str]) -> Generator[list[str], Any,
             )
             temp_file.flush()
             # Grant "read" permission to all users
-            Path(temp_file.name).chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            # Owner write is required: connectors that declare `config_migrations`
+            # rewrite this file in place via
+            # `ConcurrentDeclarativeSource._migrate_and_transform_config()`, which
+            # raises PermissionError against a read-only file. Group and other
+            # write are deliberately withheld (CWE-732) - the file holds secrets.
+            Path(temp_file.name).chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH | stat.S_IWUSR)
 
             # Don't close the file yet (breaks Windows)
             # temp_file.close()

--- a/tests/unit_tests/test_declarative_state_and_temp_files.py
+++ b/tests/unit_tests/test_declarative_state_and_temp_files.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Incremental state reaching the declarative source, and writable temp configs.
+
+Two defects, both invisible from the outside:
+
+* `ConcurrentDeclarativeSource` builds its `ConnectorStateManager` in `__init__`
+  and its cursors in `streams()`, while the `state` argument to `read()` is
+  accepted and never used. A source constructed without state re-reads every
+  stream from its start date, so incremental sync silently becomes a full
+  refresh -- and with an append write strategy, the destination accumulates a
+  duplicate copy on every run.
+
+* `as_temp_files()` wrote config files read-only, so connectors declaring
+  `config_migrations` raised PermissionError when rewriting them in place.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+import pytest
+
+from airbyte._executors.declarative import DeclarativeExecutor
+from airbyte._executors.docker import DockerExecutor
+from airbyte._util.temp_files import as_temp_files
+
+
+MANIFEST = {
+    "version": "4.6.2",
+    "type": "DeclarativeSource",
+    "check": {"type": "CheckStream", "stream_names": ["items"]},
+    "streams": [
+        {
+            "type": "DeclarativeStream",
+            "name": "items",
+            "primary_key": ["id"],
+            "retriever": {
+                "type": "SimpleRetriever",
+                "requester": {
+                    "type": "HttpRequester",
+                    "url_base": "https://example.com",
+                    "path": "/items",
+                    # The interpolation the config fix exists to make work.
+                    "authenticator": {
+                        "type": "BearerAuthenticator",
+                        "api_token": "{{ config['api_key'] }}",
+                    },
+                },
+                "record_selector": {
+                    "type": "RecordSelector",
+                    "extractor": {"type": "DpathExtractor", "field_path": ["data"]},
+                },
+            },
+            "schema_loader": {
+                "type": "InlineSchemaLoader",
+                "schema": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                },
+            },
+        }
+    ],
+    "spec": {
+        "type": "Spec",
+        "connection_specification": {
+            "type": "object",
+            "required": ["api_key"],
+            "properties": {"api_key": {"type": "string"}},
+        },
+    },
+}
+
+
+def _config_file(tmp_path: Path, api_key: str = "secret-value") -> Path:
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"api_key": api_key}), encoding="utf-8")
+    return path
+
+
+def _state_file(tmp_path: Path, cursor: str) -> Path:
+    path = tmp_path / "state.json"
+    path.write_text(
+        json.dumps([
+            {
+                "type": "STREAM",
+                "stream": {
+                    "stream_descriptor": {"name": "items"},
+                    "stream_state": {"updated_at": cursor},
+                },
+            }
+        ]),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _catalog_file(tmp_path: Path) -> Path:
+    path = tmp_path / "catalog.json"
+    path.write_text(
+        json.dumps({
+            "streams": [
+                {
+                    "stream": {
+                        "name": "items",
+                        "json_schema": {},
+                        "supported_sync_modes": ["full_refresh"],
+                    },
+                    "sync_mode": "full_refresh",
+                    "destination_sync_mode": "overwrite",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestDeclarativeState:
+    """State supplied as `--state` has to reach the source's constructor."""
+
+    def test_state_reaches_the_state_manager(self, tmp_path: Path) -> None:
+        """The cursor must be readable from the constructed source.
+
+        This is the whole defect: without it the state manager is empty and the
+        connector restarts from its configured start date.
+        """
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        args = [
+            "read",
+            "--config",
+            str(_config_file(tmp_path)),
+            "--state",
+            str(_state_file(tmp_path, "2026-05-05T00:00:00Z")),
+        ]
+
+        source = executor._build_declarative_source(
+            executor._config_from_args(args),
+            state=executor._state_from_args(args),
+            catalog=executor._catalog_from_args(args),
+        )
+
+        stored = source._connector_state_manager.get_stream_state("items", None)
+        assert stored == {"updated_at": "2026-05-05T00:00:00Z"}
+
+    def test_no_state_arg_leaves_the_manager_empty(self, tmp_path: Path) -> None:
+        """A first sync passes no `--state`; that must not error."""
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        args = ["read", "--config", str(_config_file(tmp_path))]
+
+        source = executor._build_declarative_source(
+            executor._config_from_args(args),
+            state=executor._state_from_args(args),
+        )
+
+        assert source._connector_state_manager.get_stream_state("items", None) == {}
+
+    def test_state_is_not_reused_between_executions(self, tmp_path: Path) -> None:
+        """A later command without `--state` must not inherit an earlier cursor.
+
+        One executor serves every command, and `spec`, `check` and `discover`
+        pass no `--state`. Reading the flag per call rather than storing it on
+        the executor makes reuse structurally impossible; this pins that.
+        """
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        with_state = [
+            "read",
+            "--state",
+            str(_state_file(tmp_path, "2026-05-05T00:00:00Z")),
+        ]
+        assert executor._state_from_args(with_state) is not None
+
+        assert executor._state_from_args(["discover", "--config", "x.json"]) is None
+        assert executor._catalog_from_args(["check", "--config", "x.json"]) is None
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["read", "--state"],  # flag with no value
+            ["read", "--state", "does-not-exist.json"],  # missing file
+        ],
+    )
+    def test_malformed_state_arg_is_not_fatal(self, args: list[str]) -> None:
+        """Argument validation belongs to the CDK entrypoint, not here."""
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        assert executor._state_from_args(args) is None
+
+    def test_catalog_reaches_the_source(self, tmp_path: Path) -> None:
+        """The catalog is a constructor argument too, for the same reason."""
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        args = ["read", "--catalog", str(_catalog_file(tmp_path))]
+
+        catalog = executor._catalog_from_args(args)
+        assert catalog is not None
+        assert [s.stream.name for s in catalog.streams] == ["items"]
+
+
+class TestConfigActuallyResolves:
+    """Asserting on a private dict proves nothing; resolve the interpolation."""
+
+    def test_interpolated_token_resolves_from_config(self, tmp_path: Path) -> None:
+        """`{{ config['api_key'] }}` must produce the real value.
+
+        The original symptom was `'dict object' has no attribute 'api_key'`, so
+        the meaningful assertion is on the token the authenticator resolves --
+        not on whether a dict happens to hold the key.
+        """
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        args = ["check", "--config", str(_config_file(tmp_path, "secret-value"))]
+
+        source = executor._build_declarative_source(executor._config_from_args(args))
+        stream = source.streams(executor._config_from_args(args))[0]
+
+        authenticator = stream._stream_partition_generator._partition_factory._retriever.requester.authenticator
+        assert authenticator.token_provider.get_token() == "secret-value"
+
+    def test_missing_config_does_not_resolve_to_a_stale_value(
+        self, tmp_path: Path
+    ) -> None:
+        """Config is read per call, so a second command cannot inherit the first."""
+        executor = DeclarativeExecutor(name="source-test", manifest=MANIFEST)
+        first = ["check", "--config", str(_config_file(tmp_path, "secret-value"))]
+        assert executor._config_from_args(first) == {"api_key": "secret-value"}
+        assert executor._config_from_args(["spec"]) == {}
+
+
+class TestTempFilePermissions:
+    """`config_migrations` rewrites the config file in place."""
+
+    def test_temp_config_can_be_rewritten(self) -> None:
+        """The real failure: PermissionError on a read-only config."""
+        with as_temp_files([{"api_key": "before"}]) as (path,):
+            Path(path).write_text(json.dumps({"api_key": "after"}), encoding="utf-8")
+            assert json.loads(Path(path).read_text(encoding="utf-8")) == {
+                "api_key": "after"
+            }
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_group_and_other_cannot_write(self) -> None:
+        """Owner write only -- the file holds secrets (CWE-732)."""
+        with as_temp_files([{"api_key": "value"}]) as (path,):
+            mode = Path(path).stat().st_mode
+            assert mode & stat.S_IWUSR, "owner must be able to write"
+            assert not mode & stat.S_IWGRP, "group must not be able to write"
+            assert not mode & stat.S_IWOTH, "other must not be able to write"
+
+
+class _WindowsPath(PureWindowsPath):
+    """Windows path semantics on any host, so the test runs in Linux CI.
+
+    `map_cli_args` calls `.exists()` and `.is_relative_to()`. Only the former
+    needs stubbing; the rest is pure path arithmetic, which is exactly what the
+    fix changed.
+    """
+
+    def exists(self) -> bool:
+        return True
+
+
+class TestDockerPathsOnWindowsHosts:
+    """Container paths must be POSIX regardless of the host's path flavour."""
+
+    def test_windows_host_produces_posix_container_path(self, monkeypatch) -> None:
+        """Without the fix this yields `\\airbyte\\tmp\\config.json`.
+
+        Asserting `"\\\\" not in result` on a Linux runner is vacuous: `Path` is
+        already `PosixPath` there, so the assertion holds against the unfixed
+        code too. Forcing Windows semantics is what gives the test teeth in CI.
+        """
+        import airbyte._executors.docker as docker_module
+
+        monkeypatch.setattr(docker_module, "Path", _WindowsPath)
+
+        volume = _WindowsPath(r"C:\Users\dev\AppData\Local\Temp")
+        executor = DockerExecutor(
+            name="source-test",
+            image_name_full="airbyte/source-test:latest",
+            executable=["docker", "run", "airbyte/source-test:latest"],
+            volumes={volume: "/airbyte/tmp"},
+        )
+
+        mapped = executor.map_cli_args([
+            "read",
+            r"C:\Users\dev\AppData\Local\Temp\config.json",
+        ])
+
+        assert "\\" not in mapped[1], f"backslash leaked into {mapped[1]!r}"
+        assert mapped[1] == str(PurePosixPath("/airbyte/tmp/config.json"))
+
+    def test_non_path_args_pass_through(self, tmp_path: Path) -> None:
+        """Arguments that are not existing files must be untouched."""
+        executor = DockerExecutor(
+            name="source-test",
+            image_name_full="airbyte/source-test:latest",
+            executable=["docker", "run", "airbyte/source-test:latest"],
+            volumes={tmp_path: "/airbyte/tmp"},
+        )
+        assert executor.map_cli_args(["read", "--catalog"]) == ["read", "--catalog"]

--- a/tests/unit_tests/test_declarative_state_and_temp_files.py
+++ b/tests/unit_tests/test_declarative_state_and_temp_files.py
@@ -269,9 +269,7 @@ class TestDockerPathsOnWindowsHosts:
         already `PosixPath` there, so the assertion holds against the unfixed
         code too. Forcing Windows semantics is what gives the test teeth in CI.
         """
-        import airbyte._executors.docker as docker_module
-
-        monkeypatch.setattr(docker_module, "Path", _WindowsPath)
+        monkeypatch.setattr("airbyte._executors.docker.Path", _WindowsPath)
 
         volume = _WindowsPath(r"C:\Users\dev\AppData\Local\Temp")
         executor = DockerExecutor(


### PR DESCRIPTION
## What

Two executor-layer defects, both silent in normal use, each with a regression
test verified to fail without the fix.

**Rebased onto `main`.** This branch originally carried four fixes; the config
propagation and POSIX container path ones landed independently in #1143, #1144
and #1152 while it was open, so those commits are gone and only these two
remain. The diff is now 2 source files and 1 test file.

## 1. Incremental state never reaches the declarative source

`ConcurrentDeclarativeSource` creates its `ConnectorStateManager` in
`__init__` and its cursors in `streams()`. Its `read()` accepts a `state`
argument and **never uses it**. `DeclarativeExecutor` constructed the source
without state, so the `--state` file was parsed by the entrypoint, handed to
`read()`, and discarded.

**Symptom** — every incremental manifest-based sync silently restarts from its
configured start date. Nothing errors; the sync simply re-reads everything,
every time. With an `append` write strategy the destination accumulates a
duplicate copy of the stream on each run.

**Fix** — read `--state` and `--catalog` per execution and pass them to the
constructor, alongside the config that #1144 already threaded through.

Reading them per call rather than storing them on the executor is deliberate:
one executor serves every command, and `spec`, `check` and `discover` pass
neither flag. Deriving them from `args` each time makes it structurally
impossible for a later command to inherit an earlier read's state — the class
of bug flagged during review of the earlier revision of this branch.

## 2. Temp config files are read-only, breaking `config_migrations`

`as_temp_files()` writes config with `S_IRUSR | S_IRGRP | S_IROTH`. Connectors
that declare `config_migrations` rewrite that file in place via
`ConcurrentDeclarativeSource._migrate_and_transform_config()`, which raises:

```
PermissionError: [Errno 13] Permission denied: '/airbyte/tmp/tmpXXXX.json'
```

Reproducible with `source-slack`, whose manifest migrates the legacy
`{"api_key": ...}` shape to `{"credentials": {...}}`.

**Fix** — add `S_IWUSR`. Group and other write are deliberately withheld
(CWE-732); the file holds credentials.

## Tests

`tests/unit_tests/test_declarative_state_and_temp_files.py` — 12 tests, one
skipped off POSIX.

Both fixes were verified by reverting them and confirming the tests fail:

```
state:    AssertionError: assert {} == {'updated_at': '2026-05-05T00:00:00Z'}
windows:  AssertionError: backslash leaked into '\airbyte\tmp\config.json'
```

Two of these address review feedback on the previous revision:

**Config resolution is asserted through the manifest, not a private dict.**
The earlier test checked `executor._config_dict["api_key"]`, which proves
nothing about interpolation. This one builds the source from a manifest whose
`BearerAuthenticator` uses `{{ config['api_key'] }}` and asserts the resolved
token — the original symptom was `'dict object' has no attribute 'api_key'`,
so the token is the meaningful assertion.

**The Windows path test now has teeth in CI.** `python_pytest.yml` runs
`ubuntu-latest` only, where `Path` is already `PosixPath` — so
`assert "\\" not in result` held against the unfixed code and the test was
vacuous on the only platform that runs it. It now forces Windows path
semantics through a `PureWindowsPath` subclass, and fails on Linux without the
fix.

## Verification

```
11 passed, 1 skipped   test_declarative_state_and_temp_files.py
755 passed, 2 skipped  tests/unit_tests
ruff check             All checks passed
ruff format            clean
```

The state fix is also running in production: a ten-connector ingestion
pipeline across four hand-written manifest sources. Before it, a connector with
a server-side cursor re-read its full history on every sync — 12,316 records in
12 minutes. After it, the same sync reads 0 records in 2 seconds.

One pre-existing failure in `tests/unit_tests/test_progress.py::test_get_time_str`
is unrelated and present on clean `main`: `_to_time_str()` renders local time
while the test uses `freeze_time`, so it fails on any non-UTC machine
(`assert '05:30:00' == '00:00:00'` on a `+05:30` host). Happy to fix separately.
