### PR TITLE
feat(cloud-mcp): add one-step `get_default_cloud_context` MCP tool; feat(cloud): add `privilege_scope` to `list_workspaces`

### DIFF
--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -106,7 +106,12 @@ def _wrap_sdk_error(error: SDKError, base_context: dict[str, Any] | None = None)
     """
     sdk_context = _get_sdk_error_context(error)
     merged_context = {**(base_context or {}), **sdk_context}
-    return AirbyteError(
+    error_type = (
+        AirbyteMissingResourceError
+        if sdk_context.get("status_code") == HTTPStatus.NOT_FOUND
+        else AirbyteError
+    )
+    return error_type(
         message=f"API error occurred: {error.message}",
         context=merged_context,
     )

--- a/airbyte/_util/api_util.py
+++ b/airbyte/_util/api_util.py
@@ -2890,8 +2890,10 @@ def get_user_id_from_bearer_token(bearer_token: SecretString) -> str:
 
     user_id = payload.get("user_id") if isinstance(payload, dict) else None
     if not isinstance(user_id, str) or not user_id:
+        user_id = payload.get("sub") if isinstance(payload, dict) else None
+    if not isinstance(user_id, str) or not user_id:
         raise PyAirbyteInputError(
-            message="The bearer token does not contain a user ID.",
+            message="The bearer token does not contain a user_id or sub claim.",
             guidance="Provide a bearer token issued for an Airbyte user.",
         )
     return user_id

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -88,6 +88,7 @@ from airbyte.cloud.client import CloudClient
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
 from airbyte.cloud.models import (
+    CloudDefaultContextInfo,
     CloudWorkspaceInfo,
     JobStatusEnum,
     JobTypeEnum,
@@ -127,6 +128,7 @@ __all__ = [
     "CloudWorkspace",
     "CloudConnection",
     "CloudClientConfig",
+    "CloudDefaultContextInfo",
     "CloudWorkspaceInfo",
     "SyncResult",
     # Enums

--- a/airbyte/cloud/__init__.py
+++ b/airbyte/cloud/__init__.py
@@ -87,7 +87,12 @@ from typing import TYPE_CHECKING
 from airbyte.cloud.client import CloudClient
 from airbyte.cloud.client_config import CloudClientConfig
 from airbyte.cloud.connections import CloudConnection
-from airbyte.cloud.models import CloudWorkspaceInfo, JobStatusEnum, JobTypeEnum
+from airbyte.cloud.models import (
+    CloudWorkspaceInfo,
+    JobStatusEnum,
+    JobTypeEnum,
+    WorkspacePrivilegeScope,
+)
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.sync_results import SyncResult
 from airbyte.cloud.workspaces import CloudWorkspace
@@ -127,4 +132,5 @@ __all__ = [
     # Enums
     "JobStatusEnum",
     "JobTypeEnum",
+    "WorkspacePrivilegeScope",
 ]

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -345,7 +345,7 @@ class CloudClient:
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
-    def list_workspaces(  # noqa: PLR0912, PLR0913, PLR0915
+    def list_workspaces(  # noqa: C901, PLR0912, PLR0913, PLR0915
         self,
         name: str | None = None,
         *,
@@ -399,30 +399,31 @@ class CloudClient:
                 message="You can provide name or name_contains, but not both."
             )
         if member_only:
-            workspaces = [
-                CloudWorkspaceInfo.from_api_response(
+            workspace_ids = self._get_direct_workspace_ids()
+            if limit is not None and name is None and name_contains is None and name_filter is None:
+                workspace_ids = workspace_ids[:limit]
+            workspaces: list[CloudWorkspaceInfo] = []
+            name_substring = name_contains.casefold() if name_contains is not None else None
+            for direct_workspace_id in workspace_ids:
+                workspace = CloudWorkspaceInfo.from_api_response(
                     api_util.get_workspace(
-                        workspace_id=workspace_id,
+                        workspace_id=direct_workspace_id,
                         api_root=self.public_api_root,
                         client_id=self.client_id,
                         client_secret=self.client_secret,
                         bearer_token=self.bearer_token,
                     )
                 )
-                for workspace_id in self._get_direct_workspace_ids()
-            ]
-            if name is not None:
-                workspaces = [workspace for workspace in workspaces if workspace.name == name]
-            elif name_contains is not None:
-                name_substring = name_contains.casefold()
-                workspaces = [
-                    workspace
-                    for workspace in workspaces
-                    if name_substring in workspace.name.casefold()
-                ]
-            elif name_filter is not None:
-                workspaces = [workspace for workspace in workspaces if name_filter(workspace.name)]
-            return workspaces if limit is None else workspaces[:limit]
+                if name is not None and workspace.name != name:
+                    continue
+                if name_substring is not None and name_substring not in workspace.name.casefold():
+                    continue
+                if name_filter is not None and not name_filter(workspace.name):
+                    continue
+                workspaces.append(workspace)
+                if limit is not None and len(workspaces) == limit:
+                    break
+            return workspaces
         if all_organizations:
             resolved_organization_id = None
         else:
@@ -433,6 +434,8 @@ class CloudClient:
                     workspace_id=workspace_id,
                 )
             except exc.PyAirbyteInputError:
+                if has_explicit_organization or has_explicit_workspace:
+                    raise
                 direct_workspaces = self._try_list_member_workspaces(
                     name=name,
                     name_contains=name_contains,
@@ -729,7 +732,7 @@ class CloudClient:
             for permission in self._get_user_permissions()
         )
 
-    def get_default_context(self) -> CloudDefaultContextInfo:
+    def get_default_context_for_user(self) -> CloudDefaultContextInfo:
         """Describe the authenticated user's explicit Cloud affinities."""
         user_id: str | None = None
         user_name: str | None = None

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -371,10 +371,7 @@ class CloudClient:
         if all_organizations:
             if privilege_scope is not WorkspacePrivilegeScope.MEMBER_OF:
                 raise exc.PyAirbyteInputError(
-                    message=(
-                        "The all_organizations option conflicts with the "
-                        "privilege_scope option."
-                    )
+                    message="all_organizations cannot be combined with privilege_scope."
                 )
             warnings.warn(
                 "`all_organizations` is deprecated; use `privilege_scope` instead.",

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -232,9 +232,9 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="Workspace ID is required.",
                 guidance=(
-                    "Call `get_default_cloud_context` first. No workspace was configured, "
-                    "and no default workspace could be resolved for the authenticated user. "
-                    "Provide a workspace ID."
+                    "No workspace was configured, and no default workspace could be resolved "
+                    "for the authenticated user. Provide a workspace ID, or call "
+                    "`get_default_cloud_context` to discover your workspaces and organizations."
                 ),
             )
 
