### PR TITLE
feat(mcp): add Agents skills tools (list, search, read docs)

### DIFF
--- a/airbyte/agents/__init__.py
+++ b/airbyte/agents/__init__.py
@@ -94,6 +94,10 @@ from airbyte.agents.models import (
     AgentContextStoreReadiness,
     AgentExecuteResult,
     AgentExecutionMetadata,
+    AgentSkillDocs,
+    AgentSkillInfo,
+    AgentSkillList,
+    AgentSkillSection,
     AgentWorkspaceInfo,
 )
 from airbyte.agents.organizations import AgentOrganization
@@ -127,6 +131,10 @@ __all__ = [
     "AgentExecuteResult",
     "AgentExecutionMetadata",
     "AgentOrganization",
+    "AgentSkillDocs",
+    "AgentSkillInfo",
+    "AgentSkillList",
+    "AgentSkillSection",
     "AgentWorkspace",
     "AgentWorkspaceInfo",
 ]

--- a/airbyte/agents/__init__.py
+++ b/airbyte/agents/__init__.py
@@ -101,6 +101,7 @@ from airbyte.agents.models import (
     AgentWorkspaceInfo,
 )
 from airbyte.agents.organizations import AgentOrganization
+from airbyte.agents.skills import AgentSkill
 from airbyte.agents.workspaces import AgentWorkspace
 
 
@@ -111,6 +112,7 @@ if TYPE_CHECKING:
         connectors,
         models,
         organizations,
+        skills,
         workspaces,
     )
 
