### PR TITLE
fix(mcp): accept `organization_id` on Agents connector tools

### DIFF
--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -76,10 +76,12 @@ WORKSPACE_ID_TIP_TEXT = (
     f"environment variable."
 )
 ORGANIZATION_ID_TIP_TEXT = (
-    f"Organization ID to scope the listing to. Omit it when the credentials belong to "
-    f"exactly one organization, or when it is already configured via the "
+    f"Organization ID. Omit it when the credentials belong to exactly one "
+    f"organization, or when it is already configured via the "
     f"`{MCP_ORGANIZATION_ID_HEADER}` header or the `{CLOUD_ORGANIZATION_ID_ENV_VAR}` "
-    f"environment variable."
+    f"environment variable. To discover organization IDs, call `list_agent_workspaces`, "
+    f"which reports the owning organization of each workspace, or "
+    f"`list_cloud_organizations` to search organizations by name."
 )
 
 AGENTS_ACCESS_DENIED_STATUS = "access_denied"
@@ -242,11 +244,15 @@ def _get_agent_organization(ctx: Context, organization_id: str | None) -> AgentO
     )
 
 
-def _get_agent_workspace(ctx: Context, workspace_id: str | None) -> AgentWorkspace:
+def _get_agent_workspace(
+    ctx: Context,
+    workspace_id: str | None,
+    organization_id: str | None = None,
+) -> AgentWorkspace:
     """Build an `AgentWorkspace` from MCP config."""
     return AgentWorkspace(
         workspace_id=workspace_id or get_mcp_config(ctx, MCP_CONFIG_WORKSPACE_ID),
-        organization_id=get_mcp_config(ctx, MCP_CONFIG_ORGANIZATION_ID),
+        organization_id=organization_id or get_mcp_config(ctx, MCP_CONFIG_ORGANIZATION_ID),
         client_id=get_mcp_config(ctx, MCP_CONFIG_CLIENT_ID),
         client_secret=get_mcp_config(ctx, MCP_CONFIG_CLIENT_SECRET),
         bearer_token=get_mcp_config(ctx, MCP_CONFIG_BEARER_TOKEN),
@@ -257,6 +263,7 @@ def _get_agent_connector(
     ctx: Context,
     connector_id: str,
     workspace_id: str | None = None,
+    organization_id: str | None = None,
 ) -> AgentConnector:
     """Get an `AgentConnector` from its workspace, using MCP config.
 
@@ -264,7 +271,7 @@ def _get_agent_connector(
     its workspace anyway, so a connector ID belonging to another workspace raises before
     any action runs.
     """
-    return _get_agent_workspace(ctx, workspace_id).get_connector(connector_id)
+    return _get_agent_workspace(ctx, workspace_id, organization_id).get_connector(connector_id)
 
 
 def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
@@ -272,6 +279,7 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
     *,
     connector_id: str,
     workspace_id: str | None,
+    organization_id: str | None,
     entity_type: str,
     action: str,
     api_args: dict[str, Any] | str | None,
@@ -294,7 +302,7 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
         )
 
     try:
-        result = _get_agent_connector(ctx, connector_id, workspace_id).execute(
+        result = _get_agent_connector(ctx, connector_id, workspace_id, organization_id).execute(
             entity_type,
             action,
             _resolve_api_args(api_args),
@@ -378,9 +386,16 @@ def list_agent_connectors(
             default=None,
         ),
     ],
+    organization_id: Annotated[
+        str | None,
+        Field(
+            description=ORGANIZATION_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
 ) -> AgentConnectorListResult:
     """List the connectors configured in an Airbyte Agents workspace."""
-    workspace = _get_agent_workspace(ctx, workspace_id)
+    workspace = _get_agent_workspace(ctx, workspace_id, organization_id)
     try:
         connectors = workspace.list_connectors()
     except AirbyteError as error:
@@ -420,6 +435,13 @@ def inspect_agent_connector(
             default=None,
         ),
     ],
+    organization_id: Annotated[
+        str | None,
+        Field(
+            description=ORGANIZATION_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
 ) -> AgentConnectorDetailsResult:
     """Inspect an Airbyte Agents connector: metadata, readiness, warnings, and `docs_skill_id`.
 
@@ -427,7 +449,7 @@ def inspect_agent_connector(
     connector must belong to the given workspace.
     """
     try:
-        details = _get_agent_connector(ctx, connector_id, workspace_id).inspect()
+        details = _get_agent_connector(ctx, connector_id, workspace_id, organization_id).inspect()
     except AirbyteError as error:
         message = _agents_access_message(error)
         if message is None:
@@ -525,6 +547,13 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
             default=None,
         ),
     ],
