### PR TITLE
ci: deploy `cloud-mcp-preview` on every publish, not just prereleases

### DIFF
--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -27,6 +27,13 @@ on:
         description: 'Whether to deploy the preview service instead of production ("true" or "false").'
         required: true
         type: string
+    secrets:
+      OCTAVIA_BOT_APP_ID:
+        description: 'GitHub App ID used to dispatch the airbyte-ops-mcp deploy workflow.'
+        required: true
+      OCTAVIA_BOT_PRIVATE_KEY:
+        description: 'Private key for the GitHub App above.'
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/deploy_cloud_mcp.yml
+++ b/.github/workflows/deploy_cloud_mcp.yml
@@ -8,8 +8,8 @@
 # - push (main) - Every merge refreshes cloud-mcp-preview with that commit,
 #   installed straight from git so no PyPI release is needed.
 # - workflow_call - `pypi_publish.yml` calls this after a publish to ship the
-#   published version: a public release goes to production, a prerelease to
-#   the preview service.
+#   published version: every publish refreshes the preview service, and a
+#   public release also goes to production.
 
 name: Deploy Cloud MCP
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -80,13 +80,27 @@ jobs:
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  # A publish ships the exact published version to cloud-mcp: a public release
-  # promotes it to production, while a GitHub prerelease or an on-demand
-  # prerelease build only refreshes the preview service.
+  # A publish ships the exact published version to cloud-mcp. Every publish
+  # refreshes the preview service, so preview always reports the newest
+  # published version rather than a post-release git build of the prior one.
+  deploy_cloud_mcp_preview:
+    name: Deploy Cloud MCP Preview
+    needs: publish_to_pypi
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy_cloud_mcp.yml
+    secrets: inherit
+    with:
+      pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
+      preview: 'true'
+
+  # A public (non-prerelease) release additionally promotes the version to
+  # production.
   deploy_cloud_mcp:
     name: Deploy Cloud MCP
     needs: publish_to_pypi
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+    if: github.event_name == 'release' && github.event.release.prerelease != true
     # The dispatch to airbyte-ops-mcp is authenticated with a GitHub App token,
     # not `GITHUB_TOKEN`, so this job needs nothing beyond reading the workflow.
     permissions:
@@ -94,5 +108,5 @@ jobs:
     uses: ./.github/workflows/deploy_cloud_mcp.yml
     secrets: inherit
     with:
-      pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
-      preview: ${{ (github.event_name == 'release' && github.event.release.prerelease != true) && 'false' || 'true' }}
+      pyairbyte-version: ${{ github.event.release.tag_name }}
+      preview: 'false'

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -90,7 +90,9 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/deploy_cloud_mcp.yml
-    secrets: inherit
+    secrets:
+      OCTAVIA_BOT_APP_ID: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+      OCTAVIA_BOT_PRIVATE_KEY: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
     with:
       pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
       preview: ${{ 'true' }}
@@ -106,7 +108,9 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/deploy_cloud_mcp.yml
-    secrets: inherit
+    secrets:
+      OCTAVIA_BOT_APP_ID: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+      OCTAVIA_BOT_PRIVATE_KEY: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
     with:
       pyairbyte-version: ${{ github.event.release.tag_name }}
       preview: ${{ 'false' }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -93,7 +93,7 @@ jobs:
     secrets: inherit
     with:
       pyairbyte-version: ${{ github.event.release.tag_name || github.event.inputs.version_override }}
-      preview: 'true'
+      preview: ${{ 'true' }}
 
   # A public (non-prerelease) release additionally promotes the version to
   # production.
@@ -109,4 +109,4 @@ jobs:
     secrets: inherit
     with:
       pyairbyte-version: ${{ github.event.release.tag_name }}
-      preview: 'false'
+      preview: ${{ 'false' }}


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Publishing a PyAirbyte release now redeploys the Cloud MCP preview service too, so preview reports the real released version instead of a post-release git build of the previous one.

Specifically, `pypi_publish.yml` gains a `deploy_cloud_mcp_preview` job that always calls `deploy_cloud_mcp.yml` with `preview: 'true'`, and the existing `deploy_cloud_mcp` job now only runs for public (non-prerelease) `release` events with `preview: 'false'`.

</td></tr></table>

Requested by AJ Steers (@aaronsteers) in Slack.

## Changes

- `pypi_publish.yml`: split the single conditional deploy job into `deploy_cloud_mcp_preview` (every publish: release, prerelease, on-demand `workflow_dispatch` with `publish=true`) and `deploy_cloud_mcp` (public releases only).
- `deploy_cloud_mcp.yml`: header comment updated to match, and `OCTAVIA_BOT_APP_ID` / `OCTAVIA_BOT_PRIVATE_KEY` declared as required `workflow_call.secrets`.
- Both caller jobs pass those two secrets explicitly instead of `secrets: inherit` (per review).

## Review Spotlight

Reviewers with limited time, please review first:
- [`pypi_publish.yml#L83-L112`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789084859-release-deploys-preview/.github/workflows/pypi_publish.yml#L83-L112): the two deploy jobs and their `if` conditions.

## Before / after

- Before: push to `main` -> preview (git install, version reads as `<prior>.postN`); public release -> production only; prerelease -> preview only.
- After: push to `main` -> preview (unchanged); public release -> production **and** preview at `airbyte==<version>`; prerelease -> preview (unchanged).

## Risks

- Callers must now pass the two secrets explicitly; `pypi_publish.yml` is the only caller in this repo.
- The two jobs run in parallel on a public release and dispatch two `repository_dispatch` events to `airbyte-ops-mcp`; they use different `concurrency` groups (`deploy-cloud-mcp-true` / `-false`) so they do not cancel each other.

## Test plan

- `actionlint` on both workflow files passes.
- Not exercised end-to-end; the next release will show both `Deploy Cloud MCP` and `Deploy Cloud MCP Preview` jobs in the `Publish Package` run, each dispatching a `deploy-cloud-mcp` event visible in `airbyte-ops-mcp`'s `Deploy MCP Server` runs.


Link to Devin session: https://app.devin.ai/sessions/7a60f936d7984f659f5ff4722d0ee6ee
Open in Devin Desktop: https://app.devin.ai/desktop/session/7a60f936d7984f659f5ff4722d0ee6ee?variant=devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment**
  - PyPI publishes now automatically refresh the preview service.
  - Prerelease and manually triggered publishes deploy to preview.
  - Public, non-prerelease releases deploy to both preview and production.
  - Production deployments use the published release version.
  - Production deployment is limited to public releases and does not occur for prereleases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->