@@ -120,6 +122,7 @@ __all__ = [
     "connectors",
     "models",
     "organizations",
+    "skills",
     "workspaces",
     # Classes
     "AgentConnector",
@@ -131,6 +134,7 @@ __all__ = [
     "AgentExecuteResult",
     "AgentExecutionMetadata",
     "AgentOrganization",
+    "AgentSkill",
     "AgentSkillDocs",
     "AgentSkillInfo",
     "AgentSkillList",

--- a/airbyte/agents/_api_util.py
+++ b/airbyte/agents/_api_util.py
@@ -274,6 +274,96 @@ def execute_agent_connector_action(
     )
 
 
+def list_agent_skills(
+    *,
+    credentials: _AirbyteCredentials,
+    organization_id: str | None = None,
+    workspace_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List the skills available to an organization or workspace.
+
+    The raw response is returned so the caller keeps `next_cursor`, which
+    `_records_from_response` would drop.
+    """
+    params = {
+        key: value
+        for key, value in {
+            "limit": limit,
+            "cursor": cursor,
+            "organization_id": organization_id,
+            "workspace_id": workspace_id,
+        }.items()
+        if value is not None
+    }
+    return make_agents_api_request(
+        method="GET",
+        path="/skills",
+        params=params or None,
+        credentials=credentials,
+        organization_id=organization_id,
+    )
+
+
+def search_agent_skills(
+    *,
+    query: str,
+    credentials: _AirbyteCredentials,
+    organization_id: str | None = None,
+    workspace_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Search skills by keyword, returning the raw paginated response."""
+    params = {
+        key: value
+        for key, value in {
+            "query": query,
+            "limit": limit,
+            "cursor": cursor,
+            "organization_id": organization_id,
+            "workspace_id": workspace_id,
+        }.items()
+        if value is not None
+    }
+    return make_agents_api_request(
+        method="GET",
+        path="/skills/search",
+        params=params,
+        credentials=credentials,
+        organization_id=organization_id,
+    )
+
+
+def read_agent_skill_docs(
+    *,
+    skill_id: str,
+    credentials: _AirbyteCredentials,
+    organization_id: str | None = None,
+    workspace_id: str | None = None,
+    section: str | None = None,
+) -> dict[str, Any]:
+    """Read a skill's docs, optionally scoped to a single section."""
+    params = {
+        key: value
+        for key, value in {
+            "id": skill_id,
+            "section": section,
+            "organization_id": organization_id,
+            "workspace_id": workspace_id,
+        }.items()
+        if value is not None
+    }
+    return make_agents_api_request(
+        method="GET",
+        path="/skills/docs",
+        params=params,
+        credentials=credentials,
+        organization_id=organization_id,
+    )
+
+
 def _records_from_response(*, response: dict[str, Any], path: str) -> list[dict[str, Any]]:
     """Return the `data` array from a list response, validating its shape."""
     records: Any = response.get("data")

--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -170,8 +170,8 @@ class AgentConnectorDetails(BaseModel):
     """The name of the underlying Airbyte source definition, for example `GitHub`."""
 
     docs_skill_id: str | None = None
-    """Skill ID to pass to `AgentWorkspace.read_skill_docs` (MCP: `read_agent_skill_docs`)
-    for this connector's usage docs."""
+    """Skill ID to pass to `AgentWorkspace.get_skill(...).read_docs()` (MCP:
+    `read_agent_skill_docs`) for this connector's usage docs."""
 
     context_store_readiness: AgentContextStoreReadiness | None = None
     """Context Store readiness information, when reported."""

--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -103,7 +103,7 @@ class AgentSkillList(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    data: list[AgentSkillInfo] = Field(default_factory=list)
+    data: list[AgentSkillInfo]
     """The skills on this page."""
 
     next_cursor: str | None = None

--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -74,6 +74,78 @@ class AgentContextStoreReadiness(BaseModel):
     """The entities currently configured for caching, with their sync status."""
 
 
+class AgentSkillInfo(BaseModel):
+    """Summary information about a skill, as returned by the Agents API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    """The skill ID. Pass it to `read_skill_docs` to read this skill's docs."""
+
+    kind: str | None = None
+    """The skill category, for example `static` or `connector_source`."""
+
+    title: str | None = None
+    """The human-readable skill title."""
+
+    summary: str | None = None
+    """A short summary of what the skill documents."""
+
+    tags: list[str] = Field(default_factory=list)
+    """Search and categorization tags for the skill."""
+
+    warnings: list[Any] = Field(default_factory=list)
+    """Non-fatal issues reported while building or reading the skill's docs."""
+
+
+class AgentSkillList(BaseModel):
+    """A page of skills, as returned by the Agents API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    data: list[AgentSkillInfo] = Field(default_factory=list)
+    """The skills on this page."""
+
+    next_cursor: str | None = None
+    """The cursor to pass as `cursor` to fetch the next page, when one is available."""
+
+
+class AgentSkillSection(BaseModel):
+    """A section of a skill's docs, as listed in the docs outline."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    """The section ID. Pass it as `section` to read this section."""
+
+    title: str | None = None
+    """The human-readable section title."""
+
+    summary: str | None = None
+    """A short summary of the section content."""
+
+    available: bool = True
+    """Whether this section can currently be read."""
+
+
+class AgentSkillDocs(BaseModel):
+    """Documentation for a single skill, as returned by the Agents API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    metadata: AgentSkillInfo
+    """Metadata for the requested skill."""
+
+    outline: list[AgentSkillSection] = Field(default_factory=list)
+    """The sections available for this skill."""
+
+    section_id: str | None = None
+    """The requested section ID, or `None` for the default docs response."""
+
+    content: list[dict[str, Any]] = Field(default_factory=list)
+    """Rendered docs content blocks, such as headings, paragraphs, and code blocks."""
+
+
 class AgentConnectorDetails(BaseModel):
     """Connector metadata returned by the Agents API `inspect` endpoint."""
 
@@ -98,7 +170,8 @@ class AgentConnectorDetails(BaseModel):
     """The name of the underlying Airbyte source definition, for example `GitHub`."""
 
     docs_skill_id: str | None = None
-    """Skill ID to pass to `read_skill_docs` for this connector's usage docs."""
+    """Skill ID to pass to `AgentWorkspace.read_skill_docs` (MCP: `read_agent_skill_docs`)
+    for this connector's usage docs."""
 
     context_store_readiness: AgentContextStoreReadiness | None = None
     """Context Store readiness information, when reported."""

--- a/airbyte/agents/skills.py
+++ b/airbyte/agents/skills.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Airbyte Agents skills: reusable documentation served by the Agents API.
+
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte Agents Python interfaces are experimental.** Class names, method signatures,
+> and result models may change or be removed without notice between minor versions of
+> PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airbyte.agents import _api_util
+from airbyte.agents.models import AgentSkillDocs, AgentSkillInfo, AgentSkillList
+
+
+if TYPE_CHECKING:
+    from airbyte.cloud._credentials import _AirbyteCredentials
+
+
+class AgentSkill:
+    """A skill on the Airbyte Agents platform.
+
+    Get one from `AgentWorkspace.get_skill()` or `AgentWorkspace.list_skills()` rather than
+    constructing it directly.
+    """
+
+    def __init__(
+        self,
+        skill_id: str,
+        *,
+        credentials: _AirbyteCredentials,
+        workspace_id: str | None = None,
+        info: AgentSkillInfo | None = None,
+    ) -> None:
+        """Initialize an `AgentSkill`. Prefer `AgentWorkspace.get_skill()`."""
+        self.skill_id = skill_id
+        """The skill ID."""
+
+        self._credentials = credentials
+        self._workspace_id = workspace_id
+        self._info = info
+
+    @property
+    def info(self) -> AgentSkillInfo:
+        """The skill's metadata, fetched from the Agents API if not already known."""
+        if self._info is None:
+            self._info = self.read_docs().metadata
+        return self._info
+
+    @property
+    def title(self) -> str | None:
+        """The human-readable skill title."""
+        return self.info.title
+
+    @property
+    def kind(self) -> str | None:
+        """The skill category, for example `static` or `connector_source`."""
+        return self.info.kind
+
+    def read_docs(self, *, section: str | None = None) -> AgentSkillDocs:
+        """Read this skill's docs, optionally scoped to a single section.
+
+        Omit `section` for metadata, guidance, and the outline of available sections, or
+        pass an exact section `id` from the outline to read that section.
+        """
+        docs = AgentSkillDocs.model_validate(
+            _api_util.read_agent_skill_docs(
+                skill_id=self.skill_id,
+                credentials=self._credentials,
+                organization_id=self._credentials.organization_id,
+                workspace_id=self._workspace_id,
+                section=section,
+            )
+        )
+        self._info = docs.metadata
+        return docs
+
+
+def list_skills(
+    *,
+    credentials: _AirbyteCredentials,
+    workspace_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> AgentSkillList:
+    """List the skills available to a workspace or organization.
+
+    Pass `limit` to cap the page size and the `next_cursor` of a previous result as
+    `cursor` to fetch the next page.
+    """
+    return AgentSkillList.model_validate(
+        _api_util.list_agent_skills(
+            credentials=credentials,
+            organization_id=credentials.organization_id,
+            workspace_id=workspace_id,
+            limit=limit,
+            cursor=cursor,
+        )
+    )
+
+
+def search_skills(
+    query: str,
+    *,
+    credentials: _AirbyteCredentials,
+    workspace_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> AgentSkillList:
+    """Search skills by keyword, returning a page of matching skills."""
+    return AgentSkillList.model_validate(
+        _api_util.search_agent_skills(
+            query=query,
+            credentials=credentials,
+            organization_id=credentials.organization_id,
+            workspace_id=workspace_id,
+            limit=limit,
+            cursor=cursor,
+        )
+    )

--- a/airbyte/agents/skills.py
+++ b/airbyte/agents/skills.py
@@ -17,6 +17,8 @@ from airbyte.agents.models import AgentSkillDocs, AgentSkillInfo, AgentSkillList
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
     from airbyte.cloud._credentials import _AirbyteCredentials
 
 
@@ -118,6 +120,61 @@ def search_skills(
             organization_id=credentials.organization_id,
             workspace_id=workspace_id,
             limit=limit,
+            cursor=cursor,
+        )
+    )
+
+
+def _iter_skill_pages(
+    fetch_page: Callable[[str | None], AgentSkillList],
+) -> Iterator[AgentSkillInfo]:
+    """Yield skills across pages, following `next_cursor` until it is `None`.
+
+    Stops early if the server returns a cursor already seen, rather than requesting the
+    same page forever.
+    """
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        page = fetch_page(cursor)
+        yield from page.data
+        cursor = page.next_cursor
+        if cursor is None or cursor in seen_cursors:
+            return
+        seen_cursors.add(cursor)
+
+
+def iter_skills(
+    *,
+    credentials: _AirbyteCredentials,
+    workspace_id: str | None = None,
+) -> Iterator[AgentSkillInfo]:
+    """Yield all available skills, following the API's pagination cursor.
+
+    This is the pagination-free way to list skills: each page is fetched lazily as the
+    caller iterates, so no cursor bookkeeping is needed.
+    """
+    return _iter_skill_pages(
+        lambda cursor: list_skills(
+            credentials=credentials,
+            workspace_id=workspace_id,
+            cursor=cursor,
+        )
+    )
+
+
+def iter_skill_search(
+    query: str,
+    *,
+    credentials: _AirbyteCredentials,
+    workspace_id: str | None = None,
+) -> Iterator[AgentSkillInfo]:
+    """Yield all skills matching `query`, following the API's pagination cursor."""
+    return _iter_skill_pages(
+        lambda cursor: search_skills(
+            query,
+            credentials=credentials,
+            workspace_id=workspace_id,
             cursor=cursor,
         )
     )

--- a/airbyte/agents/workspaces.py
+++ b/airbyte/agents/workspaces.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from airbyte.agents import _api_util
+from airbyte.agents import skills as _skills
 from airbyte.agents.connectors import AgentConnector, _resolve_connector_lookup
 from airbyte.agents.models import (
     AgentConnectorInfo,
@@ -20,6 +21,7 @@ from airbyte.agents.models import (
     AgentSkillList,
     AgentWorkspaceInfo,
 )
+from airbyte.agents.skills import AgentSkill
 from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteError, PyAirbyteInputError
@@ -148,14 +150,11 @@ class AgentWorkspace:
         Pass `limit` to cap the page size and the `next_cursor` of a previous result as
         `cursor` to fetch the next page.
         """
-        return AgentSkillList.model_validate(
-            _api_util.list_agent_skills(
-                credentials=self._credentials,
-                organization_id=self.organization_id,
-                workspace_id=self.workspace_id,
-                limit=limit,
-                cursor=cursor,
-            )
+        return _skills.list_skills(
+            credentials=self._credentials,
+            workspace_id=self.workspace_id,
+            limit=limit,
+            cursor=cursor,
         )
 
     def search_skills(
@@ -166,15 +165,20 @@ class AgentWorkspace:
         cursor: str | None = None,
     ) -> AgentSkillList:
         """Search skills by keyword, returning a page of matching skills."""
-        return AgentSkillList.model_validate(
-            _api_util.search_agent_skills(
-                query=query,
-                credentials=self._credentials,
-                organization_id=self.organization_id,
-                workspace_id=self.workspace_id,
-                limit=limit,
-                cursor=cursor,
-            )
+        return _skills.search_skills(
+            query,
+            credentials=self._credentials,
+            workspace_id=self.workspace_id,
+            limit=limit,
+            cursor=cursor,
+        )
+
+    def get_skill(self, skill_id: str) -> AgentSkill:
+        """Get a skill by ID, without calling the Agents API."""
+        return AgentSkill(
+            skill_id,
+            credentials=self._credentials,
+            workspace_id=self.workspace_id,
         )
 
     def read_skill_docs(
@@ -189,15 +193,7 @@ class AgentWorkspace:
         pass an exact section `id` from the outline to read that section. Connector usage
         docs use the `docs_skill_id` reported by `AgentConnector.inspect()`.
         """
-        return AgentSkillDocs.model_validate(
-            _api_util.read_agent_skill_docs(
-                skill_id=skill_id,
-                credentials=self._credentials,
-                organization_id=self.organization_id,
-                workspace_id=self.workspace_id,
-                section=section,
-            )
-        )
+        return self.get_skill(skill_id).read_docs(section=section)
 
     def get_connector(
         self,

--- a/airbyte/agents/workspaces.py
+++ b/airbyte/agents/workspaces.py
@@ -18,7 +18,6 @@ from airbyte.agents.connectors import AgentConnector, _resolve_connector_lookup
 from airbyte.agents.models import (
     AgentConnectorInfo,
     AgentSkillDocs,
-    AgentSkillList,
     AgentWorkspaceInfo,
 )
 from airbyte.agents.skills import AgentSkill
@@ -139,39 +138,36 @@ class AgentWorkspace:
             )
         ]
 
-    def list_skills(
-        self,
-        *,
-        limit: int | None = None,
-        cursor: str | None = None,
-    ) -> AgentSkillList:
-        """List the skills available to this workspace.
+    def list_skills(self) -> list[AgentSkill]:
+        """List all skills available to this workspace, following pagination."""
+        return [
+            AgentSkill(
+                skill_id=info.id,
+                credentials=self._credentials,
+                workspace_id=self.workspace_id,
+                info=info,
+            )
+            for info in _skills.iter_skills(
+                credentials=self._credentials,
+                workspace_id=self.workspace_id,
+            )
+        ]
 
-        Pass `limit` to cap the page size and the `next_cursor` of a previous result as
-        `cursor` to fetch the next page.
-        """
-        return _skills.list_skills(
-            credentials=self._credentials,
-            workspace_id=self.workspace_id,
-            limit=limit,
-            cursor=cursor,
-        )
-
-    def search_skills(
-        self,
-        query: str,
-        *,
-        limit: int | None = None,
-        cursor: str | None = None,
-    ) -> AgentSkillList:
-        """Search skills by keyword, returning a page of matching skills."""
-        return _skills.search_skills(
-            query,
-            credentials=self._credentials,
-            workspace_id=self.workspace_id,
-            limit=limit,
-            cursor=cursor,
-        )
+    def search_skills(self, query: str) -> list[AgentSkill]:
+        """Search skills by keyword, returning all matching skills across pages."""
+        return [
+            AgentSkill(
+                skill_id=info.id,
+                credentials=self._credentials,
+                workspace_id=self.workspace_id,
+                info=info,
+            )
+            for info in _skills.iter_skill_search(
+                query,
+                credentials=self._credentials,
+                workspace_id=self.workspace_id,
+            )
+        ]
 
     def get_skill(self, skill_id: str) -> AgentSkill:
         """Get a skill by ID, without calling the Agents API."""

--- a/airbyte/agents/workspaces.py
+++ b/airbyte/agents/workspaces.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 
 from airbyte.agents import _api_util
 from airbyte.agents.connectors import AgentConnector, _resolve_connector_lookup
-from airbyte.agents.models import AgentConnectorInfo, AgentWorkspaceInfo
+from airbyte.agents.models import (
+    AgentConnectorInfo,
+    AgentSkillDocs,
+    AgentSkillList,
+    AgentWorkspaceInfo,
+)
 from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteError, PyAirbyteInputError
@@ -131,6 +136,68 @@ class AgentWorkspace:
                 )
             )
         ]
+
+    def list_skills(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> AgentSkillList:
+        """List the skills available to this workspace.
+
+        Pass `limit` to cap the page size and the `next_cursor` of a previous result as
+        `cursor` to fetch the next page.
+        """
+        return AgentSkillList.model_validate(
+            _api_util.list_agent_skills(
+                credentials=self._credentials,
+                organization_id=self.organization_id,
+                workspace_id=self.workspace_id,
+                limit=limit,
+                cursor=cursor,
+            )
+        )
+
+    def search_skills(
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> AgentSkillList:
+        """Search skills by keyword, returning a page of matching skills."""
+        return AgentSkillList.model_validate(
+            _api_util.search_agent_skills(
+                query=query,
+                credentials=self._credentials,
+                organization_id=self.organization_id,
+                workspace_id=self.workspace_id,
+                limit=limit,
+                cursor=cursor,
+            )
+        )
+
+    def read_skill_docs(
+        self,
+        skill_id: str,
+        *,
+        section: str | None = None,
+    ) -> AgentSkillDocs:
+        """Read a skill's docs, optionally scoped to a single section.
+
+        Omit `section` for metadata, guidance, and the outline of available sections, or
+        pass an exact section `id` from the outline to read that section. Connector usage
+        docs use the `docs_skill_id` reported by `AgentConnector.inspect()`.
+        """
+        return AgentSkillDocs.model_validate(
+            _api_util.read_agent_skill_docs(
+                skill_id=skill_id,
+                credentials=self._credentials,
+                organization_id=self.organization_id,
+                workspace_id=self.workspace_id,
+                section=section,
+            )
+        )
 
     def get_connector(
         self,

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -27,6 +27,7 @@ from fastmcp_extensions import get_mcp_config, mcp_tool, register_mcp_tools
 from pydantic import BaseModel, Field
 
 from airbyte.agents.connectors import AgentConnector
+from airbyte.agents.models import AgentSkillInfo
 from airbyte.agents.organizations import AgentOrganization
 from airbyte.agents.workspaces import AgentWorkspace
 from airbyte.constants import (
@@ -68,7 +69,9 @@ AGENTS_AUTH_TIP_TEXT = (
     f"environment variable, or both `{CLOUD_CLIENT_ID_ENV_VAR}` and "
     f"`{CLOUD_CLIENT_SECRET_ENV_VAR}`. Call `list_agent_connectors` to discover connector "
     f"IDs, then `inspect_agent_connector` to learn which entities a connector supports, "
-    f"before calling `execute_agent_connector`."
+    f"before calling `execute_agent_connector`. Use `list_agent_skills` or "
+    f"`search_agent_skills` to discover skills, and pass a `docs_skill_id` reported by "
+    f"`inspect_agent_connector` to `read_agent_skill_docs` for connector usage docs."
 )
 WORKSPACE_ID_TIP_TEXT = (
     f"Workspace ID. Hosted MCP connections pass it via the `{MCP_WORKSPACE_ID_HEADER}` "
@@ -169,6 +172,79 @@ class AgentConnectorDetailsResult(BaseModel):
 
     message: str | None = None
     """Why the details are empty, when the Agents API denied the request."""
+
+
+class AgentSkillResult(BaseModel):
+    """A skill discoverable on the Airbyte Agents platform."""
+
+    skill_id: str
+    """The skill ID, used as `skill_id` in `read_agent_skill_docs`."""
+
+    kind: str | None = None
+    """The skill category, for example `static` or `connector_source`."""
+
+    title: str | None = None
+    """The human-readable skill title."""
+
+    summary: str | None = None
+    """A short summary of what the skill documents."""
+
+    tags: list[str]
+    """Search and categorization tags for the skill."""
+
+
+class AgentSkillListResult(BaseModel):
+    """Result of listing or searching skills on the Airbyte Agents platform."""
+
+    skills: list[AgentSkillResult]
+    """Skills matching the listing or search."""
+
+    next_cursor: str | None = None
+    """The cursor to pass as `cursor` to fetch the next page, when one is available."""
+
+    message: str | None = None
+    """Why the listing is empty, when the Agents API denied the request."""
+
+
+class AgentSkillSectionResult(BaseModel):
+    """A section of a skill's docs, as listed in the docs outline."""
+
+    section_id: str
+    """The section ID, passed as `section` to `read_agent_skill_docs`."""
+
+    title: str | None = None
+    """The human-readable section title."""
+
+    summary: str | None = None
+    """A short summary of the section content."""
+
+    available: bool = True
+    """Whether this section can currently be read."""
+
+
+class AgentSkillDocsResult(BaseModel):
+    """Documentation for a single skill on the Airbyte Agents platform."""
+
+    skill_id: str
+    """The skill ID that was read."""
+
+    title: str | None = None
+    """The human-readable skill title."""
+
+    section_id: str | None = None
+    """The section that was read, or `None` for the default docs response."""
+
+    outline: list[AgentSkillSectionResult]
+    """The sections available for this skill."""
+
+    content: list[dict[str, Any]]
+    """Rendered docs content blocks, such as headings, paragraphs, and code blocks."""
+
+    warnings: list[str]
+    """Non-fatal issues reported while building or reading the docs."""
+
+    message: str | None = None
+    """Why the docs are empty, when the Agents API denied the request."""
 
 
 class AgentExecuteToolResult(BaseModel):
@@ -424,7 +500,8 @@ def inspect_agent_connector(
     """Inspect an Airbyte Agents connector: metadata, readiness, warnings, and `docs_skill_id`.
 
     Call this before `execute_agent_connector` to learn what the connector exposes. The
-    connector must belong to the given workspace.
+    connector must belong to the given workspace. The reported `docs_skill_id` can be
+    passed to `read_agent_skill_docs` to read the connector's usage docs.
     """
     try:
         details = _get_agent_connector(ctx, connector_id, workspace_id).inspect()
@@ -652,6 +729,193 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
         cursor=cursor,
         intent=intent,
         read_only=read_only,
+    )
+
+
+def _agent_skill_result(skill: AgentSkillInfo) -> AgentSkillResult:
+    """Shape an `AgentSkillInfo` into an `AgentSkillResult`."""
+    return AgentSkillResult(
+        skill_id=skill.id,
+        kind=skill.kind,
+        title=skill.title,
+        summary=skill.summary,
+        tags=skill.tags,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def list_agent_skills(
+    ctx: Context,
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+    limit: Annotated[
+        int | None,
+        Field(description="Maximum number of skills to return in this page.", default=None),
+    ],
+    cursor: Annotated[
+        str | None,
+        Field(
+            description="Pagination cursor, taken from `next_cursor` of a previous result.",
+            default=None,
+        ),
+    ],
+) -> AgentSkillListResult:
+    """List the skills available to an Airbyte Agents workspace.
+
+    Skills are reusable documentation the Agents API serves, for example connector usage
+    docs. Pass a listed skill's `skill_id` to `read_agent_skill_docs` to read it.
+    """
+    workspace = _get_agent_workspace(ctx, workspace_id)
+    try:
+        skills = workspace.list_skills(limit=limit, cursor=cursor)
+    except AirbyteError as error:
+        message = _agents_access_message(error)
+        if message is None:
+            raise
+        return AgentSkillListResult(skills=[], message=message)
+
+    return AgentSkillListResult(
+        skills=[_agent_skill_result(skill) for skill in skills.data],
+        next_cursor=skills.next_cursor,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def search_agent_skills(
+    ctx: Context,
+    query: Annotated[
+        str,
+        Field(
+            description=("Keyword query to match against skill titles, summaries, and tags."),
+        ),
+    ],
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+    limit: Annotated[
+        int | None,
+        Field(description="Maximum number of skills to return in this page.", default=None),
+    ],
+    cursor: Annotated[
+        str | None,
+        Field(
+            description="Pagination cursor, taken from `next_cursor` of a previous result.",
+            default=None,
+        ),
+    ],
+) -> AgentSkillListResult:
+    """Search skills by keyword in an Airbyte Agents workspace.
+
+    Pass a matching skill's `skill_id` to `read_agent_skill_docs` to read it.
+    """
+    workspace = _get_agent_workspace(ctx, workspace_id)
+    try:
+        skills = workspace.search_skills(query, limit=limit, cursor=cursor)
+    except AirbyteError as error:
+        message = _agents_access_message(error)
+        if message is None:
+            raise
+        return AgentSkillListResult(skills=[], message=message)
+
+    return AgentSkillListResult(
+        skills=[_agent_skill_result(skill) for skill in skills.data],
+        next_cursor=skills.next_cursor,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=AGENTS_AUTH_TIP_TEXT,
+)
+def read_agent_skill_docs(
+    ctx: Context,
+    skill_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Skill ID, e.g. the `docs_skill_id` reported by `inspect_agent_connector`, "
+                "or an `id` from `list_agent_skills`."
+            ),
+        ),
+    ],
+    *,
+    section: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Omit to get metadata, guidance, and the outline of available sections. "
+                "Pass an exact section `id` from the outline to read that section."
+            ),
+            default=None,
+        ),
+    ],
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=WORKSPACE_ID_TIP_TEXT,
+            default=None,
+        ),
+    ],
+) -> AgentSkillDocsResult:
+    """Read a skill's docs in an Airbyte Agents workspace.
+
+    Without `section`, this returns the skill's metadata, guidance, and the outline of
+    sections, which is the cheapest way to orient before reading a specific section.
+    """
+    workspace = _get_agent_workspace(ctx, workspace_id)
+    try:
+        docs = workspace.read_skill_docs(skill_id, section=section)
+    except AirbyteError as error:
+        message = _agents_access_message(error)
+        if message is None:
+            raise
+        return AgentSkillDocsResult(
+            skill_id=skill_id,
+            section_id=section,
+            outline=[],
+            content=[],
+            warnings=[],
+            message=message,
+        )
+
+    return AgentSkillDocsResult(
+        skill_id=docs.metadata.id,
+        title=docs.metadata.title,
+        section_id=docs.section_id,
+        outline=[
+            AgentSkillSectionResult(
+                section_id=docs_section.id,
+                title=docs_section.title,
+                summary=docs_section.summary,
+                available=docs_section.available,
+            )
+            for docs_section in docs.outline
+        ],
+        content=docs.content,
+        warnings=[str(warning) for warning in docs.metadata.warnings],
     )
 
 

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -197,10 +197,7 @@ class AgentSkillListResult(BaseModel):
     """Result of listing or searching skills on the Airbyte Agents platform."""
 
     skills: list[AgentSkillResult]
-    """Skills matching the listing or search."""
-
-    next_cursor: str | None = None
-    """The cursor to pass as `cursor` to fetch the next page, when one is available."""
+    """Skills matching the listing or search, across all pages."""
 
     message: str | None = None
     """Why the listing is empty, when the Agents API denied the request."""
@@ -759,26 +756,16 @@ def list_agent_skills(
             default=None,
         ),
     ],