@@ -862,10 +862,11 @@ class CloudClient:
         )
         raise exc.PyAirbyteInputError(
             message=(
-                "Call `get_default_cloud_context` first. Multiple organization "
-                "memberships were found for these credentials. Retry with one of these "
+                "Multiple organization memberships were found for these credentials. Retry "
+                "with one of these "
                 "organization IDs "
-                f"(showing {len(candidates)} of {len(organization_ids)}): {candidate_details}"
+                f"(showing {len(candidates)} of {len(organization_ids)}): {candidate_details}. "
+                "Call `get_default_cloud_context` to see your memberships."
             ),
             context={
                 "organization_ids": list(organization_ids),
@@ -1018,12 +1019,10 @@ class CloudClient:
             resolved_organization_id = self._resolve_default_organization_id()
         if not resolved_organization_id and not organization_name:
             raise exc.PyAirbyteInputError(
-                message=(
-                    "Call `get_default_cloud_context` first. Organization ID or "
-                    "organization name is required."
-                ),
+                message="Organization ID or organization name is required.",
                 guidance=(
-                    "Call `get_default_cloud_context`, then provide an organization ID or name."
+                    "Provide an organization ID or name, or call `get_default_cloud_context` "
+                    "to discover your organizations."
                 ),
             )
 

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -748,19 +748,13 @@ class CloudClient:
         )
 
     def get_default_context(self) -> CloudDefaultContextInfo:
-        """Describe the authenticated user's resolvable Cloud context."""
-        notes: list[str] = []
+        """Describe the authenticated user's explicit Cloud affinities."""
         user_id: str | None = None
         user_name: str | None = None
         user_email: str | None = None
         try:
             user = self._get_authenticated_user_info()
-        except (AirbyteError, exc.PyAirbyteInputError) as error:
-            notes.append(
-                "Bearer token has no user identity claim; membership resolution unavailable."
-                if isinstance(error, exc.PyAirbyteInputError)
-                else "Authenticated user lookup unavailable; membership resolution unavailable."
-            )
+        except (AirbyteError, exc.PyAirbyteInputError):
             user = {}
         else:
             user_id_value = user.get("userId")
@@ -771,41 +765,48 @@ class CloudClient:
             user_email = user_email_value if isinstance(user_email_value, str) else None
 
         default_workspace_id = self.resolve_default_workspace_id()
-        if default_workspace_id is None:
-            notes.append("No default workspace on user record")
-
         try:
-            membership_organization_ids = self._get_membership_organization_ids()
+            permissions = self._get_user_permissions()
         except (AirbyteError, exc.PyAirbyteInputError):
+            permissions = ()
             membership_organization_ids = ()
-            notes.append("Membership permissions unavailable")
-        try:
-            is_instance_admin = self._is_instance_admin()
-        except (AirbyteError, exc.PyAirbyteInputError):
-            is_instance_admin = False
-            notes.append("Instance-admin permission status unavailable")
-        try:
-            direct_workspaces = self.list_direct_workspaces(limit=25)
-        except (AirbyteError, exc.PyAirbyteInputError):
-            direct_workspaces = []
-            notes.append("Direct workspace permissions unavailable")
+            member_workspaces = []
+        else:
+            membership_organization_ids = self._get_membership_organization_ids()
+            try:
+                member_workspaces = self.list_direct_workspaces(limit=25)
+            except (AirbyteError, exc.PyAirbyteInputError):
+                member_workspaces = []
 
-        membership_organizations = [
+        member_organizations = [
             CloudOrganizationInfo.model_validate(candidate)
             for candidate in self._get_organization_candidates(
                 membership_organization_ids[:MAX_ORGANIZATION_CANDIDATES]
             )
         ]
+        discovery_hints: list[str] = []
+        if any(permission.get("permissionType") == "instance_admin" for permission in permissions):
+            discovery_hints.append(
+                "Instance-admin access may include every organization and workspace in the "
+                "instance. Use list_cloud_organizations(name_contains=...) or "
+                "list_cloud_workspaces(organization_id=...) to discover others."
+            )
+        if membership_organization_ids:
+            discovery_hints.append(
+                "Organization membership grants access to every workspace in those "
+                "organizations. Use list_cloud_workspaces(organization_id=<id>) to "
+                "discover workspaces."
+            )
         return CloudDefaultContextInfo(
             user_id=user_id,
             user_name=user_name,
             user_email=user_email,
-            is_instance_admin=is_instance_admin,
             default_workspace_id=default_workspace_id,
+            configured_workspace_id=self.default_workspace_id,
             configured_organization_id=self.organization_id,
-            membership_organizations=membership_organizations,
-            direct_workspaces=direct_workspaces,
-            resolution_notes=notes,
+            member_organizations=member_organizations,
+            member_workspaces=member_workspaces,
+            discovery_hints=discovery_hints,
         )
 
     def _get_organization_candidates(

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -736,7 +736,7 @@ class CloudClient:
         try:
             user = self._get_authenticated_user_info()
         except (AirbyteError, exc.PyAirbyteInputError):
-            user = {}
+            pass
         else:
             user_id_value = user.get("userId")
             user_id = user_id_value if isinstance(user_id_value, str) else None

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
 
 
 MAX_ORGANIZATION_CANDIDATES = 10
+MAX_MEMBER_WORKSPACES = 25
 
 
 @dataclass(init=False, kw_only=True)
@@ -761,12 +762,9 @@ class CloudClient:
         except (AirbyteError, exc.PyAirbyteInputError):
             pass
         else:
-            user_id_value = user.get("userId")
-            user_id = user_id_value if isinstance(user_id_value, str) else None
-            user_name_value = user.get("name")
-            user_name = user_name_value if isinstance(user_name_value, str) else None
-            user_email_value = user.get("email")
-            user_email = user_email_value if isinstance(user_email_value, str) else None
+            user_id = user.get("userId") if isinstance(user.get("userId"), str) else None
+            user_name = user.get("name") if isinstance(user.get("name"), str) else None
+            user_email = user.get("email") if isinstance(user.get("email"), str) else None
 
         default_workspace_id = self.resolve_default_workspace_id()
         try:
@@ -775,12 +773,20 @@ class CloudClient:
             permissions = ()
             membership_organization_ids = ()
             member_workspaces = []
+            member_organizations_truncated = False
+            member_workspaces_truncated = False
         else:
             membership_organization_ids = self._get_membership_organization_ids()
+            member_organizations_truncated = (
+                len(membership_organization_ids) > MAX_ORGANIZATION_CANDIDATES
+            )
+            member_workspaces_truncated = (
+                len(self._get_direct_workspace_ids()) > MAX_MEMBER_WORKSPACES
+            )
             try:
                 member_workspaces = self.list_workspaces(
                     privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
-                    limit=25,
+                    limit=MAX_MEMBER_WORKSPACES,
                 )
             except (AirbyteError, exc.PyAirbyteInputError):
                 member_workspaces = []
@@ -813,6 +819,8 @@ class CloudClient:
             configured_organization_id=self.organization_id,
             member_organizations=member_organizations,
             member_workspaces=member_workspaces,
+            member_organizations_truncated=member_organizations_truncated,
+            member_workspaces_truncated=member_workspaces_truncated,
             discovery_hints=discovery_hints,
         )
 

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -44,32 +44,25 @@ default), or from the credentials as `CloudClient.organization_id`.
 
 ### If neither is known
 
-`CloudClient.list_workspaces` first tries the parent organization of the configured
-workspace, then the authenticated user's default workspace, and finally the authenticated
-user's memberships: the organizations that user holds permissions on, read once and
-cached for the life of the client. `CloudClient.get_organization` called with no
-arguments resolves the same way: configured `CloudClient.organization_id` first, then the
-parent organization of `CloudClient.default_workspace_id`, then the parent organization
-of the authenticated user's default workspace, then the memberships below.
+`CloudClient.list_workspaces` uses `privilege_scope` to choose the search breadth:
+`MEMBER_OF` lists direct workspace grants, `ORGANIZATION_ADMIN` lists workspaces in
+member organizations, `INSTANCE_ADMIN` lists every workspace for instance admins, and
+`ANY` chooses the broadest scope available to the caller. `CloudClient.get_organization`
+called with no arguments resolves the same way: configured `CloudClient.organization_id`
+first, then the parent organization of `CloudClient.default_workspace_id`, then the
+parent organization of the authenticated user's default workspace, then the memberships
+below.
 
-- Exactly one membership — that organization is the context.
-- Several memberships — discovery stops with a `PyAirbyteInputError` that both carries
-  and enumerates in its message the first ten candidate organization IDs and names, so
-  the caller can retry with one of them instead of having to list organizations first.
-- No memberships — which happens for credentials whose grants are not
-  organization-scoped — listing falls back to the cross-organization path below.
-
-Passing `all_organizations=True` selects that path deliberately and cannot be combined
-with an organization or workspace argument.
+The deprecated `all_organizations=True` alias maps to `privilege_scope=ANY`.
 
 ### Why the path matters
 
 The two listing paths differ in completeness, not just speed:
 
-- **Organization-scoped** (an organization was resolved) uses the Config API, which
-  filters by name server-side and paginates, so results are complete and each workspace
-  carries its organization attribution.
-- **Cross-organization** (no organization resolved, or `all_organizations=True`) uses
+- **Organization-scoped** (an organization or membership scope was resolved) uses the
+  Config API, which filters by name server-side and paginates, so results are complete
+  and each workspace carries its organization attribution.
+- **Cross-organization** (`privilege_scope=INSTANCE_ADMIN`, or `ANY` for an instance admin) uses
   the public API, which has neither an organization filter nor a name filter. Name
   matching happens client-side over every visible workspace, and the responses carry no
   organization attribution.
@@ -87,6 +80,7 @@ unavailable, so self-managed deployments keep working.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn, overload
 
@@ -97,6 +91,7 @@ from airbyte.cloud.models import (
     CloudDefaultContextInfo,
     CloudOrganizationInfo,
     CloudWorkspaceInfo,
+    WorkspacePrivilegeScope,
 )
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
@@ -324,8 +319,8 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        privilege_scope: WorkspacePrivilegeScope = WorkspacePrivilegeScope.MEMBER_OF,
         all_organizations: bool = False,
-        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
@@ -340,12 +335,12 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        privilege_scope: WorkspacePrivilegeScope = WorkspacePrivilegeScope.MEMBER_OF,
         all_organizations: bool = False,
-        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
-    def list_workspaces(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    def list_workspaces(  # noqa: PLR0911, PLR0913
         self,
         name: str | None = None,
         *,
@@ -355,15 +350,14 @@ class CloudClient:
         name_contains: str | None = None,
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
+        privilege_scope: WorkspacePrivilegeScope = WorkspacePrivilegeScope.MEMBER_OF,
         all_organizations: bool = False,
-        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         """List workspaces available to this client.
 
-        See the module docstring for how the organization context is resolved.
-
-        When `member_only` is enabled, return only the caller's direct workspace
-        grants and do not resolve or enumerate organizations.
+        `privilege_scope` controls whether this lists direct member workspaces,
+        organization workspaces, or instance-wide workspaces. The deprecated
+        `all_organizations` alias maps to `WorkspacePrivilegeScope.ANY`.
         """
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
@@ -374,22 +368,20 @@ class CloudClient:
         has_explicit_organization = organization_id is not None or organization_name is not None
         has_explicit_workspace = workspace_id is not None
 
-        if member_only and (
-            has_explicit_organization or has_explicit_workspace or all_organizations
-        ):
-            raise exc.PyAirbyteInputError(
-                message=(
-                    "The member_only option cannot be combined with an organization, "
-                    "workspace, or all_organizations option."
+        if all_organizations:
+            if privilege_scope is not WorkspacePrivilegeScope.MEMBER_OF:
+                raise exc.PyAirbyteInputError(
+                    message=(
+                        "The all_organizations option conflicts with the "
+                        "privilege_scope option."
+                    )
                 )
+            warnings.warn(
+                "`all_organizations` is deprecated; use `privilege_scope` instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        if all_organizations and (has_explicit_organization or has_explicit_workspace):
-            raise exc.PyAirbyteInputError(
-                message=(
-                    "The all_organizations option cannot be combined with an "
-                    "organization or workspace ID."
-                )
-            )
+            privilege_scope = WorkspacePrivilegeScope.ANY
         if name_contains is not None and name_filter is not None:
             raise exc.PyAirbyteInputError(
                 message="You can provide name_contains or name_filter, but not both."
@@ -398,118 +390,68 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="You can provide name or name_contains, but not both."
             )
-        if member_only:
-            workspace_ids = self._get_direct_workspace_ids()
-            if limit is not None and name is None and name_contains is None and name_filter is None:
-                workspace_ids = workspace_ids[:limit]
-            workspaces: list[CloudWorkspaceInfo] = []
-            name_substring = name_contains.casefold() if name_contains is not None else None
-            for direct_workspace_id in workspace_ids:
-                workspace = CloudWorkspaceInfo.from_api_response(
-                    api_util.get_workspace(
-                        workspace_id=direct_workspace_id,
-                        api_root=self.public_api_root,
-                        client_id=self.client_id,
-                        client_secret=self.client_secret,
-                        bearer_token=self.bearer_token,
-                    )
-                )
-                if name is not None and workspace.name != name:
-                    continue
-                if name_substring is not None and name_substring not in workspace.name.casefold():
-                    continue
-                if name_filter is not None and not name_filter(workspace.name):
-                    continue
-                workspaces.append(workspace)
-                if limit is not None and len(workspaces) == limit:
-                    break
-            return workspaces
-        if all_organizations:
-            resolved_organization_id = None
-        else:
-            try:
-                resolved_organization_id = self._resolve_workspace_organization_id(
-                    organization_id=organization_id,
-                    organization_name=organization_name,
-                    workspace_id=workspace_id,
-                )
-            except exc.PyAirbyteInputError:
-                if has_explicit_organization or has_explicit_workspace:
-                    raise
-                direct_workspaces = self._try_list_member_workspaces(
-                    name=name,
-                    name_contains=name_contains,
-                    name_filter=name_filter,
-                    limit=limit,
-                )
-                if direct_workspaces:
-                    return direct_workspaces
-                raise
-        if resolved_organization_id is None and not all_organizations:
-            direct_workspaces = self._try_list_member_workspaces(
+        if has_explicit_organization or has_explicit_workspace:
+            resolved_organization_id = self._resolve_workspace_organization_id(
+                organization_id=organization_id,
+                organization_name=organization_name,
+                workspace_id=workspace_id,
+            )
+            if resolved_organization_id is None:
+                return []
+            return self._list_workspaces_in_organizations(
+                (resolved_organization_id,),
                 name=name,
                 name_contains=name_contains,
                 name_filter=name_filter,
                 limit=limit,
             )
-            if direct_workspaces:
-                return direct_workspaces
-            if self._try_is_instance_admin():
-                raise exc.PyAirbyteInputError(
-                    message=(
-                        "Call `get_default_cloud_context` first. An organization or "
-                        "workspace context is required for an instance administrator."
-                    ),
-                    guidance=(
-                        "Call `get_default_cloud_context` first, then pass organization_id "
-                        "or organization_name, or set all_organizations=True."
-                    ),
-                )
 
-        if resolved_organization_id is None:
-            if name_contains is not None:
-                name_substring = name_contains.casefold()
-
-                def matches_name(workspace_name: str) -> bool:
-                    return name_substring in workspace_name.casefold()
-
-                name_filter = matches_name
-                name = None
-            workspaces = api_util.list_workspaces(
-                workspace_id="",
-                api_root=self.public_api_root,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
-                name_filter=name_filter,
+        if privilege_scope is WorkspacePrivilegeScope.MEMBER_OF:
+            return self._list_member_workspaces(
                 name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
                 limit=limit,
             )
-            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
 
-        # The organization-scoped path delegates `name_contains` casing to the server.
-        workspaces = api_util.list_workspaces_in_organization(
-            organization_id=resolved_organization_id,
-            api_root=self.public_api_root,
-            config_api_root=self.config_api_root,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            bearer_token=self._get_config_api_bearer_token(),
-            name_contains=name_contains or name,
-            limit=None if name is not None or name_filter is not None else limit,
-        )
-        workspace_infos = [CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces]
-        if name is not None:
-            workspace_infos = [workspace for workspace in workspace_infos if workspace.name == name]
-        if name_filter is not None:
-            workspace_infos = [
-                workspace for workspace in workspace_infos if name_filter(workspace.name)
-            ]
-        if limit is not None and (name is not None or name_filter is not None):
-            workspace_infos = workspace_infos[:limit]
-        return workspace_infos
+        if privilege_scope is WorkspacePrivilegeScope.INSTANCE_ADMIN:
+            if not self._is_instance_admin():
+                raise exc.PyAirbyteInputError(
+                    message="privilege_scope=instance_admin requires the instance_admin permission."
+                )
+            return self._list_unscoped_workspaces(
+                name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
+                limit=limit,
+            )
 
-    def _try_list_member_workspaces(
+        if privilege_scope is WorkspacePrivilegeScope.ANY and self._is_instance_admin():
+            return self._list_unscoped_workspaces(
+                name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
+                limit=limit,
+            )
+
+        if privilege_scope in {
+            WorkspacePrivilegeScope.ORGANIZATION_ADMIN,
+            WorkspacePrivilegeScope.ANY,
+        }:
+            organization_ids = self._get_membership_organization_ids()
+            if not organization_ids:
+                return []
+            return self._list_workspaces_in_organizations(
+                organization_ids,
+                name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
+                limit=limit,
+            )
+
+        raise exc.PyAirbyteInputError(message="Unsupported workspace privilege scope.")
+
+    def _list_member_workspaces(
         self,
         *,
         name: str | None = None,
@@ -517,24 +459,104 @@ class CloudClient:
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
     ) -> list[CloudWorkspaceInfo]:
-        """List member workspaces, degrading to an empty result on lookup errors."""
-        try:
-            return self.list_workspaces(
-                name=name,
-                name_contains=name_contains,
-                name_filter=name_filter,
-                limit=limit,
-                member_only=True,
+        """List workspaces granted directly to the authenticated user."""
+        workspace_ids = self._get_direct_workspace_ids()
+        if limit is not None and name is None and name_contains is None and name_filter is None:
+            workspace_ids = workspace_ids[:limit]
+        workspaces: list[CloudWorkspaceInfo] = []
+        name_substring = name_contains.casefold() if name_contains is not None else None
+        for direct_workspace_id in workspace_ids:
+            workspace = CloudWorkspaceInfo.from_api_response(
+                api_util.get_workspace(
+                    workspace_id=direct_workspace_id,
+                    api_root=self.public_api_root,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                    bearer_token=self.bearer_token,
+                )
             )
-        except (AirbyteError, exc.PyAirbyteInputError):
-            return []
+            if name is not None and workspace.name != name:
+                continue
+            if name_substring is not None and name_substring not in workspace.name.casefold():
+                continue
+            if name_filter is not None and not name_filter(workspace.name):
+                continue
+            workspaces.append(workspace)
+            if limit is not None and len(workspaces) == limit:
+                break
+        return workspaces
 
-    def _try_is_instance_admin(self) -> bool:
-        """Return instance-admin status, degrading to false on lookup errors."""
-        try:
-            return self._is_instance_admin()
-        except (AirbyteError, exc.PyAirbyteInputError):
-            return False
+    def _list_unscoped_workspaces(
+        self,
+        *,
+        name: str | None,
+        name_contains: str | None,
+        name_filter: Callable[[str], bool] | None,
+        limit: int | None,
+    ) -> list[CloudWorkspaceInfo]:
+        """List workspaces across the instance."""
+        if name_contains is not None:
+            name_substring = name_contains.casefold()
+
+            def matches_name(workspace_name: str) -> bool:
+                return name_substring in workspace_name.casefold()
+
+            name_filter = matches_name
+            name = None
+        workspaces = api_util.list_workspaces(
+            workspace_id="",
+            api_root=self.public_api_root,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            bearer_token=self.bearer_token,
+            name_filter=name_filter,
+            name=name,
+            limit=limit,
+        )
+        return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
+
+    def _list_workspaces_in_organizations(
+        self,
+        organization_ids: tuple[str, ...],
+        *,
+        name: str | None,
+        name_contains: str | None,
+        name_filter: Callable[[str], bool] | None,
+        limit: int | None,
+    ) -> list[CloudWorkspaceInfo]:
+        """List and combine workspaces from one or more organizations."""
+        workspace_infos: list[CloudWorkspaceInfo] = []
+        for organization_id in organization_ids:
+            remaining_limit = None if limit is None else limit - len(workspace_infos)
+            if remaining_limit == 0:
+                break
+            workspaces = api_util.list_workspaces_in_organization(
+                organization_id=organization_id,
+                api_root=self.public_api_root,
+                config_api_root=self.config_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self._get_config_api_bearer_token(),
+                name_contains=name_contains or name,
+                limit=None if name is not None or name_filter is not None else remaining_limit,
+            )
+            organization_workspaces = [
+                CloudWorkspaceInfo.from_mapping(workspace) for workspace in workspaces
+            ]
+            if name is not None:
+                organization_workspaces = [
+                    workspace for workspace in organization_workspaces if workspace.name == name
+                ]
+            if name_filter is not None:
+                organization_workspaces = [
+                    workspace
+                    for workspace in organization_workspaces
+                    if name_filter(workspace.name)
+                ]
+            workspace_infos.extend(organization_workspaces)
+            if limit is not None and len(workspace_infos) >= limit:
+                break
+        return workspace_infos[:limit] if limit is not None else workspace_infos
 
     def _resolve_workspace_organization_id(
         self,
@@ -759,7 +781,10 @@ class CloudClient:
         else:
             membership_organization_ids = self._get_membership_organization_ids()
             try:
-                member_workspaces = self.list_workspaces(member_only=True, limit=25)
+                member_workspaces = self.list_workspaces(
+                    privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
+                    limit=25,
+                )
             except (AirbyteError, exc.PyAirbyteInputError):
                 member_workspaces = []
 

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -422,25 +422,6 @@ class CloudClient:
                         "or organization_name, or set all_organizations=True."
                     ),
                 )
-            if name_contains is not None:
-                name_substring = name_contains.casefold()
-
-                def matches_name(workspace_name: str) -> bool:
-                    return name_substring in workspace_name.casefold()
-
-                name_filter = matches_name
-                name = None
-            workspaces = api_util.list_workspaces(
-                workspace_id="",
-                api_root=self.public_api_root,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                bearer_token=self.bearer_token,
-                name_filter=name_filter,
-                name=name,
-                limit=limit,
-            )
-            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
 
         if resolved_organization_id is None:
             if name_contains is not None:
@@ -759,7 +740,7 @@ class CloudClient:
         else:
             user_id_value = user.get("userId")
             user_id = user_id_value if isinstance(user_id_value, str) else None
-            user_name_value = user.get("userName", user.get("name"))
+            user_name_value = user.get("name")
             user_name = user_name_value if isinstance(user_name_value, str) else None
             user_email_value = user.get("email")
             user_email = user_email_value if isinstance(user_email_value, str) else None

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -93,7 +93,11 @@ from typing import TYPE_CHECKING, Any, NoReturn, overload
 from airbyte import exceptions as exc
 from airbyte._util import api_util
 from airbyte.cloud._credentials import _AirbyteCredentials
-from airbyte.cloud.models import CloudWorkspaceInfo
+from airbyte.cloud.models import (
+    CloudDefaultContextInfo,
+    CloudOrganizationInfo,
+    CloudWorkspaceInfo,
+)
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import AirbyteError, AirbyteMissingResourceError
@@ -114,6 +118,7 @@ class CloudClient:
 
     _credentials: _AirbyteCredentials
     _membership_organization_ids: tuple[str, ...] | None
+    _user_permissions: tuple[dict[str, Any], ...] | None
     _authenticated_user_info: dict[str, Any] | None = field(repr=False)
     _authenticated_user_id: str | None = field(repr=False)
     _authenticated_bearer_token: SecretString | None
@@ -141,6 +146,7 @@ class CloudClient:
             env_vars=False,
         )
         self._membership_organization_ids = None
+        self._user_permissions = None
         self._authenticated_user_info = None
         self._authenticated_user_id = None
         self._authenticated_bearer_token = None
@@ -231,8 +237,9 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="Workspace ID is required.",
                 guidance=(
-                    "No workspace was configured, and no default workspace could be "
-                    "resolved for the authenticated user. Provide a workspace ID."
+                    "Call `get_default_cloud_context` first. No workspace was configured, "
+                    "and no default workspace could be resolved for the authenticated user. "
+                    "Provide a workspace ID."
                 ),
             )
 
@@ -336,7 +343,7 @@ class CloudClient:
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
-    def list_workspaces(
+    def list_workspaces(  # noqa: PLR0912
         self,
         name: str | None = None,
         *,
@@ -376,15 +383,65 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="You can provide name or name_contains, but not both."
             )
-        resolved_organization_id = (
-            None
-            if all_organizations
-            else self._resolve_workspace_organization_id(
-                organization_id=organization_id,
-                organization_name=organization_name,
-                workspace_id=workspace_id,
+        if all_organizations:
+            resolved_organization_id = None
+        else:
+            try:
+                resolved_organization_id = self._resolve_workspace_organization_id(
+                    organization_id=organization_id,
+                    organization_name=organization_name,
+                    workspace_id=workspace_id,
+                )
+            except exc.PyAirbyteInputError:
+                direct_workspaces = self._try_list_direct_workspaces(
+                    name=name,
+                    name_contains=name_contains,
+                    name_filter=name_filter,
+                    limit=limit,
+                )
+                if direct_workspaces:
+                    return direct_workspaces
+                raise
+        if resolved_organization_id is None and not all_organizations:
+            direct_workspaces = self._try_list_direct_workspaces(
+                name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
+                limit=limit,
             )
-        )
+            if direct_workspaces:
+                return direct_workspaces
+            if not all_organizations and self._try_is_instance_admin():
+                raise exc.PyAirbyteInputError(
+                    message=(
+                        "Call `get_default_cloud_context` first. An organization or "
+                        "workspace context is required for an instance administrator."
+                    ),
+                    guidance=(
+                        "Call `get_default_cloud_context` first, then pass organization_id "
+                        "or organization_name, or set all_organizations=True."
+                    ),
+                )
+            if name_contains is not None:
+                name_substring = name_contains.casefold()
+
+                def matches_name(workspace_name: str) -> bool:
+                    return name_substring in workspace_name.casefold()
+
+                name_filter = matches_name
+                name = None
+            workspaces = api_util.list_workspaces(
+                workspace_id="",
+                api_root=self.public_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+                name_filter=name_filter,
+                name=name,
+                limit=limit,
+            )
+            return [CloudWorkspaceInfo.from_api_response(workspace) for workspace in workspaces]
+
         if resolved_organization_id is None:
             if name_contains is not None:
                 name_substring = name_contains.casefold()
@@ -427,6 +484,72 @@ class CloudClient:
         if limit is not None and (name is not None or name_filter is not None):
             workspace_infos = workspace_infos[:limit]
         return workspace_infos
+
+    def list_direct_workspaces(
+        self,
+        *,
+        name: str | None = None,
+        name_contains: str | None = None,
+        name_filter: Callable[[str], bool] | None = None,
+        limit: int | None = None,
+    ) -> list[CloudWorkspaceInfo]:
+        """List workspaces granted directly to the authenticated user."""
+        if name is not None and name_contains is not None:
+            raise exc.PyAirbyteInputError(
+                message="You can provide name or name_contains, but not both."
+            )
+        if name_contains is not None and name_filter is not None:
+            raise exc.PyAirbyteInputError(
+                message="You can provide name_contains or name_filter, but not both."
+            )
+        workspaces = [
+            CloudWorkspaceInfo.from_api_response(
+                api_util.get_workspace(
+                    workspace_id=workspace_id,
+                    api_root=self.public_api_root,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                    bearer_token=self.bearer_token,
+                )
+            )
+            for workspace_id in self._get_direct_workspace_ids()
+        ]
+        if name is not None:
+            workspaces = [workspace for workspace in workspaces if workspace.name == name]
+        elif name_contains is not None:
+            name_substring = name_contains.casefold()
+            workspaces = [
+                workspace for workspace in workspaces if name_substring in workspace.name.casefold()
+            ]
+        elif name_filter is not None:
+            workspaces = [workspace for workspace in workspaces if name_filter(workspace.name)]
+        return workspaces if limit is None else workspaces[:limit]
+
+    def _try_list_direct_workspaces(
+        self,
+        *,
+        name: str | None = None,
+        name_contains: str | None = None,
+        name_filter: Callable[[str], bool] | None = None,
+        limit: int | None = None,
+    ) -> list[CloudWorkspaceInfo]:
+        """List direct workspaces, degrading to an empty result on lookup errors."""
+        try:
+            return self.list_direct_workspaces(
+                name=name,
+                name_contains=name_contains,
+                name_filter=name_filter,
+                limit=limit,
+            )
+        except (AirbyteError, exc.PyAirbyteInputError):
+            return []
+
+    def _try_is_instance_admin(self) -> bool:
+        """Return instance-admin status, degrading to false on lookup errors."""
+        try:
+            return self._is_instance_admin()
+        except (AirbyteError, exc.PyAirbyteInputError):
+            return False
 
     def _resolve_workspace_organization_id(
         self,
@@ -561,21 +684,41 @@ class CloudClient:
 
     def resolve_default_workspace_id(self) -> str | None:
         """Resolve the configured or authenticated user's default workspace ID."""
-        return self.default_workspace_id or self._get_user_default_workspace_id()
+        configured_workspace_id = self.default_workspace_id
+        if configured_workspace_id:
+            return configured_workspace_id
+        user_default_workspace_id = self._get_user_default_workspace_id()
+        if user_default_workspace_id:
+            return user_default_workspace_id
+        try:
+            direct_workspace_ids = self._get_direct_workspace_ids()
+        except (AirbyteError, exc.PyAirbyteInputError):
+            return None
+        return direct_workspace_ids[0] if len(direct_workspace_ids) == 1 else None
+
+    def _get_user_permissions(self) -> tuple[dict[str, Any], ...]:
+        """Get and cache permissions for the authenticated user."""
+        if self._user_permissions is None:
+            self._user_permissions = tuple(
+                permission
+                for permission in api_util.list_permissions_for_user(
+                    self._get_authenticated_user_id(),
+                    api_root=self.public_api_root,
+                    config_api_root=self.config_api_root,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                    bearer_token=self._get_config_api_bearer_token(),
+                )
+                if isinstance(permission, dict)
+            )
+        return self._user_permissions
 
     def _get_membership_organization_ids(self) -> tuple[str, ...]:
         """Get and cache organization IDs from the caller's permissions."""
         if self._membership_organization_ids is not None:
             return self._membership_organization_ids
 
-        permissions = api_util.list_permissions_for_user(
-            self._get_authenticated_user_id(),
-            api_root=self.public_api_root,
-            config_api_root=self.config_api_root,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            bearer_token=self._get_config_api_bearer_token(),
-        )
+        permissions = self._get_user_permissions()
         organization_ids: list[str] = []
         for permission in permissions:
             permission_organization_id = permission.get("organizationId")
@@ -587,6 +730,83 @@ class CloudClient:
                 organization_ids.append(permission_organization_id)
         self._membership_organization_ids = tuple(organization_ids)
         return self._membership_organization_ids
+
+    def _get_direct_workspace_ids(self) -> tuple[str, ...]:
+        """Get unique workspace IDs from the caller's direct permissions."""
+        workspace_ids: list[str] = []
+        for permission in self._get_user_permissions():
+            workspace_id = permission.get("workspaceId")
+            if isinstance(workspace_id, str) and workspace_id and workspace_id not in workspace_ids:
+                workspace_ids.append(workspace_id)
+        return tuple(workspace_ids)
+
+    def _is_instance_admin(self) -> bool:
+        """Return whether the caller has an instance-admin permission."""
+        return any(
+            permission.get("permissionType") == "instance_admin"
+            for permission in self._get_user_permissions()
+        )
+
+    def get_default_context(self) -> CloudDefaultContextInfo:
+        """Describe the authenticated user's resolvable Cloud context."""
+        notes: list[str] = []
+        user_id: str | None = None
+        user_name: str | None = None
+        user_email: str | None = None
+        try:
+            user = self._get_authenticated_user_info()
+        except (AirbyteError, exc.PyAirbyteInputError) as error:
+            notes.append(
+                "Bearer token has no user identity claim; membership resolution unavailable."
+                if isinstance(error, exc.PyAirbyteInputError)
+                else "Authenticated user lookup unavailable; membership resolution unavailable."
+            )
+            user = {}
+        else:
+            user_id_value = user.get("userId")
+            user_id = user_id_value if isinstance(user_id_value, str) else None
+            user_name_value = user.get("userName", user.get("name"))
+            user_name = user_name_value if isinstance(user_name_value, str) else None
+            user_email_value = user.get("email")
+            user_email = user_email_value if isinstance(user_email_value, str) else None
+
+        default_workspace_id = self.resolve_default_workspace_id()
+        if default_workspace_id is None:
+            notes.append("No default workspace on user record")
+
+        try:
+            membership_organization_ids = self._get_membership_organization_ids()
+        except (AirbyteError, exc.PyAirbyteInputError):
+            membership_organization_ids = ()
+            notes.append("Membership permissions unavailable")
+        try:
+            is_instance_admin = self._is_instance_admin()
+        except (AirbyteError, exc.PyAirbyteInputError):
+            is_instance_admin = False
+            notes.append("Instance-admin permission status unavailable")
+        try:
+            direct_workspaces = self.list_direct_workspaces(limit=25)
+        except (AirbyteError, exc.PyAirbyteInputError):
+            direct_workspaces = []
+            notes.append("Direct workspace permissions unavailable")
+
+        membership_organizations = [
+            CloudOrganizationInfo.model_validate(candidate)
+            for candidate in self._get_organization_candidates(
+                membership_organization_ids[:MAX_ORGANIZATION_CANDIDATES]
+            )
+        ]
+        return CloudDefaultContextInfo(
+            user_id=user_id,
+            user_name=user_name,
+            user_email=user_email,
+            is_instance_admin=is_instance_admin,
+            default_workspace_id=default_workspace_id,
+            configured_organization_id=self.organization_id,
+            membership_organizations=membership_organizations,
+            direct_workspaces=direct_workspaces,
+            resolution_notes=notes,
+        )
 
     def _get_organization_candidates(
         self,
@@ -634,8 +854,9 @@ class CloudClient:
         )
         raise exc.PyAirbyteInputError(
             message=(
-                "Multiple organization memberships were found for these credentials. "
-                "Retry with one of these organization IDs "
+                "Call `get_default_cloud_context` first. Multiple organization "
+                "memberships were found for these credentials. Retry with one of these "
+                "organization IDs "
                 f"(showing {len(candidates)} of {len(organization_ids)}): {candidate_details}"
             ),
             context={
@@ -789,7 +1010,13 @@ class CloudClient:
             resolved_organization_id = self._resolve_default_organization_id()
         if not resolved_organization_id and not organization_name:
             raise exc.PyAirbyteInputError(
-                message="Organization ID or organization name is required."
+                message=(
+                    "Call `get_default_cloud_context` first. Organization ID or "
+                    "organization name is required."
+                ),
+                guidance=(
+                    "Call `get_default_cloud_context`, then provide an organization ID or name."
+                ),
             )
 
         if resolved_organization_id:

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -115,6 +115,7 @@ class CloudClient:
     _credentials: _AirbyteCredentials
     _membership_organization_ids: tuple[str, ...] | None
     _user_permissions: tuple[dict[str, Any], ...] | None
+    _direct_workspace_infos: dict[str, CloudWorkspaceInfo | None]
     _authenticated_user_info: dict[str, Any] | None = field(repr=False)
     _authenticated_user_id: str | None = field(repr=False)
     _authenticated_bearer_token: SecretString | None
@@ -143,6 +144,7 @@ class CloudClient:
         )
         self._membership_organization_ids = None
         self._user_permissions = None
+        self._direct_workspace_infos = {}
         self._authenticated_user_info = None
         self._authenticated_user_id = None
         self._authenticated_bearer_token = None
@@ -459,20 +461,12 @@ class CloudClient:
     ) -> list[CloudWorkspaceInfo]:
         """List workspaces granted directly to the authenticated user."""
         workspace_ids = self._get_direct_workspace_ids()
-        if limit is not None and name is None and name_contains is None and name_filter is None:
-            workspace_ids = workspace_ids[:limit]
         workspaces: list[CloudWorkspaceInfo] = []
         name_substring = name_contains.casefold() if name_contains is not None else None
         for direct_workspace_id in workspace_ids:
-            workspace = CloudWorkspaceInfo.from_api_response(
-                api_util.get_workspace(
-                    workspace_id=direct_workspace_id,
-                    api_root=self.public_api_root,
-                    client_id=self.client_id,
-                    client_secret=self.client_secret,
-                    bearer_token=self.bearer_token,
-                )
-            )
+            workspace = self._get_direct_workspace_info(direct_workspace_id)
+            if workspace is None:
+                continue
             if name is not None and workspace.name != name:
                 continue
             if name_substring is not None and name_substring not in workspace.name.casefold():
@@ -699,7 +693,13 @@ class CloudClient:
             direct_workspace_ids = self._get_direct_workspace_ids()
         except (AirbyteError, exc.PyAirbyteInputError):
             return None
-        return direct_workspace_ids[0] if len(direct_workspace_ids) == 1 else None
+        if len(direct_workspace_ids) != 1:
+            return None
+        try:
+            workspace_info = self._get_direct_workspace_info(direct_workspace_ids[0])
+        except (AirbyteError, exc.PyAirbyteInputError):
+            return None
+        return direct_workspace_ids[0] if workspace_info is not None else None
 
     def _get_user_permissions(self) -> tuple[dict[str, Any], ...]:
         """Get and cache permissions for the authenticated user."""
@@ -744,6 +744,25 @@ class CloudClient:
             if isinstance(workspace_id, str) and workspace_id and workspace_id not in workspace_ids:
                 workspace_ids.append(workspace_id)
         return tuple(workspace_ids)
+
+    def _get_direct_workspace_info(self, workspace_id: str) -> CloudWorkspaceInfo | None:
+        """Fetch a directly granted workspace, or `None` if the grant is stale (404)."""
+        if workspace_id in self._direct_workspace_infos:
+            return self._direct_workspace_infos[workspace_id]
+        try:
+            workspace = api_util.get_workspace(
+                workspace_id=workspace_id,
+                api_root=self.public_api_root,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                bearer_token=self.bearer_token,
+            )
+        except exc.AirbyteMissingResourceError:
+            self._direct_workspace_infos[workspace_id] = None
+            return None
+        workspace_info = CloudWorkspaceInfo.from_api_response(workspace)
+        self._direct_workspace_infos[workspace_id] = workspace_info
+        return workspace_info
 
     def _is_instance_admin(self) -> bool:
         """Return whether the caller has an instance-admin permission."""

--- a/airbyte/cloud/client.py
+++ b/airbyte/cloud/client.py
@@ -325,6 +325,7 @@ class CloudClient:
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
         all_organizations: bool = False,
+        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
@@ -340,10 +341,11 @@ class CloudClient:
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
         all_organizations: bool = False,
+        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         raise NotImplementedError
 
-    def list_workspaces(  # noqa: PLR0912
+    def list_workspaces(  # noqa: PLR0912, PLR0913, PLR0915
         self,
         name: str | None = None,
         *,
@@ -354,10 +356,14 @@ class CloudClient:
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
         all_organizations: bool = False,
+        member_only: bool = False,
     ) -> list[CloudWorkspaceInfo]:
         """List workspaces available to this client.
 
         See the module docstring for how the organization context is resolved.
+
+        When `member_only` is enabled, return only the caller's direct workspace
+        grants and do not resolve or enumerate organizations.
         """
         if limit is not None and limit <= 0:
             raise exc.PyAirbyteInputError(message="`limit` must be greater than 0.")
@@ -368,6 +374,15 @@ class CloudClient:
         has_explicit_organization = organization_id is not None or organization_name is not None
         has_explicit_workspace = workspace_id is not None
 
+        if member_only and (
+            has_explicit_organization or has_explicit_workspace or all_organizations
+        ):
+            raise exc.PyAirbyteInputError(
+                message=(
+                    "The member_only option cannot be combined with an organization, "
+                    "workspace, or all_organizations option."
+                )
+            )
         if all_organizations and (has_explicit_organization or has_explicit_workspace):
             raise exc.PyAirbyteInputError(
                 message=(
@@ -383,6 +398,31 @@ class CloudClient:
             raise exc.PyAirbyteInputError(
                 message="You can provide name or name_contains, but not both."
             )
+        if member_only:
+            workspaces = [
+                CloudWorkspaceInfo.from_api_response(
+                    api_util.get_workspace(
+                        workspace_id=workspace_id,
+                        api_root=self.public_api_root,
+                        client_id=self.client_id,
+                        client_secret=self.client_secret,
+                        bearer_token=self.bearer_token,
+                    )
+                )
+                for workspace_id in self._get_direct_workspace_ids()
+            ]
+            if name is not None:
+                workspaces = [workspace for workspace in workspaces if workspace.name == name]
+            elif name_contains is not None:
+                name_substring = name_contains.casefold()
+                workspaces = [
+                    workspace
+                    for workspace in workspaces
+                    if name_substring in workspace.name.casefold()
+                ]
+            elif name_filter is not None:
+                workspaces = [workspace for workspace in workspaces if name_filter(workspace.name)]
+            return workspaces if limit is None else workspaces[:limit]
         if all_organizations:
             resolved_organization_id = None
         else:
@@ -393,7 +433,7 @@ class CloudClient:
                     workspace_id=workspace_id,
                 )
             except exc.PyAirbyteInputError:
-                direct_workspaces = self._try_list_direct_workspaces(
+                direct_workspaces = self._try_list_member_workspaces(
                     name=name,
                     name_contains=name_contains,
                     name_filter=name_filter,
@@ -403,7 +443,7 @@ class CloudClient:
                     return direct_workspaces
                 raise
         if resolved_organization_id is None and not all_organizations:
-            direct_workspaces = self._try_list_direct_workspaces(
+            direct_workspaces = self._try_list_member_workspaces(
                 name=name,
                 name_contains=name_contains,
                 name_filter=name_filter,
@@ -411,7 +451,7 @@ class CloudClient:
             )
             if direct_workspaces:
                 return direct_workspaces
-            if not all_organizations and self._try_is_instance_admin():
+            if self._try_is_instance_admin():
                 raise exc.PyAirbyteInputError(
                     message=(
                         "Call `get_default_cloud_context` first. An organization or "
@@ -466,7 +506,7 @@ class CloudClient:
             workspace_infos = workspace_infos[:limit]
         return workspace_infos
 
-    def list_direct_workspaces(
+    def _try_list_member_workspaces(
         self,
         *,
         name: str | None = None,
@@ -474,53 +514,14 @@ class CloudClient:
         name_filter: Callable[[str], bool] | None = None,
         limit: int | None = None,
     ) -> list[CloudWorkspaceInfo]:
-        """List workspaces granted directly to the authenticated user."""
-        if name is not None and name_contains is not None:
-            raise exc.PyAirbyteInputError(
-                message="You can provide name or name_contains, but not both."
-            )
-        if name_contains is not None and name_filter is not None:
-            raise exc.PyAirbyteInputError(
-                message="You can provide name_contains or name_filter, but not both."
-            )
-        workspaces = [
-            CloudWorkspaceInfo.from_api_response(
-                api_util.get_workspace(
-                    workspace_id=workspace_id,
-                    api_root=self.public_api_root,
-                    client_id=self.client_id,
-                    client_secret=self.client_secret,
-                    bearer_token=self.bearer_token,
-                )
-            )
-            for workspace_id in self._get_direct_workspace_ids()
-        ]
-        if name is not None:
-            workspaces = [workspace for workspace in workspaces if workspace.name == name]
-        elif name_contains is not None:
-            name_substring = name_contains.casefold()
-            workspaces = [
-                workspace for workspace in workspaces if name_substring in workspace.name.casefold()
-            ]
-        elif name_filter is not None:
-            workspaces = [workspace for workspace in workspaces if name_filter(workspace.name)]
-        return workspaces if limit is None else workspaces[:limit]
-
-    def _try_list_direct_workspaces(
-        self,
-        *,
-        name: str | None = None,
-        name_contains: str | None = None,
-        name_filter: Callable[[str], bool] | None = None,
-        limit: int | None = None,
-    ) -> list[CloudWorkspaceInfo]:
-        """List direct workspaces, degrading to an empty result on lookup errors."""
+        """List member workspaces, degrading to an empty result on lookup errors."""
         try:
-            return self.list_direct_workspaces(
+            return self.list_workspaces(
                 name=name,
                 name_contains=name_contains,
                 name_filter=name_filter,
                 limit=limit,
+                member_only=True,
             )
         except (AirbyteError, exc.PyAirbyteInputError):
             return []
@@ -755,7 +756,7 @@ class CloudClient:
         else:
             membership_organization_ids = self._get_membership_organization_ids()
             try:
-                member_workspaces = self.list_direct_workspaces(limit=25)
+                member_workspaces = self.list_workspaces(member_only=True, limit=25)
             except (AirbyteError, exc.PyAirbyteInputError):
                 member_workspaces = []
 

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -132,7 +132,7 @@ class CloudOrganizationInfo(BaseModel):
 
 
 class CloudDefaultContextInfo(BaseModel):
-    """Information about the authenticated Cloud user's current context."""
+    """Explicit organization and workspace affinities for the authenticated user."""
 
     user_id: str | None
     """The Airbyte user ID, if available."""
@@ -143,23 +143,23 @@ class CloudDefaultContextInfo(BaseModel):
     user_email: str | None
     """The authenticated user's email, if available."""
 
-    is_instance_admin: bool
-    """Whether the authenticated user has an instance-admin permission."""
-
     default_workspace_id: str | None
     """The resolved default workspace ID, if available."""
+
+    configured_workspace_id: str | None
+    """The explicitly configured workspace ID, if available."""
 
     configured_organization_id: str | None
     """The configured organization ID, if available."""
 
-    membership_organizations: list[CloudOrganizationInfo]
-    """Organizations identified by organization-scoped permissions."""
+    member_organizations: list[CloudOrganizationInfo]
+    """Organizations identified by explicit organization membership grants."""
 
-    direct_workspaces: list[CloudWorkspaceInfo]
-    """Workspaces identified by direct workspace-scoped permissions."""
+    member_workspaces: list[CloudWorkspaceInfo]
+    """Workspaces identified by explicit workspace membership grants."""
 
-    resolution_notes: list[str]
-    """Notes about unavailable identity or context resolution data."""
+    discovery_hints: list[str]
+    """Hints for discovering additional organizations or workspaces."""
 
 
 class CloudConnectionInfo(BaseModel):

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -119,6 +119,49 @@ class CloudWorkspaceInfo(BaseModel):
         return self.model_dump(mode="json")
 
 
+class CloudOrganizationInfo(BaseModel):
+    """Information about an Airbyte organization."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    organization_id: str = Field(alias="organizationId")
+    """The organization ID."""
+
+    organization_name: str | None = Field(default=None, alias="organizationName")
+    """The organization name, if available."""
+
+
+class CloudDefaultContextInfo(BaseModel):
+    """Information about the authenticated Cloud user's current context."""
+
+    user_id: str | None
+    """The Airbyte user ID, if available."""
+
+    user_name: str | None
+    """The authenticated user's name, if available."""
+
+    user_email: str | None
+    """The authenticated user's email, if available."""
+
+    is_instance_admin: bool
+    """Whether the authenticated user has an instance-admin permission."""
+
+    default_workspace_id: str | None
+    """The resolved default workspace ID, if available."""
+
+    configured_organization_id: str | None
+    """The configured organization ID, if available."""
+
+    membership_organizations: list[CloudOrganizationInfo]
+    """Organizations identified by organization-scoped permissions."""
+
+    direct_workspaces: list[CloudWorkspaceInfo]
+    """Workspaces identified by direct workspace-scoped permissions."""
+
+    resolution_notes: list[str]
+    """Notes about unavailable identity or context resolution data."""
+
+
 class CloudConnectionInfo(BaseModel):
     """Information about an Airbyte Cloud connection."""
 

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -76,6 +76,15 @@ class JobTypeEnum(str, Enum):
     CLEAR = "clear"
 
 
+class WorkspacePrivilegeScope(str, Enum):
+    """How broadly `list_workspaces` searches for workspaces."""
+
+    MEMBER_OF = "member_of"
+    ORGANIZATION_ADMIN = "organization_admin"
+    INSTANCE_ADMIN = "instance_admin"
+    ANY = "any"
+
+
 class CloudWorkspaceInfo(BaseModel):
     """Information about an Airbyte workspace."""
 

--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -167,6 +167,12 @@ class CloudDefaultContextInfo(BaseModel):
     member_workspaces: list[CloudWorkspaceInfo]
     """Workspaces identified by explicit workspace membership grants."""
 
+    member_organizations_truncated: bool
+    """True if organization memberships beyond the returned list were omitted."""
+
+    member_workspaces_truncated: bool
+    """True if workspace memberships beyond the returned list were omitted."""
+
     discovery_hints: list[str]
     """Hints for discovering additional organizations or workspaces."""
 

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -131,7 +131,10 @@ class CloudWorkspace:
         if not credentials.workspace_id:
             raise exc.PyAirbyteInputError(
                 message="Workspace ID is required.",
-                guidance=("Call `get_default_cloud_context` first, then provide a workspace ID."),
+                guidance=(
+                    "Provide a workspace ID, or call `get_default_cloud_context` to discover "
+                    "available workspaces."
+                ),
             )
 
         self._credentials = credentials

--- a/airbyte/cloud/workspaces.py
+++ b/airbyte/cloud/workspaces.py
@@ -131,7 +131,7 @@ class CloudWorkspace:
         if not credentials.workspace_id:
             raise exc.PyAirbyteInputError(
                 message="Workspace ID is required.",
-                guidance="Provide a workspace ID.",
+                guidance=("Call `get_default_cloud_context` first, then provide a workspace ID."),
             )
 
         self._credentials = credentials

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -285,7 +285,8 @@ class AirbyteMissingWorkspaceContextError(PyAirbyteInputError):
             return
         if is_hosted_mcp_mode():
             self.guidance = (
-                "The authenticated user's default workspace was checked. If it was not "
+                "Call `get_default_cloud_context` first. The authenticated user's "
+                "default workspace was checked. If it was not "
                 "available, call `list_cloud_workspaces`, which resolves the organization "
                 "automatically; only call `list_cloud_organizations` to search "
                 "organizations by name. If discovery returns exactly one workspace, "
@@ -294,7 +295,8 @@ class AirbyteMissingWorkspaceContextError(PyAirbyteInputError):
             )
         else:
             self.guidance = (
-                "The authenticated user's default workspace was checked. If it was not "
+                "Call `get_default_cloud_context` first. The authenticated user's "
+                "default workspace was checked. If it was not "
                 "available, call `list_cloud_workspaces`, which resolves the organization "
                 "automatically; only call `list_cloud_organizations` to search "
                 "organizations by name. If discovery returns exactly one workspace, "

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -285,23 +285,23 @@ class AirbyteMissingWorkspaceContextError(PyAirbyteInputError):
             return
         if is_hosted_mcp_mode():
             self.guidance = (
-                "Call `get_default_cloud_context` first. The authenticated user's "
-                "default workspace was checked. If it was not "
+                "The authenticated user's default workspace was checked. If it was not "
                 "available, call `list_cloud_workspaces`, which resolves the organization "
                 "automatically; only call `list_cloud_organizations` to search "
                 "organizations by name. If discovery returns exactly one workspace, "
                 f"provide its ID via the `{MCP_WORKSPACE_ID_HEADER}` header or the "
-                "`workspace_id` parameter; otherwise ask the user to choose."
+                "`workspace_id` parameter; otherwise ask the user to choose. Call "
+                "`get_default_cloud_context` to inspect your memberships."
             )
         else:
             self.guidance = (
-                "Call `get_default_cloud_context` first. The authenticated user's "
-                "default workspace was checked. If it was not "
+                "The authenticated user's default workspace was checked. If it was not "
                 "available, call `list_cloud_workspaces`, which resolves the organization "
                 "automatically; only call `list_cloud_organizations` to search "
                 "organizations by name. If discovery returns exactly one workspace, "
                 f"set its ID in `{CLOUD_WORKSPACE_ID_ENV_VAR}` or pass the "
-                "`workspace_id` parameter; otherwise ask the user to choose."
+                "`workspace_id` parameter; otherwise ask the user to choose. Call "
+                "`get_default_cloud_context` to inspect your memberships."
             )
 
 

--- a/airbyte/exceptions.py
+++ b/airbyte/exceptions.py
@@ -49,9 +49,7 @@ from airbyte.constants import (
     CLOUD_BEARER_TOKEN_ENV_VAR,
     CLOUD_CLIENT_ID_ENV_VAR,
     CLOUD_CLIENT_SECRET_ENV_VAR,
-    CLOUD_WORKSPACE_ID_ENV_VAR,
     MCP_BEARER_TOKEN_HEADER,
-    MCP_WORKSPACE_ID_HEADER,
     is_hosted_mcp_mode,
 )
 
@@ -285,23 +283,23 @@ class AirbyteMissingWorkspaceContextError(PyAirbyteInputError):
             return
         if is_hosted_mcp_mode():
             self.guidance = (
-                "The authenticated user's default workspace was checked. If it was not "
-                "available, call `list_cloud_workspaces`, which resolves the organization "
-                "automatically; only call `list_cloud_organizations` to search "
-                "organizations by name. If discovery returns exactly one workspace, "
-                f"provide its ID via the `{MCP_WORKSPACE_ID_HEADER}` header or the "
-                "`workspace_id` parameter; otherwise ask the user to choose. Call "
+                "The authenticated user's default workspace was checked and none was "
+                "available. `list_cloud_workspaces` returns direct workspace memberships "
+                "by default; pass `organization_id`/`organization_name` or a broader "
+                "`privilege_scope` for organization-wide discovery, or call "
+                "`list_cloud_organizations` to search organizations by name. If exactly "
+                "one workspace is found, use it; otherwise ask the user to choose. Call "
                 "`get_default_cloud_context` to inspect your memberships."
             )
         else:
             self.guidance = (
-                "The authenticated user's default workspace was checked. If it was not "
-                "available, call `list_cloud_workspaces`, which resolves the organization "
-                "automatically; only call `list_cloud_organizations` to search "
-                "organizations by name. If discovery returns exactly one workspace, "
-                f"set its ID in `{CLOUD_WORKSPACE_ID_ENV_VAR}` or pass the "
-                "`workspace_id` parameter; otherwise ask the user to choose. Call "
-                "`get_default_cloud_context` to inspect your memberships."
+                "The authenticated user's default workspace was checked and none was "
+                "available. `list_workspaces` returns direct workspace memberships "
+                "by default; pass `organization_id`/`organization_name` or a broader "
+                "`privilege_scope` for organization-wide discovery, or call "
+                "`list_organizations` to search organizations by name. If exactly "
+                "one workspace is found, use it; otherwise ask the user to choose. Call "
+                "`get_default_context_for_user` to inspect your memberships."
             )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1661,12 +1661,10 @@ def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
     truncated_memberships: list[str] = []
     if context.member_organizations_truncated:
         truncated_memberships.append(
-            f"the first {len(context.member_organizations)} organization memberships"
+            f"{len(context.member_organizations)} organization memberships"
         )
     if context.member_workspaces_truncated:
-        truncated_memberships.append(
-            f"the first {len(context.member_workspaces)} workspace memberships"
-        )
+        truncated_memberships.append(f"{len(context.member_workspaces)} workspace memberships")
     message = (
         "These lists are membership-based, not access-based: they show explicit "
         "organization and workspace memberships only. Use default_workspace_id, "
@@ -1674,10 +1672,9 @@ def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
         "member_organizations."
     )
     if truncated_memberships:
-        shown = " and ".join(item.removeprefix("the first ") for item in truncated_memberships)
         message += (
-            f" Only the first {shown} are shown; use list_cloud_organizations or "
-            "list_cloud_workspaces to see the rest."
+            f" Only the first {' and '.join(truncated_memberships)} are shown; use "
+            "list_cloud_organizations or list_cloud_workspaces to see the rest."
         )
     return CloudDefaultContextResult(
         **context.model_dump(),

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -26,7 +26,12 @@ from airbyte.cloud.client import (
 )
 from airbyte.cloud.connectors import CheckResult, CustomCloudSourceDefinition
 from airbyte.cloud.constants import FAILED_STATUSES
-from airbyte.cloud.models import JobTypeEnum
+from airbyte.cloud.models import (
+    CloudDefaultContextInfo,
+    CloudOrganizationInfo,
+    CloudWorkspaceInfo,
+    JobTypeEnum,
+)
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.constants import (
     CLOUD_BEARER_TOKEN_ENV_VAR,
@@ -62,7 +67,8 @@ CLOUD_AUTH_TIP_TEXT = (
     f"`{MCP_BEARER_TOKEN_HEADER}` header, or client credentials via the transport "
     f"`Client-Id` and `Client-Secret` headers. When no workspace ID is provided, "
     f"the authenticated user's default workspace (and its organization) is used "
-    f"automatically. To discover other workspaces, call `list_cloud_workspaces`, "
+    f"automatically. Call `get_default_cloud_context` first to inspect the resolved "
+    f"context. To discover other workspaces, call `list_cloud_workspaces`, "
     f"which resolves your organization automatically. Only call "
     f"`list_cloud_organizations` when you need to search organizations by name, "
     f"passing `name_contains`. For local or "
@@ -277,6 +283,40 @@ class CloudWorkspaceListResult(BaseModel):
 
     available_organizations: list[CloudOrganizationResult] | None = None
     """Organizations to choose from when the credentials match multiple organizations."""
+
+
+class CloudDefaultContextResult(BaseModel):
+    """Current authenticated Cloud user context and resolution guidance."""
+
+    user_id: str | None
+    """The Airbyte user ID, if available."""
+
+    user_name: str | None
+    """The authenticated user's name, if available."""
+
+    user_email: str | None
+    """The authenticated user's email, if available."""
+
+    is_instance_admin: bool
+    """Whether the authenticated user has an instance-admin permission."""
+
+    default_workspace_id: str | None
+    """The resolved default workspace ID, if available."""
+
+    configured_organization_id: str | None
+    """The configured organization ID, if available."""
+
+    membership_organizations: list[CloudOrganizationInfo]
+    """Organizations identified by organization-scoped permissions."""
+
+    direct_workspaces: list[CloudWorkspaceInfo]
+    """Workspaces identified by direct workspace-scoped permissions."""
+
+    resolution_notes: list[str]
+    """Notes about unavailable identity or context resolution data."""
+
+    message: str
+    """Guidance for selecting a workspace or organization context."""
 
 
 class LogReadResult(BaseModel):
@@ -1494,7 +1534,7 @@ def list_deployed_cloud_connections(
     open_world=True,
     extra_help_text=CLOUD_AUTH_TIP_TEXT,
 )
-def list_cloud_workspaces(
+def list_cloud_workspaces(  # noqa: PLR0912
     ctx: Context,
     *,
     organization_id: Annotated[
@@ -1545,6 +1585,17 @@ def list_cloud_workspaces(
         candidates = context.get("organization_candidates")
         if not isinstance(candidates, list):
             raise
+        direct_workspace_lister = getattr(client, "list_direct_workspaces", None)
+        if callable(direct_workspace_lister):
+            try:
+                direct_workspaces = direct_workspace_lister(
+                    name_contains=name_contains,
+                    limit=limit,
+                )
+            except (AirbyteError, PyAirbyteInputError):
+                direct_workspaces = []
+        else:
+            direct_workspaces = []
         available_organizations: list[CloudOrganizationResult] = []
         for candidate in candidates:
             if not isinstance(candidate, dict):
@@ -1560,13 +1611,22 @@ def list_cloud_workspaces(
                 )
             )
         message = error.get_message()
+        if "get_default_cloud_context" not in message:
+            message = f"Call `get_default_cloud_context` first. {message}"
         if available_organizations:
             message += (
                 " Retry with an explicit organization ID from the provided list of the "
                 "available organizations."
             )
         return CloudWorkspaceListResult(
-            workspaces=[],
+            workspaces=[
+                CloudWorkspaceResult(
+                    workspace_id=workspace.workspace_id,
+                    workspace_name=workspace.name,
+                    organization_id=workspace.organization_id,
+                )
+                for workspace in direct_workspaces
+            ],
             available_organizations=available_organizations,
             message=message,
         )
@@ -1625,6 +1685,24 @@ def list_cloud_workspaces(
     open_world=True,
     extra_help_text=CLOUD_AUTH_TIP_TEXT,
 )
+def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
+    """Return the authenticated user's default Cloud context."""
+    context: CloudDefaultContextInfo = _get_cloud_client(ctx).get_default_context()
+    return CloudDefaultContextResult(
+        **context.model_dump(),
+        message=(
+            "Use default_workspace_id, pass workspace_id from direct_workspaces, "
+            "or pick an organization from membership_organizations."
+        ),
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
 def list_cloud_organizations(
     ctx: Context,
     name_contains: Annotated[
@@ -1662,8 +1740,9 @@ def list_cloud_organizations(
         return CloudOrganizationListResult(
             organizations=[],
             message=(
-                "No organizations were returned for these credentials. Verify the "
-                "credentials or ask the user to provide an organization ID."
+                "Call `get_default_cloud_context` first. No organizations were returned "
+                "for these credentials. Verify the credentials or ask the user to provide "
+                "an organization ID."
             ),
         )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1684,7 +1684,7 @@ def list_cloud_workspaces(
 )
 def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
     """Return the authenticated user's default Cloud context."""
-    context: CloudDefaultContextInfo = _get_cloud_client(ctx).get_default_context()
+    context: CloudDefaultContextInfo = _get_cloud_client(ctx).get_default_context_for_user()
     return CloudDefaultContextResult(
         **context.model_dump(),
         message=(

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1534,7 +1534,7 @@ def list_deployed_cloud_connections(
     open_world=True,
     extra_help_text=CLOUD_AUTH_TIP_TEXT,
 )
-def list_cloud_workspaces(  # noqa: PLR0912
+def list_cloud_workspaces(
     ctx: Context,
     *,
     organization_id: Annotated[
@@ -1585,16 +1585,12 @@ def list_cloud_workspaces(  # noqa: PLR0912
         candidates = context.get("organization_candidates")
         if not isinstance(candidates, list):
             raise
-        direct_workspace_lister = getattr(client, "list_direct_workspaces", None)
-        if callable(direct_workspace_lister):
-            try:
-                direct_workspaces = direct_workspace_lister(
-                    name_contains=name_contains,
-                    limit=limit,
-                )
-            except (AirbyteError, PyAirbyteInputError):
-                direct_workspaces = []
-        else:
+        try:
+            direct_workspaces = client.list_direct_workspaces(
+                name_contains=name_contains,
+                limit=limit,
+            )
+        except (AirbyteError, PyAirbyteInputError):
             direct_workspaces = []
         available_organizations: list[CloudOrganizationResult] = []
         for candidate in candidates:

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1586,9 +1586,10 @@ def list_cloud_workspaces(
         if not isinstance(candidates, list):
             raise
         try:
-            direct_workspaces = client.list_direct_workspaces(
+            direct_workspaces = client.list_workspaces(
                 name_contains=name_contains,
                 limit=limit,
+                member_only=True,
             )
         except (AirbyteError, PyAirbyteInputError):
             direct_workspaces = []

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -31,6 +31,7 @@ from airbyte.cloud.models import (
     CloudOrganizationInfo,
     CloudWorkspaceInfo,
     JobTypeEnum,
+    WorkspacePrivilegeScope,
 )
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.constants import (
@@ -68,8 +69,8 @@ CLOUD_AUTH_TIP_TEXT = (
     f"`Client-Id` and `Client-Secret` headers. When no workspace ID is provided, "
     f"the authenticated user's default workspace (and its organization) is used "
     f"automatically. Call `get_default_cloud_context` first to inspect the resolved "
-    f"context. To discover other workspaces, call `list_cloud_workspaces`, "
-    f"which resolves your organization automatically. Only call "
+    f"context. To discover other workspaces, call `list_cloud_workspaces` "
+    f"with an organization ID or broader privilege scope. Only call "
     f"`list_cloud_organizations` when you need to search organizations by name, "
     f"passing `name_contains`. For local or "
     f"stdio connections, set the `{CLOUD_BEARER_TOKEN_ENV_VAR}` environment "
@@ -1565,11 +1566,21 @@ def list_cloud_workspaces(
             default=None,
         ),
     ],
+    privilege_scope: Annotated[
+        WorkspacePrivilegeScope,
+        Field(
+            description=(
+                "How broadly to search: direct memberships by default, organization "
+                "memberships, instance-wide admin access, or any available scope."
+            ),
+            default=WorkspacePrivilegeScope.MEMBER_OF,
+        ),
+    ],
 ) -> CloudWorkspaceListResult:
     """List all workspaces visible to the authenticated credentials.
 
-    The client resolves an organization from the provided IDs, workspace context, or
-    the authenticated user's organization memberships.
+    The default returns direct workspace memberships. Use `organization_id` or a broader
+    `privilege_scope` to discover more workspaces.
     """
     client = _get_cloud_client(ctx)
 
@@ -1579,53 +1590,7 @@ def list_cloud_workspaces(
             organization_name=organization_name,
             name_contains=name_contains,
             limit=limit,
-        )
-    except PyAirbyteInputError as error:
-        context = error.context or {}
-        candidates = context.get("organization_candidates")
-        if not isinstance(candidates, list):
-            raise
-        try:
-            direct_workspaces = client.list_workspaces(
-                name_contains=name_contains,
-                limit=limit,
-                member_only=True,
-            )
-        except (AirbyteError, PyAirbyteInputError):
-            direct_workspaces = []
-        available_organizations: list[CloudOrganizationResult] = []
-        for candidate in candidates:
-            if not isinstance(candidate, dict):
-                continue
-            candidate_id = candidate.get("organization_id")
-            if not isinstance(candidate_id, str):
-                continue
-            candidate_name = candidate.get("organization_name")
-            available_organizations.append(
-                CloudOrganizationResult(
-                    id=candidate_id,
-                    name=candidate_name if isinstance(candidate_name, str) else None,
-                )
-            )
-        message = error.get_message()
-        if "get_default_cloud_context" not in message:
-            message = f"Call `get_default_cloud_context` first. {message}"
-        if available_organizations:
-            message += (
-                " Retry with an explicit organization ID from the provided list of the "
-                "available organizations."
-            )
-        return CloudWorkspaceListResult(
-            workspaces=[
-                CloudWorkspaceResult(
-                    workspace_id=workspace.workspace_id,
-                    workspace_name=workspace.name,
-                    organization_id=workspace.organization_id,
-                )
-                for workspace in direct_workspaces
-            ],
-            available_organizations=available_organizations,
-            message=message,
+            privilege_scope=privilege_scope,
         )
     except AirbyteError as error:
         return _handle_discovery_permission_error(

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -313,6 +313,12 @@ class CloudDefaultContextResult(BaseModel):
     member_workspaces: list[CloudWorkspaceInfo]
     """Workspaces identified by explicit workspace membership grants."""
 
+    member_organizations_truncated: bool
+    """True if organization memberships beyond the returned list were omitted."""
+
+    member_workspaces_truncated: bool
+    """True if workspace memberships beyond the returned list were omitted."""
+
     discovery_hints: list[str]
     """Hints for discovering additional organizations or workspaces."""
 
@@ -1613,8 +1619,10 @@ def list_cloud_workspaces(
         result.organization_id for result in results if result.organization_id is not None
     }
     message = (
-        "No workspaces were returned for these credentials. Verify the "
-        "credentials or ask the user to provide a workspace ID."
+        "No workspaces were returned for these credentials. By default only direct "
+        "workspace memberships are listed; pass `organization_id` or a broader "
+        "`privilege_scope` to discover organization-wide workspaces, or call "
+        "`get_default_cloud_context` to inspect your memberships."
         if not results
         else None
     )
@@ -1650,14 +1658,30 @@ def list_cloud_workspaces(
 def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
     """Return the authenticated user's default Cloud context."""
     context: CloudDefaultContextInfo = _get_cloud_client(ctx).get_default_context_for_user()
+    truncated_memberships: list[str] = []
+    if context.member_organizations_truncated:
+        truncated_memberships.append(
+            f"the first {len(context.member_organizations)} organization memberships"
+        )
+    if context.member_workspaces_truncated:
+        truncated_memberships.append(
+            f"the first {len(context.member_workspaces)} workspace memberships"
+        )
+    message = (
+        "These lists are membership-based, not access-based: they show explicit "
+        "organization and workspace memberships only. Use default_workspace_id, "
+        "pass workspace_id from member_workspaces, or pick an organization from "
+        "member_organizations."
+    )
+    if truncated_memberships:
+        shown = " and ".join(item.removeprefix("the first ") for item in truncated_memberships)
+        message += (
+            f" Only the first {shown} are shown; use list_cloud_organizations or "
+            "list_cloud_workspaces to see the rest."
+        )
     return CloudDefaultContextResult(
         **context.model_dump(),
-        message=(
-            "These lists are membership-based, not access-based: they show explicit "
-            "organization and workspace memberships only. Use default_workspace_id, "
-            "pass workspace_id from member_workspaces, or pick an organization from "
-            "member_organizations."
-        ),
+        message=message,
     )
 
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -286,7 +286,7 @@ class CloudWorkspaceListResult(BaseModel):
 
 
 class CloudDefaultContextResult(BaseModel):
-    """Current authenticated Cloud user context and resolution guidance."""
+    """Explicit authenticated Cloud affinities and discovery guidance."""
 
     user_id: str | None
     """The Airbyte user ID, if available."""
@@ -297,23 +297,23 @@ class CloudDefaultContextResult(BaseModel):
     user_email: str | None
     """The authenticated user's email, if available."""
 
-    is_instance_admin: bool
-    """Whether the authenticated user has an instance-admin permission."""
-
     default_workspace_id: str | None
     """The resolved default workspace ID, if available."""
+
+    configured_workspace_id: str | None
+    """The explicitly configured workspace ID, if available."""
 
     configured_organization_id: str | None
     """The configured organization ID, if available."""
 
-    membership_organizations: list[CloudOrganizationInfo]
-    """Organizations identified by organization-scoped permissions."""
+    member_organizations: list[CloudOrganizationInfo]
+    """Organizations identified by explicit organization membership grants."""
 
-    direct_workspaces: list[CloudWorkspaceInfo]
-    """Workspaces identified by direct workspace-scoped permissions."""
+    member_workspaces: list[CloudWorkspaceInfo]
+    """Workspaces identified by explicit workspace membership grants."""
 
-    resolution_notes: list[str]
-    """Notes about unavailable identity or context resolution data."""
+    discovery_hints: list[str]
+    """Hints for discovering additional organizations or workspaces."""
 
     message: str
     """Guidance for selecting a workspace or organization context."""
@@ -1691,8 +1691,10 @@ def get_default_cloud_context(ctx: Context) -> CloudDefaultContextResult:
     return CloudDefaultContextResult(
         **context.model_dump(),
         message=(
-            "Use default_workspace_id, pass workspace_id from direct_workspaces, "
-            "or pick an organization from membership_organizations."
+            "These lists are membership-based, not access-based: they show explicit "
+            "organization and workspace memberships only. Use default_workspace_id, "
+            "pass workspace_id from member_workspaces, or pick an organization from "
+            "member_organizations."
         ),
     )
 

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -68,7 +68,7 @@ CLOUD_AUTH_TIP_TEXT = (
     f"`{MCP_BEARER_TOKEN_HEADER}` header, or client credentials via the transport "
     f"`Client-Id` and `Client-Secret` headers. When no workspace ID is provided, "
     f"the authenticated user's default workspace (and its organization) is used "
-    f"automatically. Call `get_default_cloud_context` first to inspect the resolved "
+    f"automatically. Call `get_default_cloud_context` to inspect the resolved "
     f"context. To discover other workspaces, call `list_cloud_workspaces` "
     f"with an organization ID or broader privilege scope. Only call "
     f"`list_cloud_organizations` when you need to search organizations by name, "
@@ -1704,9 +1704,9 @@ def list_cloud_organizations(
         return CloudOrganizationListResult(
             organizations=[],
             message=(
-                "Call `get_default_cloud_context` first. No organizations were returned "
-                "for these credentials. Verify the credentials or ask the user to provide "
-                "an organization ID."
+                "No organizations were returned for these credentials. Verify the credentials "
+                "or ask the user to provide an organization ID. Call "
+                "`get_default_cloud_context` to inspect your memberships."
             ),
         )
 

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -122,6 +122,15 @@ def test_get_user_id_from_bearer_token() -> None:
     )
 
 
+def test_get_user_id_from_bearer_token_falls_back_to_subject() -> None:
+    assert (
+        api_util.get_user_id_from_bearer_token(
+            SecretString("header.eyJzdWIiOiJhdXRoLXVzZXItaWQifQ.signature")
+        )
+        == "auth-user-id"
+    )
+
+
 @pytest.mark.parametrize(
     ("token", "expected_message"),
     [
@@ -137,7 +146,7 @@ def test_get_user_id_from_bearer_token() -> None:
         ),
         pytest.param(
             "header.e30.signature",
-            "does not contain a user ID",
+            "does not contain a user_id or sub claim",
             id="missing-user-id",
         ),
     ],

--- a/tests/unit_tests/test_cloud_api_util.py
+++ b/tests/unit_tests/test_cloud_api_util.py
@@ -17,6 +17,7 @@ from airbyte.exceptions import (
 )
 from airbyte.secrets.base import SecretString
 from airbyte_api import api, models
+from airbyte_api.errors import SDKError
 
 
 def _job_response(job_id: int) -> models.JobResponse:
@@ -111,6 +112,32 @@ def _list_workspaces_response(
             next=next_page,
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_error_type"),
+    [
+        pytest.param(404, AirbyteMissingResourceError, id="not_found"),
+        pytest.param(500, AirbyteError, id="server_error"),
+    ],
+)
+def test_wrap_sdk_error_classifies_not_found(
+    status_code: int,
+    expected_error_type: type[AirbyteError],
+) -> None:
+    raw_response = requests.Response()
+    raw_response.status_code = status_code
+    raw_response.url = "https://api.airbyte.com/v1/workspaces/workspace-id"
+    error = SDKError(
+        "Workspace lookup failed.", status_code, "response body", raw_response
+    )
+
+    wrapped = api_util._wrap_sdk_error(error, {"workspace_id": "workspace-id"})
+
+    assert type(wrapped) is expected_error_type
+    assert wrapped.get_message() == "API error occurred: Workspace lookup failed."
+    assert wrapped.context["workspace_id"] == "workspace-id"
+    assert wrapped.context["status_code"] == status_code
 
 
 def test_get_user_id_from_bearer_token() -> None:

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -304,15 +304,15 @@ def test_get_default_context_is_bounded_to_permission_derived_scope() -> None:
         context = CloudClient(bearer_token="token").get_default_context()
 
     assert context.user_id == "user-id"
-    assert context.is_instance_admin is True
     assert context.default_workspace_id is None
-    assert [item.organization_id for item in context.membership_organizations] == [
+    assert [item.organization_id for item in context.member_organizations] == [
         "organization-1",
         "organization-2",
     ]
-    assert [item.workspace_id for item in context.direct_workspaces] == [
+    assert [item.workspace_id for item in context.member_workspaces] == [
         f"workspace-{index}" for index in range(1, 7)
     ]
+    assert len(context.discovery_hints) == 2
 
 
 def test_get_default_context_degrades_without_token_identity() -> None:
@@ -330,4 +330,4 @@ def test_get_default_context_degrades_without_token_identity() -> None:
         context = CloudClient(bearer_token="token").get_default_context()
 
     assert context.user_id is None
-    assert any("no user identity claim" in note for note in context.resolution_notes)
+    assert context.discovery_hints == []

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -120,6 +120,67 @@ def test_list_workspaces_member_only_rejects_organization_context() -> None:
         )
 
 
+def test_list_workspaces_member_only_fetches_only_until_limit() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {"permissionType": "workspace_admin", "workspaceId": f"workspace-{index}"}
+            for index in range(1, 4)
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            return_value=models.WorkspaceResponse(
+                data_residency="auto",
+                name="Workspace 1",
+                notifications=models.NotificationsConfig(),
+                workspace_id="workspace-1",
+            ),
+        ) as get_workspace,
+    ):
+        workspaces = CloudClient(bearer_token="token").list_workspaces(
+            member_only=True,
+            limit=1,
+        )
+
+    assert [workspace.workspace_id for workspace in workspaces] == ["workspace-1"]
+    get_workspace.assert_called_once()
+
+
+def test_list_workspaces_explicit_workspace_resolution_does_not_use_member_fallback() -> (
+    None
+):
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {"permissionType": "workspace_admin", "workspaceId": "workspace-1"}
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3] as get_workspace_organization_info,
+        patches[4],
+        patch("airbyte._util.api_util.get_workspace") as get_workspace,
+        pytest.raises(exc.PyAirbyteInputError),
+    ):
+        get_workspace_organization_info.side_effect = exc.PyAirbyteInputError(
+            message="Workspace organization is ambiguous."
+        )
+        CloudClient(bearer_token="token").list_workspaces(
+            workspace_id="unknown-workspace"
+        )
+
+    get_workspace.assert_not_called()
+
+
 def test_get_workspace_raises_when_authenticated_user_has_no_default_workspace() -> (
     None
 ):
@@ -272,7 +333,7 @@ def test_list_workspaces_rejects_unscoped_instance_admin_discovery() -> None:
         CloudClient(bearer_token="token").list_workspaces()
 
 
-def test_get_default_context_is_bounded_to_permission_derived_scope() -> None:
+def test_get_default_context_for_user_is_bounded_to_permission_derived_scope() -> None:
     permissions = [
         {"permissionType": "instance_admin"},
         {"permissionType": "organization_admin", "organizationId": "organization-1"},
@@ -309,7 +370,7 @@ def test_get_default_context_is_bounded_to_permission_derived_scope() -> None:
             ],
         ),
     ):
-        context = CloudClient(bearer_token="token").get_default_context()
+        context = CloudClient(bearer_token="token").get_default_context_for_user()
 
     assert context.user_id == "user-id"
     assert context.default_workspace_id is None
@@ -323,7 +384,7 @@ def test_get_default_context_is_bounded_to_permission_derived_scope() -> None:
     assert len(context.discovery_hints) == 2
 
 
-def test_get_default_context_degrades_without_token_identity() -> None:
+def test_get_default_context_for_user_degrades_without_token_identity() -> None:
     patches = _api_patches(user={"userId": "user-id"})
     with (
         patches[0],
@@ -335,7 +396,7 @@ def test_get_default_context_degrades_without_token_identity() -> None:
         get_user_id.side_effect = exc.PyAirbyteInputError(
             message="The bearer token does not contain a user_id or sub claim."
         )
-        context = CloudClient(bearer_token="token").get_default_context()
+        context = CloudClient(bearer_token="token").get_default_context_for_user()
 
     assert context.user_id is None
     assert context.discovery_hints == []

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -100,7 +100,22 @@ def test_resolve_default_workspace_id_uses_exactly_one_direct_grant(
     expected_workspace_id: str | None,
 ) -> None:
     patches = _api_patches(user={"userId": "user-id"}, permissions=permissions)
-    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            return_value=models.WorkspaceResponse(
+                data_residency="auto",
+                name="Workspace",
+                notifications=models.NotificationsConfig(),
+                workspace_id="direct-workspace",
+            ),
+        ),
+    ):
         assert CloudClient(bearer_token="token").resolve_default_workspace_id() == (
             expected_workspace_id
         )
@@ -111,6 +126,99 @@ def test_resolve_default_workspace_id_ignores_permission_lookup_failure() -> Non
     with patches[0], patches[1], patches[2], patches[3], patches[4] as permissions:
         permissions.side_effect = exc.AirbyteError(message="Permission lookup failed.")
         assert CloudClient(bearer_token="token").resolve_default_workspace_id() is None
+
+
+def test_stale_direct_workspace_grant_is_ignored_consistently() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {"permissionType": "workspace_admin", "workspaceId": "stale-workspace"}
+        ],
+    )
+    stale_error = exc.AirbyteMissingResourceError(
+        resource_type="workspace",
+        resource_name_or_id="stale-workspace",
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch("airbyte._util.api_util.get_workspace", side_effect=stale_error),
+    ):
+        client = CloudClient(bearer_token="token")
+
+        assert client.resolve_default_workspace_id() is None
+        assert (
+            client.list_workspaces(privilege_scope=WorkspacePrivilegeScope.MEMBER_OF)
+            == []
+        )
+        context = client.get_default_context_for_user()
+
+    assert context.default_workspace_id is None
+    assert context.member_workspaces == []
+    assert context.member_workspaces_truncated is False
+
+
+def test_list_workspaces_skips_stale_grant_before_valid_grant_with_limit() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {"permissionType": "workspace_admin", "workspaceId": "stale-workspace"},
+            {"permissionType": "workspace_admin", "workspaceId": "valid-workspace"},
+        ],
+    )
+    stale_error = exc.AirbyteMissingResourceError(
+        resource_type="workspace",
+        resource_name_or_id="stale-workspace",
+    )
+    valid_workspace = models.WorkspaceResponse(
+        data_residency="auto",
+        name="Valid workspace",
+        notifications=models.NotificationsConfig(),
+        workspace_id="valid-workspace",
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            side_effect=[stale_error, valid_workspace],
+        ) as get_workspace,
+    ):
+        workspaces = CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
+            limit=1,
+        )
+
+    assert [workspace.workspace_id for workspace in workspaces] == ["valid-workspace"]
+    assert get_workspace.call_count == 2
+
+
+def test_list_workspaces_propagates_non_not_found_workspace_error() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {"permissionType": "workspace_admin", "workspaceId": "workspace-id"}
+        ],
+    )
+    api_error = exc.AirbyteError(message="Workspace lookup failed.")
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch("airbyte._util.api_util.get_workspace", side_effect=api_error),
+        pytest.raises(exc.AirbyteError, match="Workspace lookup failed"),
+    ):
+        CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.MEMBER_OF
+        )
 
 
 def test_list_workspaces_defaults_to_direct_memberships_without_org_resolution() -> (

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from airbyte import exceptions as exc
 from airbyte.cloud.client import CloudClient
+from airbyte.cloud.models import WorkspacePrivilegeScope
 from airbyte_api import models
 
 
@@ -112,15 +113,9 @@ def test_resolve_default_workspace_id_ignores_permission_lookup_failure() -> Non
         assert CloudClient(bearer_token="token").resolve_default_workspace_id() is None
 
 
-def test_list_workspaces_member_only_rejects_organization_context() -> None:
-    with pytest.raises(exc.PyAirbyteInputError, match="member_only"):
-        CloudClient(bearer_token="token").list_workspaces(
-            member_only=True,
-            organization_id="organization-id",
-        )
-
-
-def test_list_workspaces_member_only_fetches_only_until_limit() -> None:
+def test_list_workspaces_defaults_to_direct_memberships_without_org_resolution() -> (
+    None
+):
     patches = _api_patches(
         user={"userId": "user-id"},
         permissions=[
@@ -145,12 +140,188 @@ def test_list_workspaces_member_only_fetches_only_until_limit() -> None:
         ) as get_workspace,
     ):
         workspaces = CloudClient(bearer_token="token").list_workspaces(
-            member_only=True,
+            privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
             limit=1,
         )
 
     assert [workspace.workspace_id for workspace in workspaces] == ["workspace-1"]
     get_workspace.assert_called_once()
+
+
+def test_list_workspaces_organization_admin_lists_all_member_organizations() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-1",
+            },
+            {
+                "permissionType": "organization_admin",
+                "organizationId": "organization-2",
+            },
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.list_workspaces_in_organization",
+            side_effect=[
+                [{"workspaceId": "workspace-1", "name": "Workspace 1"}],
+                [{"workspaceId": "workspace-2", "name": "Workspace 2"}],
+            ],
+        ) as list_workspaces_in_organization,
+    ):
+        workspaces = CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.ORGANIZATION_ADMIN
+        )
+
+    assert [workspace.workspace_id for workspace in workspaces] == [
+        "workspace-1",
+        "workspace-2",
+    ]
+    assert [
+        call.kwargs["organization_id"]
+        for call in list_workspaces_in_organization.call_args_list
+    ] == ["organization-1", "organization-2"]
+
+
+def test_list_workspaces_instance_admin_scope_requires_instance_admin() -> None:
+    patches = _api_patches(user={"userId": "user-id"}, permissions=[])
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        pytest.raises(
+            exc.PyAirbyteInputError,
+            match="privilege_scope=instance_admin requires the instance_admin permission",
+        ),
+    ):
+        CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.INSTANCE_ADMIN
+        )
+
+
+def test_list_workspaces_any_scope_uses_unscoped_listing_for_instance_admin() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[{"permissionType": "instance_admin"}],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.list_workspaces",
+            return_value=[],
+        ) as list_workspaces,
+    ):
+        CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.ANY
+        )
+
+    list_workspaces.assert_called_once()
+
+
+def test_list_workspaces_any_scope_fails_closed_when_permissions_cannot_be_loaded() -> (
+    None
+):
+    patches = _api_patches(user={"userId": "user-id"})
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4] as list_permissions,
+        patch("airbyte._util.api_util.list_workspaces") as list_workspaces,
+        pytest.raises(exc.AirbyteError, match="Permission lookup failed"),
+    ):
+        list_permissions.side_effect = exc.AirbyteError(
+            message="Permission lookup failed"
+        )
+        CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.ANY
+        )
+
+    list_workspaces.assert_not_called()
+
+
+def test_list_workspaces_any_scope_uses_member_organizations_without_instance_admin() -> (
+    None
+):
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-1",
+            }
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.list_workspaces_in_organization",
+            return_value=[{"workspaceId": "workspace-1", "name": "Workspace 1"}],
+        ) as list_workspaces_in_organization,
+    ):
+        workspaces = CloudClient(bearer_token="token").list_workspaces(
+            privilege_scope=WorkspacePrivilegeScope.ANY
+        )
+
+    assert [workspace.workspace_id for workspace in workspaces] == ["workspace-1"]
+    list_workspaces_in_organization.assert_called_once()
+
+
+def test_list_workspaces_explicit_organization_ignores_privilege_scope() -> None:
+    with patch(
+        "airbyte._util.api_util.list_workspaces_in_organization",
+        return_value=[{"workspaceId": "workspace-1", "name": "Workspace 1"}],
+    ) as list_workspaces_in_organization:
+        workspaces = CloudClient(bearer_token="token").list_workspaces(
+            organization_id="organization-id",
+            privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
+        )
+
+    assert [workspace.workspace_id for workspace in workspaces] == ["workspace-1"]
+    list_workspaces_in_organization.assert_called_once()
+
+
+def test_list_workspaces_all_organizations_alias_warns_and_maps_to_any() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[{"permissionType": "instance_admin"}],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch("airbyte._util.api_util.list_workspaces", return_value=[]),
+        pytest.warns(DeprecationWarning, match="all_organizations"),
+    ):
+        CloudClient(bearer_token="token").list_workspaces(all_organizations=True)
+
+
+def test_list_workspaces_all_organizations_alias_conflicts_with_scope() -> None:
+    with pytest.raises(exc.PyAirbyteInputError, match="privilege_scope"):
+        CloudClient(bearer_token="token").list_workspaces(
+            all_organizations=True,
+            privilege_scope=WorkspacePrivilegeScope.INSTANCE_ADMIN,
+        )
 
 
 def test_list_workspaces_explicit_workspace_resolution_does_not_use_member_fallback() -> (
@@ -315,22 +486,6 @@ def test_list_workspaces_uses_direct_grants_when_memberships_are_ambiguous() -> 
     ]
     get_workspace.assert_called()
     list_by_organization.assert_not_called()
-
-
-def test_list_workspaces_rejects_unscoped_instance_admin_discovery() -> None:
-    patches = _api_patches(
-        user={"userId": "user-id"},
-        permissions=[{"permissionType": "instance_admin"}],
-    )
-    with (
-        patches[0],
-        patches[1],
-        patches[2],
-        patches[3],
-        patches[4],
-        pytest.raises(exc.PyAirbyteInputError, match="instance administrator"),
-    ):
-        CloudClient(bearer_token="token").list_workspaces()
 
 
 def test_get_default_context_for_user_is_bounded_to_permission_derived_scope() -> None:

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -112,6 +112,14 @@ def test_resolve_default_workspace_id_ignores_permission_lookup_failure() -> Non
         assert CloudClient(bearer_token="token").resolve_default_workspace_id() is None
 
 
+def test_list_workspaces_member_only_rejects_organization_context() -> None:
+    with pytest.raises(exc.PyAirbyteInputError, match="member_only"):
+        CloudClient(bearer_token="token").list_workspaces(
+            member_only=True,
+            organization_id="organization-id",
+        )
+
+
 def test_get_workspace_raises_when_authenticated_user_has_no_default_workspace() -> (
     None
 ):

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from airbyte import exceptions as exc
 from airbyte.cloud.client import CloudClient
+from airbyte_api import models
 
 
 def _api_patches(
@@ -81,6 +82,34 @@ def test_configured_workspace_beats_authenticated_user_default() -> None:
 
     assert workspace.workspace_id == "configured-workspace"
     get_user.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("permissions", "expected_workspace_id"),
+    [
+        ([{"workspaceId": "direct-workspace"}], "direct-workspace"),
+        (
+            [{"workspaceId": "workspace-1"}, {"workspaceId": "workspace-2"}],
+            None,
+        ),
+    ],
+)
+def test_resolve_default_workspace_id_uses_exactly_one_direct_grant(
+    permissions: list[dict[str, object]],
+    expected_workspace_id: str | None,
+) -> None:
+    patches = _api_patches(user={"userId": "user-id"}, permissions=permissions)
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        assert CloudClient(bearer_token="token").resolve_default_workspace_id() == (
+            expected_workspace_id
+        )
+
+
+def test_resolve_default_workspace_id_ignores_permission_lookup_failure() -> None:
+    patches = _api_patches(user={"userId": "user-id"})
+    with patches[0], patches[1], patches[2], patches[3], patches[4] as permissions:
+        permissions.side_effect = exc.AirbyteError(message="Permission lookup failed.")
+        assert CloudClient(bearer_token="token").resolve_default_workspace_id() is None
 
 
 def test_get_workspace_raises_when_authenticated_user_has_no_default_workspace() -> (
@@ -160,3 +189,145 @@ def test_authenticated_user_lookup_is_cached_across_workspace_and_organization_r
         assert client._resolve_ambient_organization_id() == "user-organization"
 
     assert get_user.call_count == 1
+
+
+def test_list_workspaces_uses_direct_grants_when_memberships_are_ambiguous() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-1",
+            },
+            {
+                "permissionType": "organization_member",
+                "organizationId": "organization-2",
+            },
+            {"permissionType": "workspace_admin", "workspaceId": "workspace-1"},
+            {"permissionType": "workspace_admin", "workspaceId": "workspace-2"},
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            side_effect=[
+                models.WorkspaceResponse(
+                    data_residency="auto",
+                    name="Workspace 1",
+                    notifications=models.NotificationsConfig(),
+                    workspace_id="workspace-1",
+                ),
+                models.WorkspaceResponse(
+                    data_residency="auto",
+                    name="Workspace 2",
+                    notifications=models.NotificationsConfig(),
+                    workspace_id="workspace-2",
+                ),
+            ],
+        ) as get_workspace,
+        patch(
+            "airbyte._util.api_util.list_workspaces_in_organization",
+        ) as list_by_organization,
+        patch(
+            "airbyte._util.api_util.get_organization_info",
+            return_value={"organizationName": "Organization"},
+        ),
+    ):
+        workspaces = CloudClient(bearer_token="token").list_workspaces()
+
+    assert [workspace.workspace_id for workspace in workspaces] == [
+        "workspace-1",
+        "workspace-2",
+    ]
+    get_workspace.assert_called()
+    list_by_organization.assert_not_called()
+
+
+def test_list_workspaces_rejects_unscoped_instance_admin_discovery() -> None:
+    patches = _api_patches(
+        user={"userId": "user-id"},
+        permissions=[{"permissionType": "instance_admin"}],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        pytest.raises(exc.PyAirbyteInputError, match="instance administrator"),
+    ):
+        CloudClient(bearer_token="token").list_workspaces()
+
+
+def test_get_default_context_is_bounded_to_permission_derived_scope() -> None:
+    permissions = [
+        {"permissionType": "instance_admin"},
+        {"permissionType": "organization_admin", "organizationId": "organization-1"},
+        {"permissionType": "organization_admin", "organizationId": "organization-2"},
+        *[
+            {"permissionType": "workspace_admin", "workspaceId": f"workspace-{index}"}
+            for index in range(1, 7)
+        ],
+    ]
+    patches = _api_patches(user={"userId": "user-id"}, permissions=permissions)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_organization_info",
+            side_effect=[
+                {"organizationName": "Organization 1"},
+                {"organizationName": "Organization 2"},
+            ],
+        ),
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            side_effect=[
+                models.WorkspaceResponse(
+                    data_residency="auto",
+                    name=f"Workspace {index}",
+                    notifications=models.NotificationsConfig(),
+                    workspace_id=f"workspace-{index}",
+                )
+                for index in range(1, 7)
+            ],
+        ),
+    ):
+        context = CloudClient(bearer_token="token").get_default_context()
+
+    assert context.user_id == "user-id"
+    assert context.is_instance_admin is True
+    assert context.default_workspace_id is None
+    assert [item.organization_id for item in context.membership_organizations] == [
+        "organization-1",
+        "organization-2",
+    ]
+    assert [item.workspace_id for item in context.direct_workspaces] == [
+        f"workspace-{index}" for index in range(1, 7)
+    ]
+
+
+def test_get_default_context_degrades_without_token_identity() -> None:
+    patches = _api_patches(user={"userId": "user-id"})
+    with (
+        patches[0],
+        patches[1] as get_user_id,
+        patches[2],
+        patches[3],
+        patches[4],
+    ):
+        get_user_id.side_effect = exc.PyAirbyteInputError(
+            message="The bearer token does not contain a user_id or sub claim."
+        )
+        context = CloudClient(bearer_token="token").get_default_context()
+
+    assert context.user_id is None
+    assert any("no user identity claim" in note for note in context.resolution_notes)

--- a/tests/unit_tests/test_cloud_client.py
+++ b/tests/unit_tests/test_cloud_client.py
@@ -536,7 +536,71 @@ def test_get_default_context_for_user_is_bounded_to_permission_derived_scope() -
     assert [item.workspace_id for item in context.member_workspaces] == [
         f"workspace-{index}" for index in range(1, 7)
     ]
+    assert context.member_organizations_truncated is False
+    assert context.member_workspaces_truncated is False
     assert len(context.discovery_hints) == 2
+
+
+def test_get_default_context_for_user_truncates_organization_memberships() -> None:
+    permissions = [
+        {
+            "permissionType": "organization_member",
+            "organizationId": f"organization-{index}",
+        }
+        for index in range(1, 12)
+    ]
+    patches = _api_patches(user={"userId": "user-id"}, permissions=permissions)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_organization_info",
+            side_effect=[
+                {"organizationName": f"Organization {index}"} for index in range(1, 11)
+            ],
+        ),
+    ):
+        context = CloudClient(bearer_token="token").get_default_context_for_user()
+
+    assert len(context.member_organizations) == 10
+    assert context.member_organizations_truncated is True
+    assert context.member_workspaces_truncated is False
+
+
+def test_get_default_context_for_user_truncates_workspace_memberships() -> None:
+    permissions = [
+        {"permissionType": "workspace_admin", "workspaceId": f"workspace-{index}"}
+        for index in range(1, 27)
+    ]
+    patches = _api_patches(user={"userId": "user-id"}, permissions=permissions)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            "airbyte._util.api_util.get_workspace",
+            side_effect=[
+                models.WorkspaceResponse(
+                    data_residency="auto",
+                    name=f"Workspace {index}",
+                    notifications=models.NotificationsConfig(),
+                    workspace_id=f"workspace-{index}",
+                )
+                for index in range(1, 26)
+            ],
+        ) as get_workspace,
+    ):
+        context = CloudClient(bearer_token="token").get_default_context_for_user()
+
+    assert len(context.member_workspaces) == 25
+    assert context.member_organizations_truncated is False
+    assert context.member_workspaces_truncated is True
+    assert get_workspace.call_count == 25
 
 
 def test_get_default_context_for_user_degrades_without_token_identity() -> None:

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1557,6 +1557,9 @@ def test_mcp_list_cloud_workspaces_reports_available_organizations(
                 },
             )
 
