### PR TITLE
fix: parse dates on load by declared type, not column name

### DIFF
--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -896,11 +896,26 @@ class SqlProcessorBase(abc.ABC):
         to improve performance.
         """
         temp_table_name = self._create_table_for_loading(stream_name, batch_id)
-        for file_path in files:
-            dataframe = pd.read_json(file_path, lines=True)
+        sql_column_definitions: dict[str, TypeEngine] = self._get_sql_column_definitions(
+            stream_name
+        )
 
-            sql_column_definitions: dict[str, TypeEngine] = self._get_sql_column_definitions(
-                stream_name
+        # Parse dates only where the schema says date-time. `pd.read_json`
+        # otherwise coerces by column NAME (`date`, `_at`, `_time`), which
+        # turns a numeric column into a datetime and breaks the insert
+        # against the DECIMAL column this same schema created.
+        datetime_columns: list[str] = [
+            column_name
+            for column_name, sql_type in sql_column_definitions.items()
+            if isinstance(sql_type, sqlalchemy.types.DateTime)
+        ]
+
+        for file_path in files:
+            dataframe = pd.read_json(
+                file_path,
+                lines=True,
+                convert_dates=datetime_columns,
+                keep_default_dates=False,
             )
 
             # Remove fields that are not in the schema

--- a/tests/unit_tests/test_numeric_date_columns.py
+++ b/tests/unit_tests/test_numeric_date_columns.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Date parsing on load follows the declared type, not the column name."""
+
+from __future__ import annotations
+
+import io
+
+import pandas as pd
+import sqlalchemy
+
+from airbyte.types import SQLTypeConverter
+
+
+def _read(row: str, datetime_columns: list[str]) -> pd.DataFrame:
+    """Read one JSONL record the way the SQL processor now does."""
+    return pd.read_json(
+        io.StringIO(row),
+        lines=True,
+        convert_dates=datetime_columns,
+        keep_default_dates=False,
+    )
+
+
+def _declared_datetime_columns(schema: dict[str, dict]) -> list[str]:
+    """The columns a stream's JSON schema declares as timestamps."""
+    converter = SQLTypeConverter()
+    return [
+        name
+        for name, prop in schema.items()
+        if isinstance(converter.to_sql_type(prop), sqlalchemy.types.DateTime)
+    ]
+
+
+class TestSchemaDrivenDateParsing:
+    def test_numeric_column_named_date_stays_numeric(self) -> None:
+        """Epoch milliseconds in a column called `date`, declared a number."""
+        schema = {"date": {"type": "number"}, "id": {"type": "string"}}
+        row = '{"date": 1788528600000, "id": "abc"}'
+
+        frame = _read(row, _declared_datetime_columns(schema))
+
+        assert frame["date"].dtype == "int64"
+        assert frame["date"].iloc[0] == 1788528600000
+
+    def test_numeric_column_ending_in_at_stays_numeric(self) -> None:
+        """`_at` is one of pandas' default date-like suffixes."""
+        schema = {"score_at": {"type": "number"}}
+        frame = _read('{"score_at": 1788528600000}', _declared_datetime_columns(schema))
+        assert frame["score_at"].dtype == "int64"
+
+    def test_declared_timestamp_is_still_parsed(self) -> None:
+        """Declared date-time still becomes a timestamp."""
+        schema = {"updated_at": {"type": "string", "format": "date-time"}}
+        frame = _read(
+            '{"updated_at": "2026-09-04T13:30:00.000Z"}',
+            _declared_datetime_columns(schema),
+        )
+        assert "datetime64" in str(frame["updated_at"].dtype)
+
+    def test_declared_timestamp_sent_as_epoch_is_still_parsed(self) -> None:
+        """Declared date-time sent as an epoch still parses, so nothing regresses."""
+        schema = {"occurred_at": {"type": "string", "format": "date-time"}}
+        frame = _read(
+            '{"occurred_at": 1788528600000}', _declared_datetime_columns(schema)
+        )
+        assert "datetime64" in str(frame["occurred_at"].dtype)
+
+    def test_name_alone_does_not_decide(self) -> None:
+        """Same value, different declared types, different results."""
+        schema = {
+            "date": {"type": "number"},
+            "captured_at": {"type": "string", "format": "date-time"},
+        }
+        row = '{"date": 1788528600000, "captured_at": 1788528600000}'
+
+        frame = _read(row, _declared_datetime_columns(schema))
+
+        assert frame["date"].dtype == "int64", "declared a number"
+        assert "datetime64" in str(frame["captured_at"].dtype), "declared date-time"
+
+    def test_conversion_no_longer_depends_on_the_values(self) -> None:
+        """The same declared type gives the same column type every batch."""
+        schema = {"end_time": {"type": "number"}}
+        columns = _declared_datetime_columns(schema)
+
+        small = _read('{"end_time": 900}', columns)
+        epoch_sized = _read('{"end_time": 1788528600000}', columns)
+
+        assert small["end_time"].dtype == epoch_sized["end_time"].dtype == "int64"
+
+
+class TestPandasDefaultIsTheBug:
+    """Pin the pandas behaviour being corrected."""
+
+    def test_pandas_default_coerces_by_name(self) -> None:
+        """Same value, three names, three outcomes."""
+        row = (
+            '{"date": 1788528600000, "score_at": 1788528600000, '
+            '"plain_num": 1788528600000}'
+        )
+        frame = pd.read_json(io.StringIO(row), lines=True)
+
+        assert "datetime64" in str(frame["date"].dtype)
+        assert "datetime64" in str(frame["score_at"].dtype)
+        assert frame["plain_num"].dtype == "int64"