-    limit: Annotated[
-        int | None,
-        Field(description="Maximum number of skills to return in this page.", default=None),
-    ],
-    cursor: Annotated[
-        str | None,
-        Field(
-            description="Pagination cursor, taken from `next_cursor` of a previous result.",
-            default=None,
-        ),
-    ],
 ) -> AgentSkillListResult:
-    """List the skills available to an Airbyte Agents workspace.
+    """List all skills available to an Airbyte Agents workspace.
 
     Skills are reusable documentation the Agents API serves, for example connector usage
-    docs. Pass a listed skill's `skill_id` to `read_agent_skill_docs` to read it.
+    docs. All pages are fetched, so no pagination arguments are needed. Pass a listed
+    skill's `skill_id` to `read_agent_skill_docs` to read it.
     """
     workspace = _get_agent_workspace(ctx, workspace_id)
     try:
-        skills = workspace.list_skills(limit=limit, cursor=cursor)
+        skills = workspace.list_skills()
     except AirbyteError as error:
         message = _agents_access_message(error)
         if message is None:
@@ -786,8 +773,7 @@ def list_agent_skills(
         return AgentSkillListResult(skills=[], message=message)
 
     return AgentSkillListResult(
-        skills=[_agent_skill_result(skill) for skill in skills.data],
-        next_cursor=skills.next_cursor,
+        skills=[_agent_skill_result(skill.info) for skill in skills],
     )
 
 
@@ -813,25 +799,15 @@ def search_agent_skills(
             default=None,
         ),
     ],
-    limit: Annotated[
-        int | None,
-        Field(description="Maximum number of skills to return in this page.", default=None),
-    ],
-    cursor: Annotated[
-        str | None,
-        Field(
-            description="Pagination cursor, taken from `next_cursor` of a previous result.",
-            default=None,
-        ),
-    ],
 ) -> AgentSkillListResult:
     """Search skills by keyword in an Airbyte Agents workspace.
 