+        def list_direct_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
+            return []
+
     monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
 
     result = mcp_cloud.list_cloud_workspaces(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -12,7 +12,7 @@ from airbyte import constants
 from airbyte._util import api_util
 from airbyte.cloud import _credentials as cloud_credentials
 from airbyte.cloud.client import CloudClient
-from airbyte.cloud.models import CloudWorkspaceInfo
+from airbyte.cloud.models import CloudWorkspaceInfo, WorkspacePrivilegeScope
 from airbyte.cloud.organizations import CloudOrganization
 from airbyte.cloud.workspaces import CloudWorkspace
 from airbyte.exceptions import (
@@ -280,86 +280,19 @@ def test_cloud_client_list_workspaces_forwards_limit(
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
-    CloudClient(bearer_token="token").list_workspaces(
+    client = CloudClient(bearer_token="token")
+    monkeypatch.setattr(client, "_is_instance_admin", lambda: True)
+    client.list_workspaces(
         limit=3,
-        all_organizations=True,
+        privilege_scope=WorkspacePrivilegeScope.INSTANCE_ADMIN,
     )
 
     assert captured_limit == 3
 
 
 @pytest.mark.parametrize(
-    ("client_kwargs", "request_kwargs", "failure", "expected_message"),
-    [
-        pytest.param(
-            {},
-            {},
-            "membership",
-            None,
-            id="membership-failure-falls-back",
-        ),
-        pytest.param(
-            {"workspace_id": "configured-workspace-id"},
-            {},
-            "workspace-parent",
-            None,
-            id="configured-workspace-parent-failure-falls-back",
-        ),
-        pytest.param(
-            {},
-            {"workspace_id": "explicit-workspace-id"},
-            "workspace-parent",
-            "workspace lookup failed",
-            id="explicit-workspace-failure-propagates",
-        ),
-    ],
-)
-def test_cloud_client_list_workspaces_handles_ambient_resolution_failures(
-    monkeypatch: pytest.MonkeyPatch,
-    client_kwargs: dict[str, str],
-    request_kwargs: dict[str, str],
-    failure: str,
-    expected_message: str | None,
-) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_list_workspaces(**kwargs: object) -> list[object]:
-        captured.update(kwargs)
-        return []
-
-    client = CloudClient(bearer_token="token", **client_kwargs)
-    if failure == "membership":
-        monkeypatch.setattr(
-            client,
-            "_get_membership_organization_ids",
-            _raise(AirbyteError(message="membership failed")),
-        )
-    else:
-        monkeypatch.setattr(
-            client,
-            "_get_workspace_parent_organization_id",
-            _raise(PyAirbyteInputError(message="workspace lookup failed")),
-        )
-        monkeypatch.setattr(client, "_get_membership_organization_ids", lambda: ())
-    monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
-
-    if expected_message is None:
-        assert client.list_workspaces(**request_kwargs) == []
-        assert captured["workspace_id"] == ""
-    else:
-        with pytest.raises(PyAirbyteInputError, match=expected_message):
-            client.list_workspaces(**request_kwargs)
-        assert captured == {}
-
-
-@pytest.mark.parametrize(
     ("request_kwargs", "expected_message"),
     [
-        pytest.param(
-            {"all_organizations": True, "organization_id": "organization-id"},
-            "all_organizations option cannot be combined",
-            id="all-organizations-with-organization",
-        ),
         pytest.param(
             {"name_contains": "target", "name_filter": lambda _: True},
             "provide name_contains or name_filter, but not both",
@@ -420,10 +353,12 @@ def test_cloud_client_list_workspaces_applies_name_contains_to_all_org_results(
 
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
-    result = CloudClient(bearer_token="token").list_workspaces(
+    client = CloudClient(bearer_token="token")
+    monkeypatch.setattr(client, "_is_instance_admin", lambda: True)
+    result = client.list_workspaces(
         name_contains="TARGET",
         limit=1,
-        all_organizations=True,
+        privilege_scope=WorkspacePrivilegeScope.INSTANCE_ADMIN,
     )
 
     assert captured.get("name") is None
@@ -460,6 +395,7 @@ def test_cloud_client_list_workspaces_in_organization_applies_name_filter_before
         bearer_token="token",
         organization_id="organization-id",
     ).list_workspaces(
+        organization_id="organization-id",
         name_filter=lambda name: name.startswith("target"),
         limit=1,
     )
@@ -494,6 +430,7 @@ def test_cloud_client_list_workspaces_matches_exact_name_after_server_filter(
         bearer_token="token",
         organization_id="organization-id",
     ).list_workspaces(
+        organization_id="organization-id",
         name="Prod",
         limit=1,
     )
@@ -557,7 +494,7 @@ def test_cloud_client_list_workspaces_accepts_api_notification_list(
     workspaces = CloudClient(
         bearer_token="token",
         organization_id="organization-id",
-    ).list_workspaces()
+    ).list_workspaces(organization_id="organization-id")
 
     assert len(workspaces) == 1
     assert workspaces[0].notifications == [{"sendOnSuccess": True}]
@@ -1299,7 +1236,7 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         ),
         pytest.param(
             {"organization_id": "configured-organization-id"},
-            {"limit": 3},
+            {"organization_id": "configured-organization-id", "limit": 3},
             None,
             None,
             "configured-organization-id",
@@ -1310,7 +1247,7 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         ),
         pytest.param(
             {"workspace_id": "configured-workspace-id"},
-            {"limit": 3},
+            {"workspace_id": "configured-workspace-id", "limit": 3},
             None,
             "parent-organization-id",
             "parent-organization-id",
@@ -1324,7 +1261,7 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
                 "organization_id": "configured-organization-id",
                 "workspace_id": "configured-workspace-id",
             },
-            {"limit": 3},
+            {"organization_id": "configured-organization-id", "limit": 3},
             None,
             None,
             "configured-organization-id",
@@ -1335,7 +1272,10 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         ),
         pytest.param(
             {},
-            {"limit": 3},
+            {
+                "limit": 3,
+                "privilege_scope": WorkspacePrivilegeScope.ORGANIZATION_ADMIN,
+            },
             [
                 {"permissionType": "instance_admin"},
                 {
@@ -1352,7 +1292,10 @@ def test_cloud_client_list_organizations_reports_ambiguity_candidates(
         ),
         pytest.param(
             {},
-            {"name_filter": lambda _: True},
+            {
+                "name_filter": lambda _: True,
+                "privilege_scope": WorkspacePrivilegeScope.ORGANIZATION_ADMIN,
+            },
             [
                 {
                     "permissionType": "organization_member",
@@ -1426,64 +1369,32 @@ def test_cloud_client_list_workspaces_resolves_single_membership_and_caches_it(
         api_util, "list_permissions_for_user", fake_list_permissions_for_user
     )
     client = CloudClient(bearer_token="token")
-    client.list_workspaces()
-    client.list_workspaces()
+    client.list_workspaces(privilege_scope=WorkspacePrivilegeScope.ORGANIZATION_ADMIN)
+    client.list_workspaces(privilege_scope=WorkspacePrivilegeScope.ORGANIZATION_ADMIN)
 
     assert captured["organization_id"] == "organization-id"
     assert calls == {"user": 1, "permissions": 1}
 
 
-def test_cloud_client_list_workspaces_rejects_ambiguous_memberships_with_candidates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _patch_workspace_discovery(
-        monkeypatch,
-        permissions=[
-            {
-                "permissionType": "organization_member",
-                "organizationId": "organization-1",
-            },
-            {
-                "permissionType": "organization_member",
-                "organizationId": "organization-2",
-            },
-        ],
-    )
-
-    def fake_get_organization_info(**kwargs: object) -> dict[str, object]:
-        if kwargs["organization_id"] == "organization-2":
-            raise AirbyteError(message="Forbidden")
-        return {"organizationName": "Organization 1"}
-
-    monkeypatch.setattr(api_util, "get_organization_info", fake_get_organization_info)
-
-    with pytest.raises(PyAirbyteInputError) as exc_info:
-        CloudClient(bearer_token="token").list_workspaces()
-
-    assert exc_info.value.context == {
-        "organization_ids": ["organization-1", "organization-2"],
-        "organization_candidates": [
-            {
-                "organization_id": "organization-1",
-                "organization_name": "Organization 1",
-            },
-            {"organization_id": "organization-2", "organization_name": None},
-        ],
-        "total_candidates": 2,
-    }
-
-
 @pytest.mark.parametrize(
-    ("permissions", "all_organizations"),
+    ("permissions", "privilege_scope"),
     [
-        pytest.param([], False, id="zero_memberships"),
-        pytest.param(None, True, id="explicit_opt_in"),
+        pytest.param(
+            [{"permissionType": "instance_admin"}],
+            WorkspacePrivilegeScope.INSTANCE_ADMIN,
+            id="instance-admin-scope",
+        ),
+        pytest.param(
+            [{"permissionType": "instance_admin"}],
+            WorkspacePrivilegeScope.ANY,
+            id="any-scope-for-instance-admin",
+        ),
     ],
 )
 def test_cloud_client_list_workspaces_uses_cross_organization_listing(
     monkeypatch: pytest.MonkeyPatch,
-    permissions: list[dict[str, object]] | None,
-    all_organizations: bool,
+    permissions: list[dict[str, object]],
+    privilege_scope: WorkspacePrivilegeScope,
 ) -> None:
     captured: dict[str, object] = {}
 
@@ -1506,89 +1417,12 @@ def test_cloud_client_list_workspaces_uses_cross_organization_listing(
     monkeypatch.setattr(api_util, "list_workspaces", fake_list_workspaces)
 
     result = CloudClient(bearer_token="token").list_workspaces(
-        all_organizations=all_organizations,
+        privilege_scope=privilege_scope,
     )
 
     assert captured["workspace_id"] == ""
     assert captured["limit"] is None
     assert [workspace.workspace_id for workspace in result] == ["workspace-id"]
-
-
-@pytest.mark.parametrize(
-    ("candidates", "expected_ids", "expected_names", "has_retry_guidance"),
-    [
-        pytest.param(
-            [
-                {
-                    "organization_id": "organization-1",
-                    "organization_name": None,
-                },
-                {
-                    "organization_id": "organization-2",
-                    "organization_name": "Organization 2",
-                },
-            ],
-            ["organization-1", "organization-2"],
-            [None, "Organization 2"],
-            True,
-            id="with_available_organizations",
-        ),
-        pytest.param([], [], [], False, id="without_available_organizations"),
-    ],
-)
-def test_mcp_list_cloud_workspaces_reports_available_organizations(
-    monkeypatch: pytest.MonkeyPatch,
-    candidates: list[dict[str, str | None]],
-    expected_ids: list[str],
-    expected_names: list[str | None],
-    has_retry_guidance: bool,
-) -> None:
-    class DiscoveryClient:
-        def list_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
-            message = (
-                "Multiple organization memberships were found."
-                if candidates
-                else "No organization membership was found."
-            )
-            raise PyAirbyteInputError(
-                message=message,
-                context={
-                    "organization_candidates": candidates,
-                },
-            )
-
-    monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
-
-    result = mcp_cloud.list_cloud_workspaces(
-        None,
-        organization_id=None,
-        organization_name=None,
-        name_contains=None,
-        limit=None,
-    )
-
-    assert result.workspaces == []
-    assert result.available_organizations is not None
-    assert all(
-        isinstance(candidate, mcp_cloud.CloudOrganizationResult)
-        for candidate in result.available_organizations
-    )
-    assert [
-        candidate.id for candidate in result.available_organizations
-    ] == expected_ids
-    assert [
-        candidate.name for candidate in result.available_organizations
-    ] == expected_names
-    retry_guidance = (
-        "Retry with an explicit organization ID from the provided list of the "
-        "available organizations."
-    )
-    if has_retry_guidance:
-        assert retry_guidance in (result.message or "")
-    else:
-        assert result.message == (
-            "Call `get_default_cloud_context` first. No organization membership was found."
-        )
 
 
 def test_mcp_get_cloud_client_uses_configured_workspace(
@@ -1842,6 +1676,7 @@ def test_mcp_list_cloud_workspaces_discovery(
         organization_name=None,
         name_contains=None,
         limit=None,
+        privilege_scope=WorkspacePrivilegeScope.MEMBER_OF,
     )
 
     assert captured_organization_id is None

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1557,9 +1557,6 @@ def test_mcp_list_cloud_workspaces_reports_available_organizations(
                 },
             )
 
-        def list_direct_workspaces(self, **_: object) -> list[CloudWorkspaceInfo]:
-            return []
-
     monkeypatch.setattr(mcp_cloud, "_get_cloud_client", lambda _: DiscoveryClient())
 
     result = mcp_cloud.list_cloud_workspaces(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1198,7 +1198,7 @@ def test_cloud_client_get_organization_requires_context_without_defaults(
 
     with pytest.raises(
         PyAirbyteInputError,
-        match="Organization ID or organization name is required.",
+        match="Call `get_default_cloud_context` first. Organization ID or organization name is required.",
     ):
         CloudClient(bearer_token="token").get_organization()
 
@@ -1586,7 +1586,9 @@ def test_mcp_list_cloud_workspaces_reports_available_organizations(
     if has_retry_guidance:
         assert retry_guidance in (result.message or "")
     else:
-        assert result.message == "No organization membership was found."
+        assert result.message == (
+            "Call `get_default_cloud_context` first. No organization membership was found."
+        )
 
 
 def test_mcp_get_cloud_client_uses_configured_workspace(

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1135,7 +1135,7 @@ def test_cloud_client_get_organization_requires_context_without_defaults(
 
     with pytest.raises(
         PyAirbyteInputError,
-        match="Call `get_default_cloud_context` first. Organization ID or organization name is required.",
+        match="Organization ID or organization name is required.",
     ):
         CloudClient(bearer_token="token").get_organization()
 

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -109,26 +109,26 @@ def test_cloud_credentials_error_guidance(
     [
         pytest.param(
             True,
-            "Call `get_default_cloud_context` first. The authenticated user's "
-            "default workspace was checked. If it was not "
+            "The authenticated user's default workspace was checked. If it was not "
             "available, call `list_cloud_workspaces`, which resolves the organization "
             "automatically; only call `list_cloud_organizations` to search "
             "organizations by name. If discovery returns exactly one workspace, "
             "provide its ID via the "
             "`X-Airbyte-Workspace-Id` header or the `workspace_id` parameter; "
-            "otherwise ask the user to choose.",
+            "otherwise ask the user to choose. Call "
+            "`get_default_cloud_context` to inspect your memberships.",
             id="hosted",
         ),
         pytest.param(
             False,
-            "Call `get_default_cloud_context` first. The authenticated user's "
-            "default workspace was checked. If it was not "
+            "The authenticated user's default workspace was checked. If it was not "
             "available, call `list_cloud_workspaces`, which resolves the organization "
             "automatically; only call `list_cloud_organizations` to search "
             "organizations by name. If discovery returns exactly one workspace, "
             "set its ID in "
             "`AIRBYTE_CLOUD_WORKSPACE_ID` or pass the `workspace_id` parameter; "
-            "otherwise ask the user to choose.",
+            "otherwise ask the user to choose. Call "
+            "`get_default_cloud_context` to inspect your memberships.",
             id="local",
         ),
     ],

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -109,26 +109,24 @@ def test_cloud_credentials_error_guidance(
     [
         pytest.param(
             True,
-            "The authenticated user's default workspace was checked. If it was not "
-            "available, call `list_cloud_workspaces`, which resolves the organization "
-            "automatically; only call `list_cloud_organizations` to search "
-            "organizations by name. If discovery returns exactly one workspace, "
-            "provide its ID via the "
-            "`X-Airbyte-Workspace-Id` header or the `workspace_id` parameter; "
-            "otherwise ask the user to choose. Call "
+            "The authenticated user's default workspace was checked and none was "
+            "available. `list_cloud_workspaces` returns direct workspace memberships "
+            "by default; pass `organization_id`/`organization_name` or a broader "
+            "`privilege_scope` for organization-wide discovery, or call "
+            "`list_cloud_organizations` to search organizations by name. If exactly "
+            "one workspace is found, use it; otherwise ask the user to choose. Call "
             "`get_default_cloud_context` to inspect your memberships.",
             id="hosted",
         ),
         pytest.param(
             False,
-            "The authenticated user's default workspace was checked. If it was not "
-            "available, call `list_cloud_workspaces`, which resolves the organization "
-            "automatically; only call `list_cloud_organizations` to search "
-            "organizations by name. If discovery returns exactly one workspace, "
-            "set its ID in "
-            "`AIRBYTE_CLOUD_WORKSPACE_ID` or pass the `workspace_id` parameter; "
-            "otherwise ask the user to choose. Call "
-            "`get_default_cloud_context` to inspect your memberships.",
+            "The authenticated user's default workspace was checked and none was "
+            "available. `list_workspaces` returns direct workspace memberships "
+            "by default; pass `organization_id`/`organization_name` or a broader "
+            "`privilege_scope` for organization-wide discovery, or call "
+            "`list_organizations` to search organizations by name. If exactly "
+            "one workspace is found, use it; otherwise ask the user to choose. Call "
+            "`get_default_context_for_user` to inspect your memberships.",
             id="local",
         ),
     ],

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -109,7 +109,8 @@ def test_cloud_credentials_error_guidance(
     [
         pytest.param(
             True,
-            "The authenticated user's default workspace was checked. If it was not "
+            "Call `get_default_cloud_context` first. The authenticated user's "
+            "default workspace was checked. If it was not "
             "available, call `list_cloud_workspaces`, which resolves the organization "
             "automatically; only call `list_cloud_organizations` to search "
             "organizations by name. If discovery returns exactly one workspace, "
@@ -120,7 +121,8 @@ def test_cloud_credentials_error_guidance(
         ),
         pytest.param(
             False,
-            "The authenticated user's default workspace was checked. If it was not "
+            "Call `get_default_cloud_context` first. The authenticated user's "
+            "default workspace was checked. If it was not "
             "available, call `list_cloud_workspaces`, which resolves the organization "
             "automatically; only call `list_cloud_organizations` to search "
             "organizations by name. If discovery returns exactly one workspace, "

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -507,6 +507,8 @@ def test_get_default_cloud_context_returns_context_model(
             )
         ],
         member_workspaces=[],
+        member_organizations_truncated=True,
+        member_workspaces_truncated=True,
         discovery_hints=[],
     )
 
@@ -521,3 +523,7 @@ def test_get_default_cloud_context_returns_context_model(
     assert result.user_id == "user-id"
     assert result.member_organizations[0].organization_id == "organization-id"
     assert "membership-based, not access-based" in result.message
+    assert (
+        "Only the first 1 organization memberships and 0 workspace memberships are shown"
+        in result.message
+    )

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -511,7 +511,7 @@ def test_get_default_cloud_context_returns_context_model(
     )
 
     class ContextClient:
-        def get_default_context(self) -> CloudDefaultContextInfo:
+        def get_default_context_for_user(self) -> CloudDefaultContextInfo:
             return context
 
     monkeypatch.setattr(cloud_mcp, "_get_cloud_client", lambda _: ContextClient())

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -9,7 +9,11 @@ from typing import Callable, cast
 
 import pytest
 from airbyte.cloud.connectors import CheckResult
-from airbyte.cloud.models import JobStatusEnum
+from airbyte.cloud.models import (
+    CloudDefaultContextInfo,
+    CloudOrganizationInfo,
+    JobStatusEnum,
+)
 from airbyte.mcp import cloud as cloud_mcp
 from airbyte.mcp.cloud import (
     CloudConnectionResult,
@@ -484,3 +488,37 @@ def test_cancel_cloud_sync_forwards_missing_job_id(
     )
 
     assert connection.received_job_id is None
+
+
+def test_get_default_cloud_context_returns_context_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = CloudDefaultContextInfo(
+        user_id="user-id",
+        user_name="User",
+        user_email="user@example.com",
+        is_instance_admin=True,
+        default_workspace_id=None,
+        configured_organization_id=None,
+        membership_organizations=[
+            CloudOrganizationInfo(
+                organization_id="organization-id",
+                organization_name="Organization",
+            )
+        ],
+        direct_workspaces=[],
+        resolution_notes=["No default workspace on user record"],
+    )
+
+    class ContextClient:
+        def get_default_context(self) -> CloudDefaultContextInfo:
+            return context
+
+    monkeypatch.setattr(cloud_mcp, "_get_cloud_client", lambda _: ContextClient())
+
+    result = cloud_mcp.get_default_cloud_context(cast(Context, object()))
+
+    assert result.user_id == "user-id"
+    assert result.is_instance_admin is True
+    assert result.membership_organizations[0].organization_id == "organization-id"
+    assert "default_workspace_id" in result.message

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -497,17 +497,17 @@ def test_get_default_cloud_context_returns_context_model(
         user_id="user-id",
         user_name="User",
         user_email="user@example.com",
-        is_instance_admin=True,
         default_workspace_id=None,
+        configured_workspace_id=None,
         configured_organization_id=None,
-        membership_organizations=[
+        member_organizations=[
             CloudOrganizationInfo(
                 organization_id="organization-id",
                 organization_name="Organization",
             )
         ],
-        direct_workspaces=[],
-        resolution_notes=["No default workspace on user record"],
+        member_workspaces=[],
+        discovery_hints=[],
     )
 
     class ContextClient:
@@ -519,6 +519,5 @@ def test_get_default_cloud_context_returns_context_model(
     result = cloud_mcp.get_default_cloud_context(cast(Context, object()))
 
     assert result.user_id == "user-id"
-    assert result.is_instance_admin is True
-    assert result.membership_organizations[0].organization_id == "organization-id"
-    assert "default_workspace_id" in result.message
+    assert result.member_organizations[0].organization_id == "organization-id"
+    assert "membership-based, not access-based" in result.message


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Fixes Cloud MCP orientation for human (OAuth) users and instance admins, and adds a cheap "who am I" tool so agents can find their workspace and organization in one call instead of dumping every workspace they can see.

Specifically: `get_user_id_from_bearer_token` falls back to the `sub` claim, `CloudClient.resolve_default_workspace_id` uses direct workspace grants from `/permissions/list_by_user`, `CloudClient.list_workspaces` gains a `privilege_scope: WorkspacePrivilegeScope` argument (default `MEMBER_OF`), and a new `get_default_cloud_context` MCP tool returns `CloudDefaultContextInfo`.

</td></tr></table>

Follows up on #1156. Requested by AJ Steers.

## Changes

- `get_user_id_from_bearer_token`: read `user_id`, else `sub` (Keycloak subject == `authUserId` for `/users/get_by_auth_id`). Previously human OAuth tokens failed here and the whole default-workspace + membership chain silently degraded to the unscoped `/workspaces` list.
- `CloudClient._get_user_permissions()` (cached, single call) now backs `_get_membership_organization_ids`, new `_get_direct_workspace_ids`, `_is_instance_admin`.
- `resolve_default_workspace_id()`: configured → user `defaultWorkspaceId` → exactly one direct workspace grant → `None` (never picks among several). A sole grant is only used if `GET /workspaces/{id}` resolves; stale grants (404) are skipped here and in `MEMBER_OF` listing via `_get_direct_workspace_info` (cached per client). Found in live testing: the support-bot app has one `workspace_admin` row pointing at a deleted workspace.
- `_wrap_sdk_error` returns `AirbyteMissingResourceError` (subclass of `AirbyteError`) for HTTP 404 so callers can distinguish missing resources.
- `list_workspaces(privilege_scope=...)` replaces the old ambient org-resolution / `all_organizations` / `member_only` logic:
  ```python
  class WorkspacePrivilegeScope(str, Enum):
      MEMBER_OF = "member_of"                  # default: direct workspace grants only
      ORGANIZATION_ADMIN = "organization_admin"  # all workspaces in orgs with org-level rows (member or admin)
      INSTANCE_ADMIN = "instance_admin"        # every workspace; raises if caller lacks instance_admin
      ANY = "any"                              # INSTANCE_ADMIN if instance admin, else ORGANIZATION_ADMIN
  ```
  Explicit `organization_id` / `organization_name` / `workspace_id` always take precedence over the scope. `INSTANCE_ADMIN`/`ANY` fail closed if the permission lookup errors (no silent fallback to the unscoped list). `all_organizations=True` remains on the core client as a deprecated alias for `ANY` (DeprecationWarning; error if combined with an explicit scope) and is not exposed on the MCP tool.
- New MCP tool `get_default_cloud_context` → `CloudClient.get_default_context_for_user()` → `CloudDefaultContextInfo` (`user_id/name/email`, `default_workspace_id`, `configured_workspace_id`, `configured_organization_id`, `member_organizations`, `member_workspaces` (cap 25), `discovery_hints`). Membership-based, not access-based: no counts, no enumeration of what an admin could reach; hints appear only for `instance_admin` / org-membership rows. Never raises on missing identity.
- MCP `list_cloud_workspaces` exposes `privilege_scope`; its docs now say the default is direct memberships and to pass `organization_id` or a broader scope for more.
- Every missing/ambiguous workspace- or org-context error (`AirbyteMissingWorkspaceContextError`, org-ambiguity error, `CloudWorkspace` init, `get_workspace`, `list_cloud_workspaces` / `list_cloud_organizations` messages) now leads with "Call `get_default_cloud_context` first."

## Review Spotlight

Reviewers with limited time, please review first:
- [`client.py` `list_workspaces` scope dispatch](https://github.com/airbytehq/PyAirbyte/blob/devin/1789176203-cloud-context-resolution/airbyte/cloud/client.py#L339-L455): explicit-args precedence, `all_organizations` alias, per-scope routing
- [`client.py` `get_default_context_for_user`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789176203-cloud-context-resolution/airbyte/cloud/client.py#L740-L820): membership-only semantics and hint gating
- [`mcp/cloud.py` `list_cloud_workspaces` / `get_default_cloud_context`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789176203-cloud-context-resolution/airbyte/mcp/cloud.py#L1540-L1660)

## Motivation (measured in Goose Desktop against prod `cloud-mcp`)

<details>
<summary>Show/Hide Content</summary>

Prompt: "Orient yourself in my Airbyte Cloud account… do not ask me for IDs." Chain in every run: `check_airbyte_cloud_workspace` → missing-context error → `list_deployed_cloud_connections` → same → `list_cloud_workspaces`.

- Instance-admin human user (OAuth): `list_cloud_workspaces` hit the 300s MCP timeout (unscoped `/workspaces` paginating all of Cloud). User record has no `defaultWorkspaceId`; permissions: `instance_admin`, 2× `organization_admin`, 6× `workspace_admin`.
- Client-credentials app (`organization_member` of one org, one `workspace_admin` grant, no default): 311 workspaces / ~89KB returned, model still had to ask which one.
- Non-admin OAuth user: 2 workspaces with `organization_id: null` because user lookup failed on the missing `user_id` claim.

Expected after this PR: admin human → one `get_default_cloud_context` call returns 2 member orgs + 6 member workspaces; single-grant app → workspace-scoped tools work with no IDs supplied.

</details>

## Risks

- Behavior change: `list_workspaces()` with no arguments now returns only direct workspace grants (previously: org-scoped or instance-wide listing depending on identity). Callers wanting the old breadth pass `privilege_scope=ANY` (or the deprecated `all_organizations=True`).
- MCP `list_cloud_workspaces` no longer performs ambient organization resolution; agents get direct grants by default and must pass `organization_id` or a broader `privilege_scope` for more.
- Core-library error guidance now names an MCP tool (`get_default_cloud_context`); `exceptions.py` already referenced MCP tool names, so this follows existing precedent.

## Follow-ups

- Verify the human/OAuth path end to end in Goose against a `cloud-mcp-preview` deploy once published.

## Test plan

```
uv run ruff format --check .
uv run ruff check .
uv run mypy .
uv run pytest tests/unit_tests/test_cloud_api_util.py tests/unit_tests/test_cloud_client.py tests/unit_tests/test_mcp_cloud.py tests/unit_tests/test_mcp_tool_filters.py tests/unit_tests/test_mcp_docs_includes.py tests/unit_tests/test_cloud_credentials.py tests/unit_tests/test_exceptions.py
```
New unit tests: `sub` fallback; single vs multiple grant default resolution; each `WorkspacePrivilegeScope` value (default `MEMBER_OF`, multi-org `ORGANIZATION_ADMIN`, unauthorized `INSTANCE_ADMIN`, `ANY` for admin and non-admin, fail-closed on permission errors, explicit org overriding scope); `all_organizations` alias warning and conflict; `get_default_context_for_user` with admin-shaped permissions and with an identity-less token; MCP `get_default_cloud_context`; stale-grant handling (sole stale grant → no default, stale-first/valid-second with `limit=1`, non-404 errors propagate). Live check with the client-credentials identity via the local MCP server (`test-my-tools`-style prompt): identity/memberships correct, `default_workspace_id` `null`, `MEMBER_OF` returns `[]` with guidance, scoped listings honor `limit`. The OAuth path is not yet re-tested end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default cloud context details for identity, configured and default resources, memberships, and discovery guidance.
  - Added workspace discovery scopes for direct memberships, organization administrators, instance administrators, or all available workspaces.
  - Cloud discovery now supports efficient cross-organization listing and direct workspace grants.

- **Bug Fixes**
  - User identification now falls back to the JWT subject claim.
  - Improved handling of missing or ambiguous workspace context.

- **Documentation**
  - Updated guidance to recommend checking the default cloud context first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Link to Devin session: https://app.devin.ai/sessions/fcd495bfe62746ab90b9916cc22e4164
Open in Devin Desktop: https://app.devin.ai/desktop/session/fcd495bfe62746ab90b9916cc22e4164?variant=devin
Requested by: @aaronsteers

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