### PR DESCRIPTION
## What

`pd.read_json` defaults to `convert_dates=True`, which coerces a column into a timestamp based on its **name** — `date`, `datetime`, `modified`, or anything ending in `_at` or `_time` — whenever the values happen to look like epochs.

That contradicts the stream's schema, which the same function passes to `to_sql` as `dtype` a few lines below. A numeric column named `date` is created `DECIMAL` from the schema and then arrives as a datetime:

```
column "date" is of type numeric but expression is of type timestamp without time zone
```

Same value, three names, three outcomes — none of them the declared type:

```python
row = '{"date": 1788528600000, "score_at": 1788528600000, "plain_num": 1788528600000}'
pd.read_json(io.StringIO(row), lines=True).dtypes

date         datetime64[ns]     <- coerced, because it is called "date"
score_at     datetime64[ns]     <- coerced, because it ends in "_at"
plain_num    int64              <- identical value, left alone
```

It is also **value-dependent**, which is the worse half: a numeric column named `end_time` loads as `int64` when its values are small and as a timestamp when they look like epochs. The same column can therefore change type between syncs depending on what a batch happened to contain.

## Fix

Limit date parsing to the columns the schema declares as `date-time`:

```python
datetime_columns = [
    name for name, sql_type in sql_column_definitions.items()
    if isinstance(sql_type, sqlalchemy.types.DateTime)
]
pd.read_json(file_path, lines=True,
             convert_dates=datetime_columns, keep_default_dates=False)
```

`_get_sql_column_definitions()` was already called in this function; it just moved above the read.

## Why not `convert_dates=False`

That would break connectors which declare a field as `date-time` but emit an epoch **number** — pandas currently rescues that mismatch by accident, and disabling conversion outright would send an integer into a `TIMESTAMP` column.

The schema-driven version keeps those working. The only behaviour that changes is conversions that **contradict** the declared type, so this is strictly narrowing:

| | before | after |
| --- | --- | --- |
| numeric `date` / `created_at` | coerced to timestamp was ✘ | stays numeric ✓ |
| declared `date-time`, ISO string | parsed ✓| parsed ✓|
| declared `date-time`, epoch number | parsed ✓| parsed ✓|

## Tests

`tests/unit_tests/test_numeric_date_columns.py` — 7 tests, verified to fail against the default behaviour. They cover both directions, including the value-dependence and the epoch-declared-as-date-time case that must keep working.

```
7 passed          test_numeric_date_columns.py
751 passed        tests/unit_tests
ruff check        All checks passed
```

Found while loading a connector whose `date` field is epoch milliseconds alongside a separate ISO `dateString` field — the first failed the insert, the second loaded correctly, purely because of their names.

One pre-existing failure in `test_progress.py::test_get_time_str` is unrelated and present on clean `main`: `_to_time_str()` renders local time while the test uses `freeze_time`, so it fails on any non-UTC machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric fields with names like `date` or ending in `_at` are no longer incorrectly converted to timestamps.
  * Date parsing now follows the declared schema, including support for epoch-based timestamp values.
  * Prevents type mismatches when loading numeric data into database tables.

* **Tests**
  * Added coverage for schema-based date parsing and numeric column handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->