-    Pass a matching skill's `skill_id` to `read_agent_skill_docs` to read it.
+    All pages are fetched, so no pagination arguments are needed. Pass a matching skill's
+    `skill_id` to `read_agent_skill_docs` to read it.
     """
     workspace = _get_agent_workspace(ctx, workspace_id)
     try:
-        skills = workspace.search_skills(query, limit=limit, cursor=cursor)
+        skills = workspace.search_skills(query)
     except AirbyteError as error:
         message = _agents_access_message(error)
         if message is None:
@@ -839,8 +815,7 @@ def search_agent_skills(
         return AgentSkillListResult(skills=[], message=message)
 
     return AgentSkillListResult(
-        skills=[_agent_skill_result(skill) for skill in skills.data],
-        next_cursor=skills.next_cursor,
+        skills=[_agent_skill_result(skill.info) for skill in skills],
     )
 
 

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -53,6 +53,37 @@ WORKSPACES_RESPONSE: dict[str, Any] = {
         {"id": "workspace-2", "name": "secondary", "organization_id": "org-id"},
     ]
 }
+SKILL_LIST_RESPONSE: dict[str, Any] = {
+    "data": [
+        {
+            "id": "connector:github",
+            "kind": "connector_source",
+            "title": "GitHub",
+            "summary": "GitHub usage docs.",
+            "tags": ["github", "connector"],
+        }
+    ],
+    "next_cursor": "cursor-skills-1",
+}
+SKILL_DOCS_RESPONSE: dict[str, Any] = {
+    "metadata": {
+        "id": "connector:github",
+        "kind": "connector_source",
+        "title": "GitHub",
+        "warnings": ["Partial runtime metadata."],
+    },
+    "outline": [
+        {
+            "id": "setup",
+            "title": "Setup",
+            "summary": "How to configure.",
+            "available": True,
+        },
+        {"id": "faq", "title": "FAQ", "available": False},
+    ],
+    "section_id": None,
+    "content": [{"type": "paragraph", "text": "Hello"}],
+}
 
 
 class _FakeResponse:
@@ -101,6 +132,10 @@ def captured_requests(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
             return _FakeResponse(INSPECT_RESPONSE)
         if url.endswith("/execute"):
             return _FakeResponse(EXECUTE_RESPONSE)
+        if url.endswith("/skills/docs"):
+            return _FakeResponse(SKILL_DOCS_RESPONSE)
+        if url.endswith("/skills/search") or url.endswith("/skills"):
+            return _FakeResponse(SKILL_LIST_RESPONSE)
         if url.endswith("/connectors"):
             return _FakeResponse(CONNECTORS_RESPONSE)
         if url.endswith("/workspaces"):
@@ -754,3 +789,138 @@ def test_conversion_rejects_non_public_cloud_api_roots(
         convert()
 
     assert captured_requests == []
+
+
+@pytest.mark.parametrize(
+    ("call_api", "expected_path", "expected_params"),
+    [
+        pytest.param(
+            lambda: _api_util.list_agent_skills(
+                credentials=_credentials(),
+                organization_id="org-id",
+                workspace_id="workspace-id",
+                limit=5,
+                cursor="c1",
+            ),
+            "/skills",
+            {
+                "limit": 5,
+                "cursor": "c1",
+                "organization_id": "org-id",
+                "workspace_id": "workspace-id",
+            },
+            id="list_skills",
+        ),
+        pytest.param(
+            lambda: _api_util.search_agent_skills(
+                query="github",
+                credentials=_credentials(),
+                organization_id="org-id",
+                workspace_id="workspace-id",
+                limit=5,
+                cursor="c1",
+            ),
+            "/skills/search",
+            {
+                "query": "github",
+                "limit": 5,
+                "cursor": "c1",
+                "organization_id": "org-id",
+                "workspace_id": "workspace-id",
+            },
+            id="search_skills",
+        ),
+        pytest.param(
+            lambda: _api_util.read_agent_skill_docs(
+                skill_id="connector:github",
+                credentials=_credentials(),
+                organization_id="org-id",
+                workspace_id="workspace-id",
+                section="setup",
+            ),
+            "/skills/docs",
+            {
+                "id": "connector:github",
+                "section": "setup",
+                "organization_id": "org-id",
+                "workspace_id": "workspace-id",
+            },
+            id="read_skill_docs",
+        ),
+    ],
+)
+def test_skill_requests(
+    captured_requests: list[dict[str, Any]],
+    call_api: Any,
+    expected_path: str,
+    expected_params: dict[str, Any],
+) -> None:
+    """Skill API calls hit their `/skills` endpoints with only non-`None` params."""
+    response = call_api()
+
+    call = captured_requests[0]
+    assert call["url"] == f"https://api.airbyte.ai/api/v1{expected_path}"
+    assert call["params"] == expected_params
+    assert call["headers"]["X-Organization-Id"] == "org-id"
+
+    if expected_path == "/skills/docs":
+        assert response["metadata"]["id"] == "connector:github"
+    else:
+        # The raw response is returned, so `next_cursor` is not dropped.
+        assert response["next_cursor"] == "cursor-skills-1"
+
+
+def test_skill_requests_omit_none_params(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    """Unset skill API arguments are left out of the query string."""
+    _api_util.list_agent_skills(credentials=_credentials(organization_id=None))
+    assert captured_requests[0]["params"] is None
+
+    _api_util.search_agent_skills(
+        query="github",
+        credentials=_credentials(organization_id=None),
+    )
+    assert captured_requests[1]["params"] == {"query": "github"}
+
+    _api_util.read_agent_skill_docs(
+        skill_id="connector:github",
+        credentials=_credentials(organization_id=None),
+    )
+    assert captured_requests[2]["params"] == {"id": "connector:github"}
+
+
+def test_workspace_skill_methods(captured_requests: list[dict[str, Any]]) -> None:
+    """`AgentWorkspace` skill methods scope requests to the workspace and parse results."""
+    workspace = AgentWorkspace(workspace_id="workspace-id", bearer_token="test-token")
+
+    skills = workspace.list_skills(limit=5)
+    assert captured_requests[0]["url"].endswith("/skills")
+    assert captured_requests[0]["params"] == {
+        "limit": 5,
+        "workspace_id": "workspace-id",
+    }
+    assert skills.data[0].id == "connector:github"
+    assert skills.next_cursor == "cursor-skills-1"
+
+    skills = workspace.search_skills("github", cursor="c1")
+    assert captured_requests[1]["url"].endswith("/skills/search")
+    assert captured_requests[1]["params"] == {
+        "query": "github",
+        "cursor": "c1",
+        "workspace_id": "workspace-id",
+    }
+    assert skills.data[0].id == "connector:github"
+
+    docs = workspace.read_skill_docs("connector:github", section="setup")
+    assert captured_requests[2]["url"].endswith("/skills/docs")
+    assert captured_requests[2]["params"] == {
+        "id": "connector:github",
+        "section": "setup",
+        "workspace_id": "workspace-id",
+    }
+    assert docs.metadata.id == "connector:github"
+    assert docs.metadata.warnings == ["Partial runtime metadata."]
+    assert docs.outline[0].id == "setup"
+    assert docs.outline[1].available is False
+    assert docs.content == [{"type": "paragraph", "text": "Hello"}]

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -11,6 +11,7 @@ from airbyte.agents import _api_util
 from airbyte.agents.connectors import AgentConnector
 from airbyte.agents.models import AgentExecuteResult
 from airbyte.agents.organizations import AgentOrganization
+from airbyte.agents.skills import AgentSkill
 from airbyte.agents.workspaces import AgentWorkspace
 from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud.organizations import CloudOrganization
@@ -924,3 +925,55 @@ def test_workspace_skill_methods(captured_requests: list[dict[str, Any]]) -> Non
     assert docs.outline[0].id == "setup"
     assert docs.outline[1].available is False
     assert docs.content == [{"type": "paragraph", "text": "Hello"}]
+
+
+def test_get_skill(captured_requests: list[dict[str, Any]]) -> None:
+    """`get_skill()` returns an `AgentSkill` bound to the workspace, without a request."""
+    workspace = AgentWorkspace(
+        workspace_id="workspace-id",
+        organization_id="org-id",
+        bearer_token="test-token",
+    )
+
+    skill = workspace.get_skill("connector:github")
+
+    assert isinstance(skill, AgentSkill)
+    assert skill.skill_id == "connector:github"
+    assert captured_requests == []
+
+
+@pytest.mark.parametrize("section", [None, "setup"], ids=["no_section", "with_section"])
+def test_agent_skill_read_docs(
+    captured_requests: list[dict[str, Any]],
+    section: str | None,
+) -> None:
+    """`AgentSkill.read_docs()` requests `/skills/docs` for its skill and section."""
+    skill = AgentSkill(
+        "connector:github",
+        credentials=_credentials(),
+        workspace_id="workspace-id",
+    )
+
+    docs = skill.read_docs(section=section)
+
+    expected_params: dict[str, Any] = {
+        "id": "connector:github",
+        "organization_id": "org-id",
+        "workspace_id": "workspace-id",
+    }
+    if section is not None:
+        expected_params["section"] = section
+    assert captured_requests[0]["url"].endswith("/skills/docs")
+    assert captured_requests[0]["params"] == expected_params
+    assert docs.metadata.id == "connector:github"
+    assert skill.info.id == "connector:github"
+
+
+def test_agent_skill_info_is_cached(captured_requests: list[dict[str, Any]]) -> None:
+    """`AgentSkill.info` fetches once and caches across property accesses."""
+    skill = AgentSkill("connector:github", credentials=_credentials())
+
+    assert skill.title == "GitHub"
+    assert skill.kind == "connector_source"
+    assert skill.info.id == "connector:github"
+    assert len(captured_requests) == 1

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 import requests
 from airbyte.agents import _api_util
+from airbyte.agents import skills as skills_module
 from airbyte.agents.connectors import AgentConnector
 from airbyte.agents.models import AgentExecuteResult
 from airbyte.agents.organizations import AgentOrganization
@@ -64,7 +65,7 @@ SKILL_LIST_RESPONSE: dict[str, Any] = {
             "tags": ["github", "connector"],
         }
     ],
-    "next_cursor": "cursor-skills-1",
+    "next_cursor": None,
 }
 SKILL_DOCS_RESPONSE: dict[str, Any] = {
     "metadata": {
@@ -868,7 +869,8 @@ def test_skill_requests(
         assert response["metadata"]["id"] == "connector:github"
     else:
         # The raw response is returned, so `next_cursor` is not dropped.
-        assert response["next_cursor"] == "cursor-skills-1"
+        assert "next_cursor" in response
+        assert response["data"][0]["id"] == "connector:github"
 
 
 def test_skill_requests_omit_none_params(
@@ -895,23 +897,22 @@ def test_workspace_skill_methods(captured_requests: list[dict[str, Any]]) -> Non
     """`AgentWorkspace` skill methods scope requests to the workspace and parse results."""
     workspace = AgentWorkspace(workspace_id="workspace-id", bearer_token="test-token")
 
-    skills = workspace.list_skills(limit=5)
+    skills = workspace.list_skills()
     assert captured_requests[0]["url"].endswith("/skills")
-    assert captured_requests[0]["params"] == {
-        "limit": 5,
-        "workspace_id": "workspace-id",
-    }
-    assert skills.data[0].id == "connector:github"
-    assert skills.next_cursor == "cursor-skills-1"
+    assert captured_requests[0]["params"] == {"workspace_id": "workspace-id"}
+    assert [skill.skill_id for skill in skills] == ["connector:github"]
+    # `info` is already populated from the listing, so reading it is free.
+    assert skills[0].info.id == "connector:github"
+    assert skills[0].title == "GitHub"
+    assert len(captured_requests) == 1
 
-    skills = workspace.search_skills("github", cursor="c1")
+    skills = workspace.search_skills("github")
     assert captured_requests[1]["url"].endswith("/skills/search")
     assert captured_requests[1]["params"] == {
         "query": "github",
-        "cursor": "c1",
         "workspace_id": "workspace-id",
     }
-    assert skills.data[0].id == "connector:github"
+    assert [skill.skill_id for skill in skills] == ["connector:github"]
 
     docs = workspace.read_skill_docs("connector:github", section="setup")
     assert captured_requests[2]["url"].endswith("/skills/docs")
@@ -925,6 +926,69 @@ def test_workspace_skill_methods(captured_requests: list[dict[str, Any]]) -> Non
     assert docs.outline[0].id == "setup"
     assert docs.outline[1].available is False
     assert docs.content == [{"type": "paragraph", "text": "Hello"}]
+
+
+@pytest.mark.parametrize(
+    ("pages", "expected_ids", "expected_request_count"),
+    [
+        pytest.param(
+            [
+                (["s1", "s2"], "cursor-1"),
+                (["s3"], None),
+            ],
+            ["s1", "s2", "s3"],
+            2,
+            id="follows_cursor_to_last_page",
+        ),
+        pytest.param(
+            [(["s1"], None)],
+            ["s1"],
+            1,
+            id="single_page",
+        ),
+        pytest.param(
+            [
+                (["s1"], "cursor-1"),
+                (["s2"], "cursor-1"),
+            ],
+            ["s1", "s2"],
+            2,
+            id="stops_when_cursor_does_not_advance",
+        ),
+    ],
+)
+def test_iter_skills(
+    monkeypatch: pytest.MonkeyPatch,
+    pages: list[tuple[list[str], str | None]],
+    expected_ids: list[str],
+    expected_request_count: int,
+) -> None:
+    """`iter_skills()` follows the API's cursor and stops without looping."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_request(**kwargs: Any) -> _FakeResponse:
+        calls.append(kwargs)
+        ids, next_cursor = pages[min(len(calls) - 1, len(pages) - 1)]
+        return _FakeResponse({
+            "data": [{"id": skill_id} for skill_id in ids],
+            "next_cursor": next_cursor,
+        })
+
+    monkeypatch.setattr(requests, "request", _fake_request)
+
+    skills = list(
+        skills_module.iter_skills(
+            credentials=_credentials(),
+            workspace_id="workspace-id",
+        )
+    )
+
+    assert [skill.id for skill in skills] == expected_ids
+    assert len(calls) == expected_request_count
+    assert [call["params"].get("cursor") for call in calls] == [
+        None,
+        *[page[1] for page in pages[: expected_request_count - 1]],
+    ]
 
 
 def test_get_skill(captured_requests: list[dict[str, Any]]) -> None:

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -17,7 +17,6 @@ from airbyte.agents.models import (
     AgentExecutionMetadata,
     AgentSkillDocs,
     AgentSkillInfo,
-    AgentSkillList,
     AgentSkillSection,
 )
 from airbyte.agents.connectors import AgentConnector
