### PR TITLE
fix(ci): use correct `pr-source-repo-is-fork` output in PR welcome workflow

### DIFF
--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -38,7 +38,7 @@ jobs:
         uses: chuhlomin/render-template@807354a04d9300c9c2ac177c0aa41556c92b3f75 # v1.10
         with:
           # Use a different template for internal vs forks (community)
-          template: ${{ steps.vars.outputs.pr-source-is-fork == 'true' && '.github/pr-welcome-community.md' || '.github/pr-welcome-internal.md' }}
+          template: ${{ steps.vars.outputs.pr-source-repo-is-fork == 'true' && '.github/pr-welcome-community.md' || '.github/pr-welcome-internal.md' }}
           vars: |
             repo_name: ${{ steps.vars.outputs.pr-source-repo-name-full }}
             branch_name: ${{ steps.vars.outputs.pr-source-git-branch }}


### PR DESCRIPTION
## Summary

Community PR [#1146](https://github.com/airbytehq/PyAirbyte/pull/1146) (from fork `Sh1vam09/PyAirbyte`) received the "Greetings, Airbyte Team Member!" internal welcome message instead of the community one.

Root cause: `welcome-message.yml` reads `steps.vars.outputs.pr-source-is-fork`, but `resolve-ci-vars-action` emits the output as `pr-source-repo-is-fork` (confirmed in the [run log](https://github.com/airbytehq/PyAirbyte/actions/runs/34138563197): `Resolved CI variable: pr-source-repo-is-fork = true`). The misspelled output resolves to empty, so the `== 'true'` check always fails and every PR falls through to `.github/pr-welcome-internal.md`.

```diff
- template: ${{ steps.vars.outputs.pr-source-is-fork == 'true' && '.github/pr-welcome-community.md' || '.github/pr-welcome-internal.md' }}
+ template: ${{ steps.vars.outputs.pr-source-repo-is-fork == 'true' && '.github/pr-welcome-community.md' || '.github/pr-welcome-internal.md' }}
```

Note: because this workflow uses `pull_request_target`, the fix only takes effect for PRs opened/reopened after this merges; it can't be exercised from this PR itself.


Link to Devin session: https://app.devin.ai/sessions/1dad5d736e40476695ab80451329124b
Open in Devin Desktop: https://app.devin.ai/desktop/session/1dad5d736e40476695ab80451329124b?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected pull request welcome-message template selection so the appropriate community or internal message is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->