### PR TITLE
feat(direct): add `as_direct_connector()` bridge from sources to hosted direct connectors

### DIFF
--- a/airbyte/__init__.py
+++ b/airbyte/__init__.py
@@ -104,6 +104,8 @@ has its own documentation and code samples related to effectively using the rela
     other formats, such as Pandas, Arrow, and LLM Document formats.
 - **`airbyte.destinations`** - Working with destinations, including how to write to Airbyte
     destinations connectors.
+- **`airbyte.direct`** - Direct connectors for entity/action operations (`execute`,
+    `list_entities`, and friends) on deployed sources, as opposed to batch replication.
 - **`airbyte.documents`** - Working with LLM documents, including how to convert records into
     document formats, for instance, when working with AI libraries like LangChain.
 - **`airbyte.exceptions`** - Definitions of all exception and warning classes used in PyAirbyte.
@@ -154,6 +156,7 @@ if TYPE_CHECKING:
         constants,
         datasets,
         destinations,
+        direct,
         documents,
         exceptions,  # noqa: ICN001  # No 'exc' alias for top-level module
         experimental,
@@ -176,6 +179,7 @@ __all__ = [
     "constants",
     "datasets",
     "destinations",
+    "direct",
     "documents",
     "exceptions",
     "experimental",

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -48,6 +49,7 @@ import yaml
 
 from airbyte import exceptions as exc
 from airbyte._util import api_util, text_util
+from airbyte.agents import _api_util as _agents_api_util
 from airbyte.cloud.models import (
     CloudCustomSourceDefinitionInfo,
     CloudDestinationInfo,
@@ -56,6 +58,7 @@ from airbyte.cloud.models import (
     _DestinationResponseLike,
     _SourceResponseLike,
 )
+from airbyte.direct import HostedDirectConnector
 
 
 if TYPE_CHECKING:
@@ -280,6 +283,40 @@ class CloudSource(CloudConnector):
         )
         result._connector_info = source_info  # noqa: SLF001  # Accessing Non-Public API
         return result
+
+    def as_direct_connector(self, *, verify: bool = True) -> HostedDirectConnector:
+        """Return this source as a direct connector backed by the hosted Airbyte Agents API.
+
+        Cloud source IDs are also Agents connector IDs, but a source is only usable as a
+        direct connector when its connector type is supported and Agents access is
+        enabled for it in the organization. By default this is verified by calling
+        `inspect()`; pass `verify=False` to skip that request.
+
+        Raises `AirbyteDirectConnectorNotSupportedError` when the source is not available
+        as a direct connector, and `PyAirbyteInputError` when the workspace uses
+        non-public Cloud API roots (the Agents API is hosted on Airbyte Cloud only).
+        """
+        _agents_api_util.check_public_cloud_api_roots(
+            self.workspace._credentials,  # noqa: SLF001  # Same-domain conversion.
+        )
+        connector = HostedDirectConnector(
+            connector_id=self.connector_id,
+            credentials=self.workspace._credentials,  # noqa: SLF001  # Same-domain conversion.
+            name=self._connector_info.name if self._connector_info else None,
+        )
+        if verify:
+            try:
+                connector.inspect()
+            except exc.AirbyteError as ex:
+                status_code = (ex.context or {}).get("status_code")
+                if status_code not in {HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND}:
+                    raise
+                raise exc.AirbyteDirectConnectorNotSupportedError(
+                    connector_name=(self._connector_info.name if self._connector_info else None),
+                    connector_id=self.connector_id,
+                    context={"status_code": status_code},
+                ) from ex
+        return connector
 
 
 class CloudDestination(CloudConnector):

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -49,7 +49,6 @@ import yaml
 
 from airbyte import exceptions as exc
 from airbyte._util import api_util, text_util
-from airbyte.agents import _api_util as _agents_api_util
 from airbyte.cloud.models import (
     CloudCustomSourceDefinitionInfo,
     CloudDestinationInfo,
@@ -58,11 +57,11 @@ from airbyte.cloud.models import (
     _DestinationResponseLike,
     _SourceResponseLike,
 )
-from airbyte.direct import HostedDirectConnector
 
 
 if TYPE_CHECKING:
     from airbyte.cloud.workspaces import CloudWorkspace
+    from airbyte.direct import HostedDirectConnector
 
 
 @dataclass
@@ -296,6 +295,15 @@ class CloudSource(CloudConnector):
         as a direct connector, and `PyAirbyteInputError` when the workspace uses
         non-public Cloud API roots (the Agents API is hosted on Airbyte Cloud only).
         """
+        # Deferred imports: `airbyte.agents` and `airbyte.direct` import `airbyte.cloud`
+        # modules at runtime, so a top-level import here creates a circular import.
+        from airbyte.agents import (  # noqa: PLC0415  # Deferred to avoid an import cycle.
+            _api_util as _agents_api_util,
+        )
+        from airbyte.direct import (  # noqa: PLC0415  # Deferred to avoid an import cycle.
+            HostedDirectConnector,
+        )
+
         _agents_api_util.check_public_cloud_api_roots(
             self.workspace._credentials,  # noqa: SLF001  # Same-domain conversion.
         )

--- a/airbyte/cloud/connectors.py
+++ b/airbyte/cloud/connectors.py
@@ -283,13 +283,22 @@ class CloudSource(CloudConnector):
         result._connector_info = source_info  # noqa: SLF001  # Accessing Non-Public API
         return result
 
-    def as_direct_connector(self, *, verify: bool = True) -> HostedDirectConnector:
+    def as_direct_connector(
+        self,
+        *,
+        organization_id: str | None = None,
+        verify: bool = True,
+    ) -> HostedDirectConnector:
         """Return this source as a direct connector backed by the hosted Airbyte Agents API.
 
         Cloud source IDs are also Agents connector IDs, but a source is only usable as a
         direct connector when its connector type is supported and Agents access is
         enabled for it in the organization. By default this is verified by calling
         `inspect()`; pass `verify=False` to skip that request.
+
+        The connector's organization is taken from `organization_id` when provided,
+        otherwise from the credentials' own organization, otherwise resolved once from
+        the workspace's owning organization.
 
         Raises `AirbyteDirectConnectorNotSupportedError` when the source is not available
         as a direct connector, and `PyAirbyteInputError` when the workspace uses
@@ -307,9 +316,16 @@ class CloudSource(CloudConnector):
         _agents_api_util.check_public_cloud_api_roots(
             self.workspace._credentials,  # noqa: SLF001  # Same-domain conversion.
         )
+        credentials = self.workspace._credentials  # noqa: SLF001  # Same-domain conversion.
+        if organization_id is not None:
+            credentials = credentials.with_organization_id(organization_id)
+        elif credentials.organization_id is None:
+            organization = self.workspace.get_organization()
+            credentials = credentials.with_organization_id(organization.organization_id)
+
         connector = HostedDirectConnector(
             connector_id=self.connector_id,
-            credentials=self.workspace._credentials,  # noqa: SLF001  # Same-domain conversion.
+            credentials=credentials,
             name=self._connector_info.name if self._connector_info else None,
         )
         if verify:

--- a/airbyte/direct/__init__.py
+++ b/airbyte/direct/__init__.py
@@ -25,6 +25,7 @@ for entity in direct.iter_entities("issues"):
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from airbyte.agents.connectors import AgentConnector
@@ -42,19 +43,20 @@ class DirectConnector(Protocol):
     """Entity/action interface satisfied by every direct connector implementation."""
 
     @property
+    @abstractmethod
     def connector_id(self) -> str | None:
         """The connector ID."""
-        ...
 
     @property
+    @abstractmethod
     def name(self) -> str | None:
         """The connector name, if known."""
-        ...
 
+    @abstractmethod
     def inspect(self, *, force_refresh: bool = False) -> AgentConnectorDetails:
         """Return connector metadata, optionally bypassing any cached result."""
-        ...
 
+    @abstractmethod
     def execute(  # noqa: PLR0913  # Mirrors `AgentConnector.execute()`.
         self,
         entity_type: str,
@@ -69,8 +71,8 @@ class DirectConnector(Protocol):
         intent: str | None = None,
     ) -> AgentExecuteResult:
         """Execute a single action against one entity type on this connector."""
-        ...
 
+    @abstractmethod
     def list_entities(
         self,
         entity_type: str,
@@ -78,8 +80,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `list` action, which returns a page of entities of `entity_type`."""
-        ...
 
+    @abstractmethod
     def iter_entities(
         self,
         entity_type: str,
@@ -89,8 +91,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `list_entities()`.
     ) -> Iterator[dict[str, Any]]:
         """Yield entities of `entity_type`, following the connector's pagination cursor."""
-        ...
 
+    @abstractmethod
     def search_entities(
         self,
         entity_type: str,
@@ -98,8 +100,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `search` action, which returns matching entities of `entity_type`."""
-        ...
 
+    @abstractmethod
     def get_entity(
         self,
         entity_type: str,
@@ -107,8 +109,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `get` action, which returns a single entity of `entity_type`."""
-        ...
 
+    @abstractmethod
     def create_entity(
         self,
         entity_type: str,
@@ -116,8 +118,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `create` action, which creates an entity of `entity_type`."""
-        ...
 
+    @abstractmethod
     def update_entity(
         self,
         entity_type: str,
@@ -125,8 +127,8 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `update` action, which updates an entity of `entity_type`."""
-        ...
 
+    @abstractmethod
     def delete_entity(
         self,
         entity_type: str,
@@ -134,7 +136,6 @@ class DirectConnector(Protocol):
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
     ) -> AgentExecuteResult:
         """Run the `delete` action, which deletes an entity of `entity_type`."""
-        ...
 
 
 class HostedDirectConnector(AgentConnector):

--- a/airbyte/direct/__init__.py
+++ b/airbyte/direct/__init__.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Direct connectors: entity/action operations on deployed Airbyte sources.
+
+> ## ⚠️ Experimental Interface
+>
+> **The Airbyte direct connector interfaces are experimental.** Class names, method
+> signatures, and result models may change or be removed without notice between minor
+> versions of PyAirbyte. Pin an exact PyAirbyte version if you depend on them.
+
+A direct connector exposes entity/action style operations — `execute`, `list_entities`,
+`iter_entities`, `search_entities`, `get_entity`, `create_entity`, `update_entity`, and
+`delete_entity` — on a single deployed connector, as opposed to the batch record
+replication that `Source.read` and `airbyte.cloud` syncs provide.
+
+```python
+from airbyte.cloud import CloudWorkspace
+
+workspace = CloudWorkspace.from_env()
+cloud_source = workspace.get_source("...")
+direct = cloud_source.as_direct_connector()
+for entity in direct.iter_entities("issues"):
+    print(entity)
+```
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from airbyte.agents.connectors import AgentConnector
+from airbyte.exceptions import AirbyteDirectConnectorNotSupportedError
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from airbyte.agents.models import AgentConnectorDetails, AgentExecuteResult
+
+
+@runtime_checkable
+class DirectConnector(Protocol):
+    """Entity/action interface satisfied by every direct connector implementation."""
+
+    @property
+    def connector_id(self) -> str | None:
+        """The connector ID."""
+        ...
+
+    @property
+    def name(self) -> str | None:
+        """The connector name, if known."""
+        ...
+
+    def inspect(self, *, force_refresh: bool = False) -> AgentConnectorDetails:
+        """Return connector metadata, optionally bypassing any cached result."""
+        ...
+
+    def execute(  # noqa: PLR0913  # Mirrors `AgentConnector.execute()`.
+        self,
+        entity_type: str,
+        action: str,
+        api_args: dict[str, Any] | None = None,
+        *,
+        select_fields: list[str] | None = None,
+        exclude_fields: list[str] | None = None,
+        page_size: int | None = None,
+        cursor: str | None = None,
+        skip_truncation: bool = True,
+        intent: str | None = None,
+    ) -> AgentExecuteResult:
+        """Execute a single action against one entity type on this connector."""
+        ...
+
+    def list_entities(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `list` action, which returns a page of entities of `entity_type`."""
+        ...
+
+    def iter_entities(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        *,
+        limit: int | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `list_entities()`.
+    ) -> Iterator[dict[str, Any]]:
+        """Yield entities of `entity_type`, following the connector's pagination cursor."""
+        ...
+
+    def search_entities(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `search` action, which returns matching entities of `entity_type`."""
+        ...
+
+    def get_entity(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `get` action, which returns a single entity of `entity_type`."""
+        ...
+
+    def create_entity(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `create` action, which creates an entity of `entity_type`."""
+        ...
+
+    def update_entity(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `update` action, which updates an entity of `entity_type`."""
+        ...
+
+    def delete_entity(
+        self,
+        entity_type: str,
+        api_args: dict[str, Any] | None = None,
+        **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to `execute()`.
+    ) -> AgentExecuteResult:
+        """Run the `delete` action, which deletes an entity of `entity_type`."""
+        ...
+
+
+class HostedDirectConnector(AgentConnector):
+    """A direct connector executed by the hosted Airbyte Agents API.
+
+    Get one from `CloudSource.as_direct_connector()` rather than constructing it directly.
+    """
+
+
+__all__ = [
+    "AirbyteDirectConnectorNotSupportedError",
+    "DirectConnector",
+    "HostedDirectConnector",
+]

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -412,6 +412,19 @@ class AirbyteConnectorNotPyPiPublishedError(AirbyteConnectorRegistryError):
     guidance = "This likely means that the connector is not ready for use with PyAirbyte."
 
 
+@dataclass
+class AirbyteDirectConnectorNotSupportedError(PyAirbyteError):
+    """The source has no direct connector, so it cannot perform direct entity actions."""
+
+    connector_name: str | None = None
+    connector_id: str | None = None
+    guidance: str | None = (
+        "Direct entity actions require a source with a mapped direct connector that is "
+        "enabled for Airbyte Agents. Check that the connector type is supported and that "
+        "Agents access is enabled for this source in its organization."
+    )
+
+
 # Connector Errors
 
 

--- a/airbyte/sources/base.py
+++ b/airbyte/sources/base.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from airbyte.caches import CacheBase
     from airbyte.callbacks import ConfigChangeCallback
     from airbyte.datasets._inmemory import InMemoryDataset
+    from airbyte.direct import DirectConnector
     from airbyte.documents import Document
     from airbyte.shared.state_providers import StateProviderBase
     from airbyte.shared.state_writers import StateWriterBase
@@ -998,6 +999,21 @@ class Source(ConnectorBase):  # noqa: PLR0904
             progress_tracker=progress_tracker,
             processed_streams=stream_names,
             cache=cache,
+        )
+
+    def as_direct_connector(self) -> DirectConnector:
+        """Return this source as a direct connector for entity/action operations.
+
+        Local sources do not yet support direct execution, so this always raises
+        `AirbyteDirectConnectorNotSupportedError`. Use `CloudSource.as_direct_connector()`
+        for sources deployed to Airbyte Cloud.
+        """
+        raise exc.AirbyteDirectConnectorNotSupportedError(
+            connector_name=self.name,
+            guidance=(
+                "Local sources cannot yet run direct entity actions. Deploy the source to "
+                "Airbyte Cloud and call `CloudSource.as_direct_connector()` instead."
+            ),
         )
 
 

--- a/tests/unit_tests/test_direct.py
+++ b/tests/unit_tests/test_direct.py
@@ -113,7 +113,11 @@ def _cloud_source(**workspace_kwargs: Any) -> CloudSource:
 
 def test_hosted_direct_connector_satisfies_protocol() -> None:
     """`HostedDirectConnector` is a `DirectConnector`."""
-    connector = HostedDirectConnector("cid", credentials=_credentials())
+    # `isinstance` reads the `name` property, which fetches it from the Agents API
+    # when unset — pass one so the check stays offline.
+    connector = HostedDirectConnector(
+        "cid", credentials=_credentials(), name="test-connector"
+    )
     assert isinstance(connector, DirectConnector)
 
 

--- a/tests/unit_tests/test_direct.py
+++ b/tests/unit_tests/test_direct.py
@@ -88,6 +88,18 @@ def captured_requests(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
     return calls
 
 
+@pytest.fixture
+def patched_organization(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Stub `CloudWorkspace.get_organization` so no org lookup hits the API."""
+    organization = Mock(organization_id="org-y")
+    monkeypatch.setattr(
+        CloudWorkspace,
+        "get_organization",
+        lambda self, **_: organization,
+    )
+    return organization
+
+
 def _cloud_source(**workspace_kwargs: Any) -> CloudSource:
     """Build a `CloudSource` wired to test credentials."""
     kwargs: dict[str, Any] = {
@@ -107,6 +119,7 @@ def test_hosted_direct_connector_satisfies_protocol() -> None:
 
 def test_cloud_source_as_direct_connector(
     captured_requests: list[dict[str, Any]],
+    patched_organization: Mock,
 ) -> None:
     """`as_direct_connector()` returns a hosted connector verified via `inspect()`."""
     connector = _cloud_source().as_direct_connector()
@@ -115,11 +128,39 @@ def test_cloud_source_as_direct_connector(
     assert connector.connector_id == "src-1"
     assert len(captured_requests) == 1
     assert captured_requests[0]["url"].endswith("/connectors/src-1/inspect")
-    assert "X-Organization-Id" not in captured_requests[0]["headers"]
+    assert captured_requests[0]["headers"]["X-Organization-Id"] == "org-y"
+
+
+def test_cloud_source_as_direct_connector_explicit_organization(
+    captured_requests: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit `organization_id` is used without a workspace org lookup."""
+    monkeypatch.setattr(
+        CloudWorkspace,
+        "get_organization",
+        Mock(side_effect=AssertionError("org lookup should not be called")),
+    )
+    connector = _cloud_source().as_direct_connector(organization_id="org-x")
+
+    assert isinstance(connector, HostedDirectConnector)
+    assert captured_requests[0]["headers"]["X-Organization-Id"] == "org-x"
+
+
+def test_cloud_source_as_direct_connector_resolves_organization(
+    captured_requests: list[dict[str, Any]],
+    patched_organization: Mock,
+) -> None:
+    """Without `organization_id`, the org is resolved once from the workspace."""
+    connector = _cloud_source().as_direct_connector()
+
+    assert isinstance(connector, HostedDirectConnector)
+    assert captured_requests[0]["headers"]["X-Organization-Id"] == "org-y"
 
 
 def test_cloud_source_as_direct_connector_no_verify(
     captured_requests: list[dict[str, Any]],
+    patched_organization: Mock,
 ) -> None:
     """`verify=False` skips the `inspect()` request."""
     connector = _cloud_source().as_direct_connector(verify=False)
@@ -138,6 +179,7 @@ def test_cloud_source_as_direct_connector_no_verify(
 )
 def test_cloud_source_as_direct_connector_not_supported(
     monkeypatch: pytest.MonkeyPatch,
+    patched_organization: Mock,
     status_code: int,
     expected_error: type[AirbyteError],
 ) -> None:
@@ -189,6 +231,7 @@ def test_local_source_as_direct_connector_raises() -> None:
 
 def test_hosted_direct_connector_inspect(
     captured_requests: list[dict[str, Any]],
+    patched_organization: Mock,
 ) -> None:
     """The hosted connector's `inspect()` returns the Agents API payload."""
     details: AgentConnectorDetails = _cloud_source().as_direct_connector().inspect()

--- a/tests/unit_tests/test_direct.py
+++ b/tests/unit_tests/test_direct.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+"""Unit tests for the `airbyte.direct` module and `as_direct_connector` bridges."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from airbyte.agents.models import AgentConnectorDetails
+from airbyte.cloud._credentials import _AirbyteCredentials
+from airbyte.cloud.connectors import CloudSource
+from airbyte.cloud.workspaces import CloudWorkspace
+from airbyte.direct import (
+    AirbyteDirectConnectorNotSupportedError,
+    DirectConnector,
+    HostedDirectConnector,
+)
+from airbyte.exceptions import AirbyteError, PyAirbyteInputError
+from airbyte.secrets.base import SecretString
+from airbyte.sources.base import Source
+
+
+INSPECT_RESPONSE: dict[str, Any] = {
+    "connector_id": "src-1",
+    "name": "GitHub",
+    "workspace_id": "ws",
+    "source_definition_name": "GitHub",
+    "docs_skill_id": "connector:github",
+    "context_store_readiness": {
+        "supported_context_store_entities": [
+            {"entity": "issues", "suggested": True},
+            {"entity": "repositories", "suggested": False},
+        ]
+    },
+}
+
+
+class _FakeResponse:
+    """Minimal stand-in for a `requests.Response`."""
+
+    def __init__(
+        self,
+        payload: Any,
+        status_code: int = 200,
+        content_type: str = "application/json",
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+        self.headers = {"Content-Type": content_type}
+
+    def json(self) -> Any:
+        """Return the canned payload."""
+        return self._payload
+
+
+def _credentials(**overrides: Any) -> _AirbyteCredentials:
+    """Build bearer-token credentials for tests."""
+    kwargs: dict[str, Any] = {
+        "client_id": None,
+        "client_secret": None,
+        "bearer_token": SecretString("test-token"),
+        "public_api_root": "https://api.airbyte.com/v1",
+        "config_api_root": None,
+        "workspace_id": "ws",
+        "organization_id": None,
+    }
+    kwargs.update(overrides)
+    return _AirbyteCredentials(**kwargs)
+
+
+@pytest.fixture
+def captured_requests(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture Agents API requests, returning the canned inspect response."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_request(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _FakeResponse(INSPECT_RESPONSE)
+
+    monkeypatch.setattr(requests, "request", _fake_request)
+    # Client credentials are exchanged for a bearer token via `requests.post`.
+    monkeypatch.setattr(
+        requests, "post", lambda **_: _FakeResponse({"access_token": "test-token"})
+    )
+    return calls
+
+
+def _cloud_source(**workspace_kwargs: Any) -> CloudSource:
+    """Build a `CloudSource` wired to test credentials."""
+    kwargs: dict[str, Any] = {
+        "workspace_id": "ws",
+        "client_id": "id",
+        "client_secret": "secret",
+    }
+    kwargs.update(workspace_kwargs)
+    return CloudSource(CloudWorkspace(**kwargs), "src-1")
+
+
+def test_hosted_direct_connector_satisfies_protocol() -> None:
+    """`HostedDirectConnector` is a `DirectConnector`."""
+    connector = HostedDirectConnector("cid", credentials=_credentials())
+    assert isinstance(connector, DirectConnector)
+
+
+def test_cloud_source_as_direct_connector(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    """`as_direct_connector()` returns a hosted connector verified via `inspect()`."""
+    connector = _cloud_source().as_direct_connector()
+
+    assert isinstance(connector, HostedDirectConnector)
+    assert connector.connector_id == "src-1"
+    assert len(captured_requests) == 1
+    assert captured_requests[0]["url"].endswith("/connectors/src-1/inspect")
+    assert "X-Organization-Id" not in captured_requests[0]["headers"]
+
+
+def test_cloud_source_as_direct_connector_no_verify(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    """`verify=False` skips the `inspect()` request."""
+    connector = _cloud_source().as_direct_connector(verify=False)
+
+    assert isinstance(connector, HostedDirectConnector)
+    assert captured_requests == []
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_error"),
+    [
+        pytest.param(404, AirbyteDirectConnectorNotSupportedError, id="not_found"),
+        pytest.param(403, AirbyteDirectConnectorNotSupportedError, id="forbidden"),
+        pytest.param(500, AirbyteError, id="server_error_propagates"),
+    ],
+)
+def test_cloud_source_as_direct_connector_not_supported(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    expected_error: type[AirbyteError],
+) -> None:
+    """A 404/403 on `inspect()` maps to `AirbyteDirectConnectorNotSupportedError`."""
+    monkeypatch.setattr(
+        requests,
+        "request",
+        lambda **_: _FakeResponse({"message": "nope"}, status_code=status_code),
+    )
+    monkeypatch.setattr(
+        requests, "post", lambda **_: _FakeResponse({"access_token": "test-token"})
+    )
+
+    with pytest.raises(expected_error) as error_info:
+        _cloud_source().as_direct_connector()
+
+    error = error_info.value
+    if isinstance(error, AirbyteDirectConnectorNotSupportedError):
+        assert error.connector_id == "src-1"
+        assert not isinstance(error, PyAirbyteInputError)
+    else:
+        assert not isinstance(error, AirbyteDirectConnectorNotSupportedError)
+
+
+def test_cloud_source_as_direct_connector_rejects_non_public_roots(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    """A workspace with custom API roots cannot produce a direct connector."""
+    source = _cloud_source(api_root="https://example.com/api")
+
+    with pytest.raises(PyAirbyteInputError, match="only available on Airbyte Cloud"):
+        source.as_direct_connector()
+
+    assert captured_requests == []
+
+
+def test_local_source_as_direct_connector_raises() -> None:
+    """A local `Source` always raises `AirbyteDirectConnectorNotSupportedError`."""
+    with patch.object(Source, "_discover", return_value=Mock()):
+        source = Source(executor=Mock(), name="source-test")
+
+    with pytest.raises(
+        AirbyteDirectConnectorNotSupportedError, match="direct entity actions"
+    ) as error_info:
+        source.as_direct_connector()
+
+    assert error_info.value.connector_name == "source-test"
+
+
+def test_hosted_direct_connector_inspect(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    """The hosted connector's `inspect()` returns the Agents API payload."""
+    details: AgentConnectorDetails = _cloud_source().as_direct_connector().inspect()
+    assert details.name == "GitHub"


### PR DESCRIPTION
## Summary

First step toward accessing agentic (entity/action) functions from the regular Cloud object graph instead of the parallel `AgentWorkspace`/`AgentOrganization`/`AgentConnector` primitives. Post-Fusion a Sonar connector for an external Cloud org *is* the Cloud actor (Sonar gates `execute` by `actor_id`), so `CloudSource.connector_id` maps 1:1 to the Agents connector ID and no lookup/conversion layer is needed.

Nomenclature: **"direct"** (direct connector, direct entity actions) is the prima-facie proposal; "agent"/"agentic" remain fallback names to reconsider before merge.

New public surface:

```python
# airbyte/direct
class DirectConnector(Protocol):        # inspect / execute / list_entities / iter_entities / search|get|create|update|delete_entity
class HostedDirectConnector(AgentConnector): ...   # hosted Agents API implementation

# airbyte/cloud/connectors.py
class CloudSource:
    def as_direct_connector(self, *, organization_id: str | None = None, verify: bool = True) -> HostedDirectConnector

# airbyte/sources/base.py
class Source:
    def as_direct_connector(self) -> DirectConnector   # always raises for now (clean failure point)

# airbyte/exceptions.py
class AirbyteDirectConnectorNotSupportedError(PyAirbyteError): connector_name, connector_id
```

`CloudSource.as_direct_connector()` reuses the workspace credentials, refuses non-public Cloud API roots (same rule as the existing Agents conversions), and with `verify=True` calls `inspect()`; a 403/404 is translated to `AirbyteDirectConnectorNotSupportedError` (not supported / not agent-enabled), other `AirbyteError`s propagate.

Organization routing: workspace credentials carry no `organization_id`, and the Agents API requires `X-Organization-Id` for multi-org credentials. Resolution order: explicit `organization_id` arg → the credentials' own org → one `CloudWorkspace.get_organization()` lookup.

Import cycle: `airbyte.agents`'s package `__init__` imports `airbyte.cloud.workspaces`, so `airbyte/cloud/connectors.py` cannot import `airbyte.direct`/`airbyte.agents` at module scope (it broke `from airbyte.cloud import CloudWorkspace`). Those imports are `TYPE_CHECKING`-only plus deferred inside `as_direct_connector()`. `DirectConnector` protocol members are `@abstractmethod` with docstring-only bodies (satisfies both CodeQL's "statement has no effect" and pyrefly's missing-return check).

`Source.as_direct_connector()` is the local-side bridge point; it raises until we decide whether local execution should depend on `airbyte-agent-sdk`'s `LocalExecutor`, vendor it, or stay hosted-only.

Deliberately out of scope here: MCP tools (`airbyte/mcp/agents.py`), skills methods, and deprecating the `Agent*` classes — follow-ups once the naming/shape is agreed. Supersedes the stale local-Sonar bridge in #873.

## Test plan

- `uv run pytest tests/unit_tests/test_direct.py tests/unit_tests/test_agents.py` (77 passed; includes explicit-org and resolved-org `X-Organization-Id` header assertions)
- `uv run python -c "from airbyte.cloud import CloudWorkspace"` and `uv run pytest tests/ --collect-only` (import cycle regression)
- `uv run ruff check`, `uv run pyrefly check` on touched files
- `uv run poe docs-generate` resolves the new `airbyte.direct` module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental direct connector interface for inspecting deployed connectors and performing entity actions, including searching, listing, creating, updating, and deleting entities.
  * Added support for creating direct connectors from Airbyte Cloud sources, including selecting an organization when needed.
  * Added clear errors when direct connector access is unavailable or unsupported.
* **Bug Fixes**
  * Added validation for supported Airbyte Cloud API configurations and connector access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Link to Devin session: https://app.devin.ai/sessions/7bed6499de3e47fa9aeb55affbaddd6a
Open in Devin Desktop: https://app.devin.ai/desktop/session/7bed6499de3e47fa9aeb55affbaddd6a?variant=devin
Requested by: @aaronsteers