### PR TITLE
feat(mcp): support `sql_select` action on agent connector tools

### DIFF
--- a/airbyte/agents/models.py
+++ b/airbyte/agents/models.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from airbyte.exceptions import PyAirbyteInputError
 
@@ -165,6 +165,11 @@ class AgentExecuteResult(BaseModel):
 
     warning: dict[str, Any] | None = None
     """A warning reported alongside an otherwise successful result."""
+
+    @field_validator("connector_metadata", "execution_metadata", mode="before")
+    @classmethod
+    def _none_to_empty(cls, value: object) -> object:
+        return {} if value is None else value
 
     @property
     def entities(self) -> list[dict[str, Any]]:

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -329,9 +329,9 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
             workspace_id=workspace_id,
             organization_id=organization_id,
         ).execute(
-            entity_type,
-            action,
-            _resolve_api_args(api_args),
+            entity_type=entity_type,
+            action=action,
+            api_args=_resolve_api_args(api_args),
             select_fields=resolve_list_of_strings(select_fields),
             exclude_fields=resolve_list_of_strings(exclude_fields),
             page_size=page_size,

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -324,10 +324,10 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
 
     try:
         result = _get_agent_connector(
-            ctx,
-            connector_id,
-            workspace_id,
-            organization_id,
+            ctx=ctx,
+            connector_id=connector_id,
+            workspace_id=workspace_id,
+            organization_id=organization_id,
         ).execute(
             entity_type,
             action,

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -47,7 +47,7 @@ from airbyte.constants import (
 from airbyte.exceptions import AirbyteError, PyAirbyteInputError
 from airbyte.mcp._arg_resolvers import resolve_list_of_strings
 from airbyte.mcp._tool_utils import AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET
-from airbyte.mcp.cloud import _add_defaults_for_exclude_args
+from airbyte.mcp.cloud import _add_defaults_for_exclude_args, _get_cloud_workspace
 
 
 AgentReadAction = Literal["list", "get", "search", "api_search", "sql_select"]
@@ -270,8 +270,6 @@ def _get_agent_connector(
     connector_id: str,
     workspace_id: str | None = None,
     organization_id: str | None = None,
-    *,
-    verify_in_workspace: bool = True,
 ) -> AgentConnector:
     """Get an `AgentConnector` from its workspace, using MCP config.
 
@@ -279,14 +277,22 @@ def _get_agent_connector(
     its workspace anyway, so a connector ID belonging to another workspace raises before
     any action runs.
 
-    Destination connectors targeted by `sql_select` are not listed by the workspace connectors
-    endpoint, so they are addressed by ID alone and the Agents API enforces workspace/org
-    authorization.
+    Destination connectors (targets of `sql_select`) are not listed by the Agents API, so IDs it
+    does not know are verified against the Cloud workspace's destinations instead.
     """
     workspace = _get_agent_workspace(ctx, workspace_id, organization_id)
-    if verify_in_workspace:
+    try:
         return workspace.get_connector(connector_id)
-    return workspace.get_connector(connector_id=connector_id)
+    except AirbyteError as error:
+        if error.get_message() != "No connector found with the given ID or name.":
+            raise
+        cloud_destination_ids = {
+            destination.connector_id
+            for destination in _get_cloud_workspace(ctx, workspace.workspace_id).list_destinations()
+        }
+        if connector_id not in cloud_destination_ids:
+            raise
+        return workspace.get_connector(connector_id=connector_id)
 
 
 def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
@@ -322,7 +328,6 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
             connector_id,
             workspace_id,
             organization_id,
-            verify_in_workspace=action != "sql_select",
         ).execute(
             entity_type,
             action,

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -270,14 +270,23 @@ def _get_agent_connector(
     connector_id: str,
     workspace_id: str | None = None,
     organization_id: str | None = None,
+    *,
+    verify_in_workspace: bool = True,
 ) -> AgentConnector:
     """Get an `AgentConnector` from its workspace, using MCP config.
 
     The Agents API addresses a connector by ID alone, but the connector is fetched through
     its workspace anyway, so a connector ID belonging to another workspace raises before
     any action runs.
+
+    Destination connectors targeted by `sql_select` are not listed by the workspace connectors
+    endpoint, so they are addressed by ID alone and the Agents API enforces workspace/org
+    authorization.
     """
-    return _get_agent_workspace(ctx, workspace_id, organization_id).get_connector(connector_id)
+    workspace = _get_agent_workspace(ctx, workspace_id, organization_id)
+    if verify_in_workspace:
+        return workspace.get_connector(connector_id)
+    return workspace.get_connector(connector_id=connector_id)
 
 
 def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
@@ -308,7 +317,13 @@ def _execute(  # noqa: PLR0913  # Mirrors the tool signatures it serves.
         )
 
     try:
-        result = _get_agent_connector(ctx, connector_id, workspace_id, organization_id).execute(
+        result = _get_agent_connector(
+            ctx,
+            connector_id,
+            workspace_id,
+            organization_id,
+            verify_in_workspace=action != "sql_select",
+        ).execute(
             entity_type,
             action,
             _resolve_api_args(api_args),

--- a/airbyte/mcp/agents.py
+++ b/airbyte/mcp/agents.py
@@ -50,14 +50,20 @@ from airbyte.mcp._tool_utils import AIRBYTE_CLOUD_WORKSPACE_ID_IS_SET
 from airbyte.mcp.cloud import _add_defaults_for_exclude_args
 
 
-AgentReadAction = Literal["list", "get", "search", "api_search"]
+AgentReadAction = Literal["list", "get", "search", "api_search", "sql_select"]
 """The connector actions that only read data.
+
+The `sql_select` action runs one read-only SQL statement (or `SHOW TABLES`) on the query
+engine behind a destination connector. Pass `sql` and `sql_dialect` (and optionally
+`dry_run`) in `api_args`; `entity_type` is ignored for this action.
 
 The `download` action is deliberately absent even though it reads: it returns a binary
 stream rather than JSON, which PyAirbyte does not yet support.
 """
 
-AgentAction = Literal["list", "get", "search", "api_search", "create", "update", "delete"]
+AgentAction = Literal[
+    "list", "get", "search", "api_search", "sql_select", "create", "update", "delete"
+]
 """Every connector action callable through the MCP layer, including writes."""
 
 AGENTS_AUTH_TIP_TEXT = (
@@ -495,7 +501,14 @@ def execute_agent_connector_ro(  # noqa: PLR0913  # Explicit args are the point 
     ],
     action: Annotated[
         AgentReadAction,
-        Field(description="The read action to run against the entity type."),
+        Field(
+            description=(
+                "The read action to run against the entity type. "
+                "For `sql_select`, pass `sql` and `sql_dialect` (snowflake, bigquery, athena, "
+                "trino) "
+                "in `api_args` and any value for `entity_type`."
+            ),
+        ),
     ],
     api_args: Annotated[
         dict[str, Any] | str | None,
@@ -600,7 +613,14 @@ def execute_agent_connector(  # noqa: PLR0913  # Explicit args are the point of 
     ],
     action: Annotated[
         AgentAction,
-        Field(description="The action to run against the entity type."),
+        Field(
+            description=(
+                "The action to run against the entity type. "
+                "For `sql_select`, pass `sql` and `sql_dialect` (snowflake, bigquery, athena, "
+                "trino) "
+                "in `api_args` and any value for `entity_type`."
+            ),
+        ),
     ],
     api_args: Annotated[
         dict[str, Any] | str | None,

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 from airbyte.agents import _api_util
 from airbyte.agents.connectors import AgentConnector
-from airbyte.agents.models import AgentExecuteResult
+from airbyte.agents.models import AgentConnectorMetadata, AgentExecuteResult
 from airbyte.agents.organizations import AgentOrganization
 from airbyte.agents.workspaces import AgentWorkspace
 from airbyte.cloud._credentials import _AirbyteCredentials
@@ -332,6 +332,21 @@ def test_entities(
             _ = result.entities
     else:
         assert result.entities == expectation
+
+
+def test_execute_result_accepts_null_metadata() -> None:
+    """`AgentExecuteResult` accepts null metadata from the Agents API."""
+    result = AgentExecuteResult.model_validate({
+        "status": "success",
+        "result": {"data": [], "meta": {}},
+        "connector_metadata": None,
+        "execution_metadata": None,
+        "bundle": None,
+    })
+
+    assert result.connector_metadata == AgentConnectorMetadata()
+    assert result.has_next_page is False
+    assert result.end_cursor is None
 
 
 def test_inspect(captured_requests: list[dict[str, Any]]) -> None:

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -101,7 +101,12 @@ def connector(monkeypatch: pytest.MonkeyPatch) -> _AgentConnectorLike:
     monkeypatch.setattr(
         agents_mcp,
         "_get_agent_connector",
-        lambda ctx, connector_id, workspace_id=None, organization_id=None: stub,
+        lambda ctx,
+        connector_id,
+        workspace_id=None,
+        organization_id=None,
+        *,
+        verify_in_workspace=True: stub,
     )
     return stub
 
@@ -152,6 +157,53 @@ def test_execute_result_is_shaped_for_agents(connector: _AgentConnectorLike) -> 
     assert result.has_next_page is True
     assert result.end_cursor == "cursor-2"
     assert result.execution_time_ms == 42
+
+
+def test_execute_sql_select_addresses_connector_by_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify `sql_select` does not list workspace connectors before execution."""
+    _patch_mcp_config(monkeypatch)
+
+    def fail_list_connectors(self) -> list[Any]:
+        raise AssertionError("workspace connectors were listed")
+
+    monkeypatch.setattr(
+        agents_mcp.AgentWorkspace,
+        "list_connectors",
+        fail_list_connectors,
+    )
+    monkeypatch.setattr(
+        agents_mcp.AgentConnector,
+        "execute",
+        lambda self, *args, **kwargs: AgentExecuteResult(status="success", result=[]),
+    )
+
+    result = _execute(
+        action="sql_select",
+        api_args={"sql": "SELECT 1", "sql_dialect": "snowflake"},
+    )
+
+    assert result.status == "success"
+
+
+def test_execute_list_uses_positional_connector_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify non-SQL actions keep the workspace-validating connector lookup."""
+    _patch_mcp_config(monkeypatch)
+    connector = _AgentConnectorLike()
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def get_connector(self, *args: Any, **kwargs: Any) -> _AgentConnectorLike:
+        calls.append((args, kwargs))
+        return connector
+
+    monkeypatch.setattr(agents_mcp.AgentWorkspace, "get_connector", get_connector)
+
+    _execute(action="list")
+
+    assert calls == [(("connector-id",), {})]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -31,14 +31,14 @@ class _AgentConnectorLike:
 
     def execute(
         self,
-        entity: str,
+        entity_type: str,
         action: str,
         api_args: dict[str, Any] | None = None,
         **kwargs: Any,  # noqa: ANN401  # Forwarded verbatim to the recorded call.
     ) -> AgentExecuteResult:
         """Record the call and return a fixed successful result."""
         self.calls.append({
-            "entity": entity,
+            "entity": entity_type,
             "action": action,
             "api_args": api_args,
             **kwargs,

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -232,7 +232,7 @@ def test_read_only_tool_action_type_excludes_writes() -> None:
     """Verify the read-only tool's action type offers no write or download actions."""
     read_actions = set(agents_mcp.get_args(agents_mcp.AgentReadAction))
 
-    assert read_actions == {"list", "get", "search", "api_search"}
+    assert read_actions == {"list", "get", "search", "api_search", "sql_select"}
     assert "download" not in set(agents_mcp.get_args(agents_mcp.AgentAction))
 
 

--- a/tests/unit_tests/test_mcp_agents.py
+++ b/tests/unit_tests/test_mcp_agents.py
@@ -101,12 +101,7 @@ def connector(monkeypatch: pytest.MonkeyPatch) -> _AgentConnectorLike:
     monkeypatch.setattr(
         agents_mcp,
         "_get_agent_connector",
-        lambda ctx,
-        connector_id,
-        workspace_id=None,
-        organization_id=None,
-        *,
-        verify_in_workspace=True: stub,
+        lambda ctx, connector_id, workspace_id=None, organization_id=None: stub,
     )
     return stub
 
@@ -159,19 +154,24 @@ def test_execute_result_is_shaped_for_agents(connector: _AgentConnectorLike) -> 
     assert result.execution_time_ms == 42
 
 
-def test_execute_sql_select_addresses_connector_by_id(
+def test_execute_sql_select_falls_back_to_cloud_destinations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify `sql_select` does not list workspace connectors before execution."""
+    """Verify `sql_select` falls back to Cloud destinations when Agents listing omits one."""
     _patch_mcp_config(monkeypatch)
+    monkeypatch.setattr(agents_mcp.AgentWorkspace, "list_connectors", lambda self: [])
 
-    def fail_list_connectors(self) -> list[Any]:
-        raise AssertionError("workspace connectors were listed")
+    class _CloudDestination:
+        connector_id = "connector-id"
+
+    class _CloudWorkspace:
+        def list_destinations(self) -> list[_CloudDestination]:
+            return [_CloudDestination()]
 
     monkeypatch.setattr(
-        agents_mcp.AgentWorkspace,
-        "list_connectors",
-        fail_list_connectors,
+        agents_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id: _CloudWorkspace(),
     )
     monkeypatch.setattr(
         agents_mcp.AgentConnector,
@@ -185,6 +185,51 @@ def test_execute_sql_select_addresses_connector_by_id(
     )
 
     assert result.status == "success"
+
+
+def test_execute_unknown_connector_raises_when_not_a_cloud_destination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify an unknown connector still raises after the Cloud destination fallback."""
+    _patch_mcp_config(monkeypatch)
+    monkeypatch.setattr(agents_mcp.AgentWorkspace, "list_connectors", lambda self: [])
+
+    class _CloudWorkspace:
+        def list_destinations(self) -> list[Any]:
+            return []
+
+    monkeypatch.setattr(
+        agents_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id: _CloudWorkspace(),
+    )
+
+    with pytest.raises(
+        AirbyteError, match="No connector found with the given ID or name"
+    ):
+        _execute(action="sql_select")
+
+
+def test_execute_connector_lookup_error_is_not_treated_as_missing_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify unrelated connector lookup errors do not trigger Cloud destination fallback."""
+    _patch_mcp_config(monkeypatch)
+
+    def raise_lookup_error(self: Any) -> list[Any]:
+        raise AirbyteError(message="Connector listing failed.")
+
+    monkeypatch.setattr(
+        agents_mcp.AgentWorkspace, "list_connectors", raise_lookup_error
+    )
+    monkeypatch.setattr(
+        agents_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id: pytest.fail("Cloud fallback should not run"),
+    )
+
+    with pytest.raises(AirbyteError, match="Connector listing failed"):
+        _execute(action="sql_select")
 
 
 def test_execute_list_uses_positional_connector_lookup(
@@ -383,6 +428,15 @@ def test_connector_resolution_validates_workspace_scope(
             AgentConnector(connector_id=connector_id, credentials=self._credentials)  # noqa: SLF001
             for connector_id in workspace_connector_ids
         ],
+    )
+    monkeypatch.setattr(
+        agents_mcp,
+        "_get_cloud_workspace",
+        lambda ctx, workspace_id: type(
+            "_CloudWorkspace",
+            (),
+            {"list_destinations": lambda self: []},
+        )(),
     )
 
     if expect_error:


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Lets agents run the new passthrough SQL action against destination connectors through the MCP connector tools. Previously the tools rejected the action outright, could not find destination connectors at all, and choked on the metadata shape the live API returns for SQL results.

Specifically, this adds `"sql_select"` to `AgentReadAction` / `AgentAction`, adds a Cloud-workspace destination fallback in `_get_agent_connector`, and makes `AgentExecuteResult` accept `null` for `connector_metadata` / `execution_metadata`.

</td></tr></table>

Requested by AJ Steers (@aaronsteers) to validate passthrough SQL end-to-end via `cloud-mcp-preview`.

## Changes

- Add `sql_select` to `AgentReadAction` (read-only tool) and `AgentAction`; extend the `action` descriptions so agents pass `sql`, `sql_dialect`, and optional `dry_run` in `api_args` (`entity_type` is ignored server-side). No plumbing change: `api_args` already flows into request `params`.
- `_get_agent_connector`: destinations are not listed by the Agents API, so when the Agents workspace lookup raises "No connector found", check `CloudWorkspace.list_destinations()` for the same workspace; if the ID is a destination there, build an explicit-ID `AgentConnector`, otherwise re-raise. Unrelated `AirbyteError`s are not swallowed. No bypass flag (`verify_in_workspace` was removed per review).
- `AgentExecuteResult`: `field_validator(mode="before")` maps `None` → `{}` for `connector_metadata` / `execution_metadata` (the live API returns `null` for SQL results), so `has_next_page` / `end_cursor` keep working.
- Call sites use keyword args for `_get_agent_connector(...)` and `.execute(...)`.

## Review Spotlight

Reviewers with limited time, please review first:
- [`agents.py` `_get_agent_connector`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789078510-mcp-sql-select/airbyte/mcp/agents.py#L268-L295): the Cloud-destination fallback and its error filter
- [`models.py` `_none_to_empty`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789078510-mcp-sql-select/airbyte/agents/models.py): null-metadata normalization

## Risks

- The fallback is action-agnostic (applies to any action whose connector ID is a Cloud destination in the caller's workspace). Membership is still validated; which actions a destination supports is enforced server-side by the Agents API. Discussed and accepted in review.

## Test plan

- `uv run pytest tests/unit_tests/test_mcp_agents.py tests/unit_tests/test_agents.py` (39 + 67 passed)
- `uv run ruff check` / `ruff format --check` on touched files; `mypy airbyte/agents/models.py`
- Live: `cloud-mcp-preview` deployed from `f2a2946` and exercised via `execute_agent_connector_ro` against real Snowflake and BigQuery destinations: `SELECT`, `dry_run`, `CURRENT_TIMESTAMP`, write-SQL rejection, and wrong-dialect rejection all behave identically to the direct `api.airbyte.ai` calls. (`SHOW TABLES` failures observed are destination/Sonar-side and unrelated to this PR.)


Link to Devin session: https://app.devin.ai/sessions/7a60f936d7984f659f5ff4722d0ee6ee
Open in Devin Desktop: https://app.devin.ai/desktop/session/7a60f936d7984f659f5ff4722d0ee6ee?variant=devin