+    organization_id: Annotated[
+        str | None,
+        Field(
+            description=ORGANIZATION_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
 ) -> AgentExecuteToolResult:
     """Read data from an Airbyte Agents connector, without modifying anything.
 
@@ -537,6 +566,7 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
         ctx,
         connector_id=connector_id,
         workspace_id=workspace_id,
+        organization_id=organization_id,
         entity_type=entity_type,
         action=action,
         api_args=api_args,
@@ -632,6 +662,13 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
             default=None,
         ),
     ],
+    organization_id: Annotated[
+        str | None,
+        Field(
+            description=ORGANIZATION_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
 ) -> AgentExecuteToolResult:
     """Execute a single action against an Airbyte Agents connector, including writes.
 
@@ -643,6 +680,7 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
         ctx,
         connector_id=connector_id,
         workspace_id=workspace_id,
+        organization_id=organization_id,
         entity_type=entity_type,
         action=action,
         api_args=api_args,

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -101,7 +101,7 @@ def connector(monkeypatch: pytest.MonkeyPatch) -> _AgentConnectorLike:
     monkeypatch.setattr(
         agents_mcp,
         "_get_agent_connector",
-        lambda ctx, connector_id, workspace_id=None: stub,
+        lambda ctx, connector_id, workspace_id=None, organization_id=None: stub,
     )
     return stub
 
@@ -120,6 +120,7 @@ def _execute_ro(**kwargs: Any) -> agents_mcp.AgentExecuteToolResult:  # noqa: AN
         cursor=kwargs.pop("cursor", None),
         intent=kwargs.pop("intent", None),
         workspace_id=kwargs.pop("workspace_id", "workspace-id"),
+        organization_id=kwargs.pop("organization_id", None),
     )
 
 
@@ -138,6 +139,7 @@ def _execute(**kwargs: Any) -> agents_mcp.AgentExecuteToolResult:  # noqa: ANN40
         intent=kwargs.pop("intent", None),
         read_only=kwargs.pop("read_only", None),
         workspace_id=kwargs.pop("workspace_id", "workspace-id"),
+        organization_id=kwargs.pop("organization_id", None),
     )
 
 
