### PR TITLE
chore(executors): address bot review nits from `#1143` and `#1144`

### DIFF
--- a/airbyte/_executors/declarative.py
+++ b/airbyte/_executors/declarative.py
@@ -86,9 +86,10 @@ class DeclarativeExecutor(Executor):
     def _config_from_args(self, args: list[str]) -> dict[str, Any]:
         """Read the connector config from the `--config <path>` CLI arg.
 
-        Returns an empty dict when the arg is absent (as for `spec`) or when the
-        referenced file cannot be read. Argument parsing and validation remain the
-        responsibility of the CDK entrypoint.
+        Returns an empty dict when the arg is absent (as for `spec`), when the
+        referenced file cannot be read, or when it does not contain a JSON object.
+        Argument parsing and validation remain the responsibility of the CDK
+        entrypoint.
         """
         if "--config" not in args:
             return {}
@@ -102,12 +103,12 @@ class DeclarativeExecutor(Executor):
             return {}
 
         try:
-            return cast(
-                "dict[str, Any]",
-                json.loads(config_path.read_text(encoding="utf-8")),
-            )
+            loaded = json.loads(config_path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return {}
+        if not isinstance(loaded, dict):
+            return {}
+        return loaded
 
     def _build_declarative_source(
         self,

--- a/tests/unit_tests/test_declarative_executor.py
+++ b/tests/unit_tests/test_declarative_executor.py
@@ -45,6 +45,17 @@ def test_config_from_args_reads_the_config_file(
     assert executor._config_from_args(args) == config
 
 
+def test_config_from_args_with_non_object_json(
+    executor: DeclarativeExecutor,
+    tmp_path: Path,
+) -> None:
+    """A config file with a non-object JSON root is ignored."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(["invalid"]))
+
+    assert executor._config_from_args(["check", "--config", str(config_path)]) == {}
+
+
 def test_config_from_args_without_config_flag(executor: DeclarativeExecutor) -> None:
     """`spec` takes no config, so there is nothing to read."""
     assert executor._config_from_args(["spec"]) == {}
@@ -59,7 +70,6 @@ def test_config_from_args_with_missing_file(executor: DeclarativeExecutor) -> No
 
 def test_declarative_source_receives_connector_config(
     executor: DeclarativeExecutor,
-    tmp_path: Path,
     mocker: Any,
 ) -> None:
     """The config read from args must reach the underlying CDK source."""
@@ -80,7 +90,7 @@ def test_declarative_source_receives_connector_config(
     assert captured["config"]["client_id"] == "abc"
 
 
-def test_injected_components_are_preserved(tmp_path: Path, mocker: Any) -> None:
+def test_injected_components_are_preserved(mocker: Any) -> None:
     """Connector config must merge with, not replace, injected components."""
     captured: dict[str, Any] = {}
 

--- a/tests/unit_tests/test_docker_executor.py
+++ b/tests/unit_tests/test_docker_executor.py
@@ -32,7 +32,11 @@ def test_map_cli_args_emits_posix_container_paths(tmp_path: Path) -> None:
     executor = _make_executor(tmp_path)
     mapped = executor.map_cli_args(["check", "--config", str(config_file)])
 
-    assert mapped == ["check", "--config", "/airbyte/tmp/config.json"]
+    assert mapped == [
+        "check",
+        "--config",
+        f"{DEFAULT_AIRBYTE_CONTAINER_TEMP_DIR}/config.json",
+    ]
 
 
 def test_map_cli_args_maps_nested_paths_with_posix_separators(tmp_path: Path) -> None:
@@ -45,7 +49,9 @@ def test_map_cli_args_maps_nested_paths_with_posix_separators(tmp_path: Path) ->
     executor = _make_executor(tmp_path)
     mapped = executor.map_cli_args([str(catalog_file)])
 
-    assert mapped == ["/airbyte/tmp/sub/dir/catalog.json"]
+    assert mapped == [
+        f"{DEFAULT_AIRBYTE_CONTAINER_TEMP_DIR}/sub/dir/catalog.json",
+    ]
 
 
 def test_map_cli_args_leaves_non_path_args_untouched(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-on to https://github.com/airbytehq/PyAirbyte/pull/1143 and https://github.com/airbytehq/PyAirbyte/pull/1144 (by @sagarrh), resolving the CodeRabbit/Copilot review nits left open on those PRs. Requested by AJ Steers.

Changes:
- `DeclarativeExecutor._config_from_args`: validate that the decoded `--config` JSON root is an object before returning it. Previously a `cast(...)` accepted any JSON value, so a list/scalar root would reach `{**self._config_dict, **config}` in `_build_declarative_source` and raise `TypeError`. Non-object roots now return `{}`, matching the existing behavior for unreadable/invalid files (the CDK entrypoint still owns real config validation).
  ```diff
  -    return cast("dict[str, Any]", json.loads(...))
  +    loaded = json.loads(...)
   except (OSError, ValueError):
       return {}
  +if not isinstance(loaded, dict):
  +    return {}
  +return loaded
  ```
- `test_declarative_executor.py`: add `test_config_from_args_with_non_object_json` regression test; drop unused `tmp_path` fixture params from two tests.
- `test_docker_executor.py`: build expected container paths from `DEFAULT_AIRBYTE_CONTAINER_TEMP_DIR` instead of hardcoding `/airbyte/tmp`.

No behavior change for valid configs.

## Test plan

- `uv run pytest tests/unit_tests/test_declarative_executor.py tests/unit_tests/test_docker_executor.py` — 10 passed
- `uv run ruff format --check .` / `uv run ruff check` on changed files — clean
- `mypy airbyte/_executors/declarative.py` — clean

Link to Devin session: https://app.devin.ai/sessions/c5c4a30a83184cba9584a2eba1c2ae25
Open in Devin Desktop: https://app.devin.ai/desktop/session/c5c4a30a83184cba9584a2eba1c2ae25?variant=devin
Requested by: @aaronsteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid configuration files with a non-object JSON root, such as a list or scalar, are now safely ignored instead of causing configuration parsing issues.

- **Tests**
  - Added coverage for invalid configuration formats.
  - Updated container path checks to remain aligned with the configured temporary directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._