@@ -417,8 +416,6 @@ _ACCESS_FAILURE_CASES = [
         lambda: agents_mcp.list_agent_skills(
             ctx=cast(Context, object()),
             workspace_id="workspace-1",
-            limit=None,
-            cursor=None,
         ),
         {"skills": []},
         id="list_skills",
@@ -430,8 +427,6 @@ _ACCESS_FAILURE_CASES = [
             ctx=cast(Context, object()),
             query="github",
             workspace_id="workspace-1",
-            limit=None,
-            cursor=None,
         ),
         {"skills": []},
         id="search_skills",
@@ -560,15 +555,15 @@ def test_workspace_organization_id_comes_from_mcp_config(
 def test_skills_tools_shape_results(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verify the skills tools shape `AgentSkillList`/`AgentSkillDocs` into results."""
 
+    class _SkillLike:
+        def __init__(self, info: AgentSkillInfo) -> None:
+            self.info = info
+
     class _SkilledWorkspace:
-        def list_skills(
-            self,
-            *,
-            limit: int | None = None,
-            cursor: str | None = None,
-        ) -> AgentSkillList:
-            return AgentSkillList(
-                data=[
+        def list_skills(self) -> list[Any]:
+            # Two skills spanning two pages; pagination is internal to the workspace.
+            return [
+                _SkillLike(
                     AgentSkillInfo(
                         id="connector:github",
                         kind="connector_source",
@@ -576,18 +571,12 @@ def test_skills_tools_shape_results(monkeypatch: pytest.MonkeyPatch) -> None:
                         summary="GitHub usage docs.",
                         tags=["github"],
                     )
-                ],
-                next_cursor="cursor-1",
-            )
+                ),
+                _SkillLike(AgentSkillInfo(id="context-store", title="Context Store")),
+            ]
 
-        def search_skills(
-            self,
-            query: str,
-            *,
-            limit: int | None = None,
-            cursor: str | None = None,
-        ) -> AgentSkillList:
-            return AgentSkillList(data=[], next_cursor=None)
+        def search_skills(self, query: str) -> list[Any]:
+            return []
 
         def read_skill_docs(
             self,
@@ -618,8 +607,6 @@ def test_skills_tools_shape_results(monkeypatch: pytest.MonkeyPatch) -> None:
     listed = agents_mcp.list_agent_skills(
         ctx=cast(Context, object()),
         workspace_id="workspace-1",
-        limit=5,
-        cursor="c0",
     )
     assert listed.skills == [
         agents_mcp.AgentSkillResult(
@@ -628,19 +615,20 @@ def test_skills_tools_shape_results(monkeypatch: pytest.MonkeyPatch) -> None:
             title="GitHub",
             summary="GitHub usage docs.",
             tags=["github"],
-        )
+        ),
+        agents_mcp.AgentSkillResult(
+            skill_id="context-store",
+            title="Context Store",
+            tags=[],
+        ),
     ]
-    assert listed.next_cursor == "cursor-1"
 
     searched = agents_mcp.search_agent_skills(
         ctx=cast(Context, object()),
         query="github",
         workspace_id="workspace-1",
-        limit=None,
-        cursor=None,
     )
     assert searched.skills == []
-    assert searched.next_cursor is None
 
     docs = agents_mcp.read_agent_skill_docs(
         ctx=cast(Context, object()),

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -15,6 +15,10 @@ from airbyte.agents.models import (
     AgentContextStoreReadiness,
     AgentExecuteResult,
     AgentExecutionMetadata,
+    AgentSkillDocs,
+    AgentSkillInfo,
+    AgentSkillList,
+    AgentSkillSection,
 )
 from airbyte.agents.connectors import AgentConnector
 from airbyte.constants import MCP_CONFIG_BEARER_TOKEN, MCP_CONFIG_ORGANIZATION_ID
@@ -75,6 +79,18 @@ class _RaisingWorkspace:
         self._error = error
 
     def list_connectors(self) -> list[Any]:
+        """Raise the configured error."""
+        raise self._error
+
+    def list_skills(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        """Raise the configured error."""
+        raise self._error
+
+    def search_skills(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        """Raise the configured error."""
+        raise self._error
+
+    def read_skill_docs(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Raise the configured error."""
         raise self._error
 
@@ -284,6 +300,9 @@ def test_agents_tools_are_registered_with_expected_read_only_hints() -> None:
 
     assert tools["execute_agent_connector_ro"].annotations.readOnlyHint is True
     assert tools["execute_agent_connector"].annotations.readOnlyHint is False
+    assert tools["list_agent_skills"].annotations.readOnlyHint is True
+    assert tools["search_agent_skills"].annotations.readOnlyHint is True
+    assert tools["read_agent_skill_docs"].annotations.readOnlyHint is True
     assert "read_only" in tools["execute_agent_connector"].parameters["properties"]
     assert (
         "read_only" not in tools["execute_agent_connector_ro"].parameters["properties"]
@@ -393,6 +412,43 @@ _ACCESS_FAILURE_CASES = [
         id="execute",
     ),
     pytest.param(
+        "_get_agent_workspace",
+        _RaisingWorkspace,
+        lambda: agents_mcp.list_agent_skills(
+            ctx=cast(Context, object()),
+            workspace_id="workspace-1",
+            limit=None,
+            cursor=None,
+        ),
+        {"skills": []},
+        id="list_skills",
+    ),
+    pytest.param(
+        "_get_agent_workspace",
+        _RaisingWorkspace,
+        lambda: agents_mcp.search_agent_skills(
+            ctx=cast(Context, object()),
+            query="github",
+            workspace_id="workspace-1",
+            limit=None,
+            cursor=None,
+        ),
+        {"skills": []},
+        id="search_skills",
+    ),
+    pytest.param(
+        "_get_agent_workspace",
+        _RaisingWorkspace,
+        lambda: agents_mcp.read_agent_skill_docs(
+            ctx=cast(Context, object()),
+            skill_id="connector:github",
+            section=None,
+            workspace_id="workspace-1",
+        ),
+        {"skill_id": "connector:github", "outline": [], "content": []},
+        id="read_skill_docs",
+    ),
+    pytest.param(
         "_get_agent_connector",
         _RaisingConnector,
         lambda: agents_mcp.inspect_agent_connector(
@@ -499,3 +555,103 @@ def test_workspace_organization_id_comes_from_mcp_config(
 
     assert workspace.organization_id == "org-from-config"
     assert workspace._credentials.organization_id == "org-from-config"  # noqa: SLF001
+
+
+def test_skills_tools_shape_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the skills tools shape `AgentSkillList`/`AgentSkillDocs` into results."""
+
+    class _SkilledWorkspace:
+        def list_skills(
+            self,
+            *,
+            limit: int | None = None,
+            cursor: str | None = None,
+        ) -> AgentSkillList:
+            return AgentSkillList(
+                data=[
+                    AgentSkillInfo(
+                        id="connector:github",
+                        kind="connector_source",
+                        title="GitHub",
+                        summary="GitHub usage docs.",
+                        tags=["github"],
+                    )
+                ],
+                next_cursor="cursor-1",
+            )
+
+        def search_skills(
+            self,
+            query: str,
+            *,
+            limit: int | None = None,
+            cursor: str | None = None,
+        ) -> AgentSkillList:
+            return AgentSkillList(data=[], next_cursor=None)
+
+        def read_skill_docs(
+            self,
+            skill_id: str,
+            *,
+            section: str | None = None,
+        ) -> AgentSkillDocs:
+            return AgentSkillDocs(
+                metadata=AgentSkillInfo(
+                    id=skill_id,
+                    title="GitHub",
+                    warnings=["Partial runtime metadata."],
+                ),
+                outline=[
+                    AgentSkillSection(id="setup", title="Setup", available=True),
+                    AgentSkillSection(id="faq", title="FAQ", available=False),
+                ],
+                section_id=section,
+                content=[{"type": "paragraph", "text": "Hello"}],
+            )
+
+    monkeypatch.setattr(
+        agents_mcp,
+        "_get_agent_workspace",
+        lambda ctx, workspace_id=None: _SkilledWorkspace(),  # noqa: ARG005
+    )
+
+    listed = agents_mcp.list_agent_skills(
+        ctx=cast(Context, object()),
+        workspace_id="workspace-1",
+        limit=5,
+        cursor="c0",
+    )
+    assert listed.skills == [
+        agents_mcp.AgentSkillResult(
+            skill_id="connector:github",
+            kind="connector_source",
+            title="GitHub",
+            summary="GitHub usage docs.",
+            tags=["github"],
+        )
+    ]
+    assert listed.next_cursor == "cursor-1"
+
+    searched = agents_mcp.search_agent_skills(
+        ctx=cast(Context, object()),
+        query="github",
+        workspace_id="workspace-1",
+        limit=None,
+        cursor=None,
+    )
+    assert searched.skills == []
+    assert searched.next_cursor is None
+
+    docs = agents_mcp.read_agent_skill_docs(
+        ctx=cast(Context, object()),
+        skill_id="connector:github",
+        section="setup",
+        workspace_id="workspace-1",
+    )
+    assert docs.skill_id == "connector:github"
+    assert docs.title == "GitHub"
+    assert docs.section_id == "setup"
+    assert [section.section_id for section in docs.outline] == ["setup", "faq"]
+    assert docs.outline[1].available is False
+    assert docs.content == [{"type": "paragraph", "text": "Hello"}]
+    assert docs.warnings == ["Partial runtime metadata."]


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Lets AI agents using the Airbyte Cloud MCP discover the skills (reusable documentation) that the Agents platform serves, search them by keyword, and read their docs. Before this, the MCP reported a skill ID for each connector but had no way to read it.

Specifically, this adds the `list_agent_skills`, `search_agent_skills`, and `read_agent_skill_docs` MCP tools, a new `airbyte.agents.skills` module (`AgentSkill`, `iter_skills`, `iter_skill_search`), and `AgentWorkspace.list_skills()` / `.search_skills()` / `.get_skill()` / `.read_skill_docs()`, all wrapping the Sonar `GET /skills`, `/skills/search`, and `/skills/docs` endpoints.

</td></tr></table>

Requested by AJ.

## Changes

- `airbyte/agents/_api_util.py`: `list_agent_skills`, `search_agent_skills`, `read_agent_skill_docs` low-level wrappers. Return raw dicts so `next_cursor` survives; only non-`None` query params are sent; `organization_id`/`workspace_id` go in the query string plus the existing `X-Organization-Id` header. `/skills/functions/invoke` is deliberately not wrapped (agent-engine only).
- `airbyte/agents/models.py`: `AgentSkillInfo`, `AgentSkillList` (`data` required, `next_cursor` optional), `AgentSkillSection`, `AgentSkillDocs`, all `extra="allow"`.
- `airbyte/agents/skills.py` (new, mirrors `agents/connectors.py`): `AgentSkill` with `.info` / `.title` / `.kind` / `.read_docs(section=None)`; page-level `list_skills` / `search_skills`; `iter_skills` / `iter_skill_search` follow `next_cursor` and stop on `None`, blank, or repeated cursors.
- `airbyte/agents/workspaces.py`: `AgentWorkspace.list_skills()` and `.search_skills(query)` return every page as `list[AgentSkill]`; `.get_skill(skill_id)` makes no API call; `.read_skill_docs(skill_id, section=None)`.
- `airbyte/mcp/agents.py`: three read-only, idempotent MCP tools with the same error handling as `list_agent_connectors` (401/403 become an empty result with `message`). Pagination is internal; no `limit`/`cursor` is exposed to the agent. `AGENTS_AUTH_TIP_TEXT` and the `inspect_agent_connector` docstring now point `docs_skill_id` at `read_agent_skill_docs`.
- Unit tests in `tests/unit_tests/test_agents.py` and `tests/unit_tests/test_mcp_agents.py`.

```
list_agent_skills(workspace_id?) -> AgentSkillListResult{skills, message}
search_agent_skills(query, workspace_id?) -> AgentSkillListResult
read_agent_skill_docs(skill_id, section?, workspace_id?) -> AgentSkillDocsResult{skill_id, title, section_id, outline[], content[], warnings[], message}
```

## Review Spotlight

Reviewers with limited time, please review first:
- [`skills.py#L129-L146`](https://github.com/airbytehq/PyAirbyte/blob/90c4acdbe33e24e9e0c8b4b2f5f439f79870d6aa/airbyte/agents/skills.py#L129-L146): `_iter_skill_pages`, the cursor-following loop and its termination rules
- [`skills.py#L65-L83`](https://github.com/airbytehq/PyAirbyte/blob/90c4acdbe33e24e9e0c8b4b2f5f439f79870d6aa/airbyte/agents/skills.py#L65-L83): `AgentSkill.read_docs` and how cached metadata from list/search is preserved
- [`mcp/agents.py#L824-L960`](https://github.com/airbytehq/PyAirbyte/blob/90c4acdbe33e24e9e0c8b4b2f5f439f79870d6aa/airbyte/mcp/agents.py#L824-L960): the three MCP tools and their result shaping

## Risks

- `AgentSkillList.data` is required, so a Skills API response missing `data` raises a validation error instead of silently returning an empty page. This is intentional.
- Skills tools follow all pages before returning; a workspace with a very large skill catalog would make one MCP call issue several API requests.

## Test plan

- `uv run pytest tests/unit_tests/test_agents.py tests/unit_tests/test_mcp_agents.py` (135 passed): request path/param construction, `next_cursor` retention, `AgentSkill.read_docs` and `.info` caching (including that list metadata is not downgraded by a sparser docs response), multi-page iteration, blank and repeated-cursor termination, `AgentWorkspace` methods, MCP result shapes, access-denied handling, `readOnlyHint` registration.
- `uv run ruff format --check .`, `uv run ruff check .`, `uv run pyrefly check`: clean.
- Live-tested against `api.airbyte.ai`: list with pagination, search, docs outline and a single section, the connector `docs_skill_id` path, and real 403 handling. Details in the PR comment.

## Review history

<details>
<summary>Show/Hide Content</summary>

- AJ's review: skills logic moved out of `mcp/agents.py` into `airbyte.agents.skills`; MCP list/search tools dropped their `limit`/`cursor` args and return all results.
- Devin Review: `AgentSkillList.data` made required (`9559f14`).
- Copilot: `read_docs()` no longer overwrites richer list metadata with the sparser docs metadata (`abcdd43`).
- CodeRabbit: blank `next_cursor` ends pagination; `read_agent_skill_docs` description says `skill_id` rather than `id` (`e6c6ff0`).
- Merged `main` at `46194af`; the only conflict was adjacent test additions in `test_mcp_agents.py`.

</details>

---
[Devin session](https://app.devin.ai/sessions/36b4d70a155940d1b62f7ef2a6e7da76)