@@ -258,13 +260,17 @@ def test_inspect_tool_reports_context_store_entities(
     monkeypatch.setattr(
         agents_mcp,
         "_get_agent_connector",
-        lambda ctx, connector_id, workspace_id=None: _InspectableConnector(),
+        lambda ctx,
+        connector_id,
+        workspace_id=None,
+        organization_id=None: _InspectableConnector(),
     )
 
     result = agents_mcp.inspect_agent_connector(
         ctx=cast(Context, object()),
         connector_id="connector-id",
         workspace_id="workspace-id",
+        organization_id=None,
     )
 
     assert result.context_store_entities == ["issues"]
@@ -381,6 +387,7 @@ _ACCESS_FAILURE_CASES = [
         lambda: agents_mcp.list_agent_connectors(
             ctx=cast(Context, object()),
             workspace_id="workspace-1",
+            organization_id=None,
         ),
         {"connectors": []},
         id="list_connectors",
@@ -399,6 +406,7 @@ _ACCESS_FAILURE_CASES = [
             ctx=cast(Context, object()),
             connector_id="connector-id",
             workspace_id="workspace-1",
+            organization_id=None,
         ),
         {"context_store_entities": [], "connector_id": "connector-id"},
         id="inspect",
@@ -484,6 +492,41 @@ def test_organization_id_resolution(
     )
 
     assert organization.organization_id == expected_organization_id
+
+
+@pytest.mark.parametrize(
+    ("explicit_organization_id", "expected_organization_id"),
+    [
+        pytest.param(None, "org-from-config", id="falls_back_to_config"),
+        pytest.param("org-from-argument", "org-from-argument", id="explicit_wins"),
+    ],
+)
+def test_list_agent_connectors_threads_organization_id(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit_organization_id: str | None,
+    expected_organization_id: str,
+) -> None:
+    """Verify `list_agent_connectors` passes `organization_id` to the workspace."""
+    _patch_mcp_config(monkeypatch)
+    constructed: list[dict[str, Any]] = []
+
+    class _RecordingWorkspace:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed.append(kwargs)
+
+        def list_connectors(self) -> list[Any]:
+            return []
+
+    monkeypatch.setattr(agents_mcp, "AgentWorkspace", _RecordingWorkspace)
+
+    result = agents_mcp.list_agent_connectors(
+        ctx=cast(Context, object()),
+        workspace_id="workspace-1",
+        organization_id=explicit_organization_id,
+    )
+
+    assert constructed[0]["organization_id"] == expected_organization_id
+    assert result.connectors == []
 
 
 def test_workspace_organization_id_comes_from_mcp_config(


### PR DESCRIPTION
## Summary

<table><tr><td>

**:point_right: TL;DR:** Users whose credentials span multiple organizations could not use the Agents connector tools at all: the API demanded an organization, but the tools had no way to pass one. Every Agents connector tool now takes an optional `organization_id`.

`list_agent_connectors`, `inspect_agent_connector`, `execute_agent_connector_ro`, `execute_agent_connector` gain `organization_id: str | None = None`, threaded through `_get_agent_workspace` / `_get_agent_connector` / `_execute` (explicit arg → `X-Airbyte-Organization-Id` header / `AIRBYTE_CLOUD_ORGANIZATION_ID` env fallback).

</td></tr></table>

Requested by AJ; reported by Alexandre in #team-agents:

```
mcp__airbyte_internal__inspect_agent_connector → HTTP 400
These credentials belong to more than one organization, so the Agents API
cannot infer which one to use. Pass organization_id, or set the
AIRBYTE_CLOUD_ORGANIZATION_ID environment variable.
```
…and adding `organization_id` was rejected by the tool schema. This keeps the server stateless (per AJ: discover the org ID via `list_agent_workspaces` / `list_cloud_organizations`, then pass it as an arg) rather than adding a "switch org" tool.

## Changes

- `_get_agent_workspace(ctx, workspace_id, organization_id=None)`; `_get_agent_connector` and `_execute` thread `organization_id` through.
- `organization_id` keyword-only `Annotated` param added to the four connector tools, after `workspace_id`.
- `ORGANIZATION_ID_TIP_TEXT` generalized (no longer listing-specific) and names the discovery tools.
- Tests: `test_list_agent_connectors_threads_organization_id` (explicit arg wins; omission falls back to config); existing stubs updated for the new kwarg.

## Testing

- `uv run ruff check` / `ruff format --check` → clean
- `uv run pyrefly check airbyte/mcp/agents.py` → 0 errors
- `uv run pytest tests -k agent -q` → 105 passed
- Not exercised against a live multi-org credential.

Link to Devin session: https://app.devin.ai/sessions/7c58bca3f69f439eaa2444b811fdc7b4
Open in Devin Desktop: https://app.devin.ai/desktop/session/7c58bca3f69f439eaa2444b811fdc7b4?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional organization selection to Airbyte Agents tools for listing, inspecting, and executing connectors.
  * Organization context can be discovered through available organization and workspace listing tools.
  * Organization settings may be inferred from configured credentials when applicable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->