### PR TITLE
feat(mcp): add `describe_cloud_workspace` and `get_cloud_organization_billing_status` tools

### DIFF
--- a/airbyte/cloud/models.py
+++ b/airbyte/cloud/models.py
@@ -85,6 +85,19 @@ class WorkspacePrivilegeScope(str, Enum):
     ANY = "any"
 
 
+class CloudOrganizationBillingInfo(BaseModel):
+    """Billing status information for an Airbyte organization."""
+
+    payment_status: str | None = None
+    """Payment status of the organization."""
+
+    subscription_status: str | None = None
+    """Subscription status of the organization."""
+
+    is_account_locked: bool = False
+    """Whether the organization account is locked."""
+
+
 class CloudWorkspaceInfo(BaseModel):
     """Information about an Airbyte workspace."""
 

--- a/airbyte/cloud/organizations.py
+++ b/airbyte/cloud/organizations.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import requests
+
 from airbyte._util import api_util
 from airbyte.cloud._credentials import _AirbyteCredentials
 from airbyte.cloud.models import CloudOrganizationBillingInfo
+from airbyte.exceptions import AirbyteError
 from airbyte.secrets.base import SecretString
 
 
@@ -101,15 +104,26 @@ class CloudOrganization:
 
     def get_billing_status(self) -> CloudOrganizationBillingInfo:
         """Fetch billing status for the organization or raise on failure."""
-        info = api_util.get_organization_info(
-            organization_id=self.organization_id,
-            api_root=self._credentials.public_api_root,
-            config_api_root=self._credentials.config_api_root,
-            client_id=self._credentials.client_id,
-            client_secret=self._credentials.client_secret,
-            bearer_token=self._credentials.bearer_token,
-        )
-        billing = info.get("billing") or {}
+        try:
+            info = api_util.get_organization_info(
+                organization_id=self.organization_id,
+                api_root=self._credentials.public_api_root,
+                config_api_root=self._credentials.config_api_root,
+                client_id=self._credentials.client_id,
+                client_secret=self._credentials.client_secret,
+                bearer_token=self._credentials.bearer_token,
+            )
+        except (requests.RequestException, ValueError) as ex:
+            raise AirbyteError(
+                message="Failed to retrieve organization billing information.",
+                context={"organization_id": self.organization_id},
+            ) from ex
+        billing = info.get("billing")
+        if not isinstance(billing, dict):
+            raise AirbyteError(
+                message="Organization info did not include billing details.",
+                context={"organization_id": self.organization_id},
+            )
         payment_status = billing.get("paymentStatus")
         subscription_status = billing.get("subscriptionStatus")
         return CloudOrganizationBillingInfo(

--- a/airbyte/cloud/organizations.py
+++ b/airbyte/cloud/organizations.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from airbyte._util import api_util
 from airbyte.cloud._credentials import _AirbyteCredentials
+from airbyte.cloud.models import CloudOrganizationBillingInfo
 from airbyte.secrets.base import SecretString
 
 
@@ -97,6 +98,27 @@ class CloudOrganization:
             return self._email
         info = self._fetch_organization_info()
         return info.get("email")
+
+    def get_billing_status(self) -> CloudOrganizationBillingInfo:
+        """Fetch billing status for the organization or raise on failure."""
+        info = api_util.get_organization_info(
+            organization_id=self.organization_id,
+            api_root=self._credentials.public_api_root,
+            config_api_root=self._credentials.config_api_root,
+            client_id=self._credentials.client_id,
+            client_secret=self._credentials.client_secret,
+            bearer_token=self._credentials.bearer_token,
+        )
+        billing = info.get("billing") or {}
+        payment_status = billing.get("paymentStatus")
+        subscription_status = billing.get("subscriptionStatus")
+        return CloudOrganizationBillingInfo(
+            payment_status=payment_status if isinstance(payment_status, str) else None,
+            subscription_status=(
+                subscription_status if isinstance(subscription_status, str) else None
+            ),
+            is_account_locked=api_util.is_account_locked(payment_status, subscription_status),
+        )
 
     @property
     def payment_status(self) -> str | None:

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -1864,14 +1864,12 @@ def get_cloud_organization_billing_status(
     try:
         info = org.get_billing_status()
     except (AirbyteError, NotImplementedError) as error:
+        reason = error.message if isinstance(error, AirbyteError) and error.message else str(error)
         return CloudOrganizationBillingStatusResult(
             organization_id=org.organization_id,
             organization_name=org.organization_name,
             billing_info_available=False,
-            message=(
-                "Billing information could not be retrieved: "
-                f"{getattr(error, 'message', str(error))}"
-            ),
+            message=f"Billing information could not be retrieved: {reason}",
         )
     return CloudOrganizationBillingStatusResult(
         organization_id=org.organization_id,

--- a/airbyte/mcp/cloud.py
+++ b/airbyte/mcp/cloud.py
@@ -20,6 +20,7 @@ from fastmcp_extensions import get_mcp_config, mcp_tool, register_mcp_tools
 from pydantic import BaseModel, Field
 
 from airbyte import cloud, get_destination, get_source
+from airbyte._util import api_util
 from airbyte.cloud.client import MAX_WORKSPACES_TO_VALIDATE, CloudClient
 from airbyte.cloud.connectors import CheckResult, CustomCloudSourceDefinition
 from airbyte.cloud.constants import FAILED_STATUSES
@@ -221,16 +222,6 @@ class CloudOrganizationResult(BaseModel):
     """Display name of the organization, when available."""
     email: str | None = None
     """Email associated with the organization, when available."""
-    payment_status: str | None = None
-    """Payment status of the organization (e.g., 'okay', 'grace_period', 'disabled', 'locked').
-    When 'disabled', syncs are blocked due to unpaid invoices."""
-    subscription_status: str | None = None
-    """Subscription status of the organization (e.g., 'pre_subscription', 'subscribed',
-    'unsubscribed')."""
-    is_account_locked: bool = False
-    """Whether the account is locked due to billing issues.
-    True if payment_status is 'disabled'/'locked' or subscription_status is 'unsubscribed'.
-    Defaults to False unless we have affirmative evidence of a locked state."""
 
 
 class CloudOrganizationListResult(BaseModel):
@@ -256,18 +247,19 @@ class CloudWorkspaceResult(BaseModel):
     """ID of the organization, if known and available."""
     organization_name: str | None = None
     """Name of the organization (requires ORGANIZATION_READER permission)."""
+
+
+class CloudOrganizationBillingStatusResult(BaseModel):
+    """Billing and account status for an Airbyte organization."""
+
+    organization_id: str
+    organization_name: str | None = None
+    billing_info_available: bool
+    """False when billing info could not be retrieved."""
     payment_status: str | None = None
-    """Payment status of the organization (e.g., 'okay', 'grace_period', 'disabled', 'locked').
-    When 'disabled', syncs are blocked due to unpaid invoices.
-    Requires ORGANIZATION_READER permission."""
     subscription_status: str | None = None
-    """Subscription status of the organization (e.g., 'pre_subscription', 'subscribed',
-    'unsubscribed'). Requires ORGANIZATION_READER permission."""
     is_account_locked: bool = False
-    """Whether the account is locked due to billing issues.
-    True if payment_status is 'disabled'/'locked' or subscription_status is 'unsubscribed'.
-    Defaults to False unless we have affirmative evidence of a locked state.
-    Requires ORGANIZATION_READER permission."""
+    message: str | None = None
 
 
 class CloudWorkspaceListResult(BaseModel):
@@ -1749,6 +1741,48 @@ def list_cloud_organizations(
     open_world=True,
     extra_help_text=CLOUD_AUTH_TIP_TEXT,
 )
+def describe_cloud_workspace(
+    ctx: Context,
+    *,
+    workspace_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Workspace ID. With no argument, resolves the configured default or the "
+                "authenticated user's default workspace."
+            ),
+            default=None,
+        ),
+    ],
+) -> CloudWorkspaceResult:
+    """Get basic details about a workspace (ID, name, URL, parent organization).
+
+    Does not include billing/account status; use `get_cloud_organization_billing_status` for that.
+    """
+    workspace = _get_cloud_workspace(ctx, workspace_id)
+    workspace_response = api_util.get_workspace(
+        workspace_id=workspace.workspace_id,
+        api_root=workspace.api_root,
+        client_id=workspace.client_id,
+        client_secret=workspace.client_secret,
+        bearer_token=workspace.bearer_token,
+    )
+    organization = workspace.get_organization(raise_on_error=False)
+    return CloudWorkspaceResult(
+        workspace_id=workspace_response.workspace_id,
+        workspace_name=workspace_response.name,
+        workspace_url=workspace.workspace_url,
+        organization_id=organization.organization_id if organization else None,
+        organization_name=organization.organization_name if organization else None,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
 def describe_cloud_organization(
     ctx: Context,
     *,
@@ -1774,7 +1808,9 @@ def describe_cloud_organization(
         ),
     ],
 ) -> CloudOrganizationResult:
-    """Get details about a specific organization including billing status.
+    """Get basic details about an organization (ID, name, email).
+
+    Billing/account status is available via `get_cloud_organization_billing_status`.
 
     With no arguments, resolves the organization from the configured default or the
     authenticated user's sole membership. With multiple memberships, the error lists
@@ -1786,14 +1822,64 @@ def describe_cloud_organization(
         organization_name=organization_name,
     )
 
-    # CloudOrganization has lazy loading of billing properties
     return CloudOrganizationResult(
         id=org.organization_id,
         name=org.organization_name,
         email=org.email,
-        payment_status=org.payment_status,
-        subscription_status=org.subscription_status,
-        is_account_locked=org.is_account_locked,
+    )
+
+
+@mcp_tool(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    extra_help_text=CLOUD_AUTH_TIP_TEXT,
+)
+def get_cloud_organization_billing_status(
+    ctx: Context,
+    *,
+    organization_id: Annotated[
+        str | None,
+        Field(
+            description="Organization ID, when known.",
+            default=None,
+        ),
+    ],
+    organization_name: Annotated[
+        str | None,
+        Field(
+            description="Organization name for an exact match, when ID is not provided.",
+            default=None,
+        ),
+    ],
+) -> CloudOrganizationBillingStatusResult:
+    """Get billing and account status for an organization.
+
+    This generally requires elevated `ORGANIZATION_READER` or administrator permissions.
+    """
+    org = _get_cloud_client(ctx).get_organization(
+        organization_id=organization_id,
+        organization_name=organization_name,
+    )
+    try:
+        info = org.get_billing_status()
+    except (AirbyteError, NotImplementedError) as error:
+        return CloudOrganizationBillingStatusResult(
+            organization_id=org.organization_id,
+            organization_name=org.organization_name,
+            billing_info_available=False,
+            message=(
+                "Billing information could not be retrieved: "
+                f"{getattr(error, 'message', str(error))}"
+            ),
+        )
+    return CloudOrganizationBillingStatusResult(
+        organization_id=org.organization_id,
+        organization_name=org.organization_name,
+        billing_info_available=True,
+        payment_status=info.payment_status,
+        subscription_status=info.subscription_status,
+        is_account_locked=info.is_account_locked,
     )
 
 

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import NoReturn
 
 import pytest
+import requests
 from airbyte_api import models
 
 from airbyte import constants
@@ -1766,3 +1767,26 @@ def test_cloud_organization_get_billing_status(monkeypatch: pytest.MonkeyPatch) 
     assert result.payment_status == "okay"
     assert result.subscription_status == "subscribed"
     assert result.is_account_locked is False
+
+
+def test_cloud_organization_get_billing_status_requires_billing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        api_util, "get_organization_info", lambda **_: {"organizationId": "org-1"}
+    )
+    organization = CloudOrganization(organization_id="organization-id")
+    with pytest.raises(AirbyteError, match="billing details"):
+        organization.get_billing_status()
+
+
+def test_cloud_organization_get_billing_status_wraps_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def get_organization_info(**_: object) -> None:
+        raise requests.ConnectionError("reset")
+
+    monkeypatch.setattr(api_util, "get_organization_info", get_organization_info)
+    organization = CloudOrganization(organization_id="organization-id")
+    with pytest.raises(AirbyteError, match="Failed to retrieve organization billing"):
+        organization.get_billing_status()

--- a/tests/unit_tests/test_cloud_credentials.py
+++ b/tests/unit_tests/test_cloud_credentials.py
@@ -1748,3 +1748,21 @@ def test_cloud_organization_fetch_returns_cached_info_after_refresh_failure(
     assert organization._fetch_organization_info(force_refresh=True) == {  # noqa: SLF001
         "organizationName": "cached"
     }
+
+
+def test_cloud_organization_get_billing_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        api_util,
+        "get_organization_info",
+        lambda **_: {
+            "billing": {
+                "paymentStatus": "okay",
+                "subscriptionStatus": "subscribed",
+            }
+        },
+    )
+    organization = CloudOrganization(organization_id="organization-id")
+    result = organization.get_billing_status()
+    assert result.payment_status == "okay"
+    assert result.subscription_status == "subscribed"
+    assert result.is_account_locked is False

--- a/tests/unit_tests/test_mcp_cloud.py
+++ b/tests/unit_tests/test_mcp_cloud.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Callable, cast
 
 import pytest
@@ -572,3 +573,129 @@ def test_get_default_cloud_context_flags_unverified_default_workspace(
         "Default workspace ID deleted-workspace could not be verified "
         "(it may have been deleted or is not accessible with these credentials). These"
     )
+
+
+def test_describe_cloud_workspace_includes_parent_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization = SimpleNamespace(
+        organization_id="org-id", organization_name="Organization"
+    )
+    workspace = SimpleNamespace(
+        workspace_id="workspace-id",
+        api_root="https://api.airbyte.com/v1",
+        client_id=None,
+        client_secret=None,
+        bearer_token=None,
+        workspace_url="https://cloud.airbyte.com/workspaces/workspace-id",
+        get_organization=lambda **_: organization,
+    )
+    monkeypatch.setattr(cloud_mcp, "_get_cloud_workspace", lambda *_: workspace)
+    monkeypatch.setattr(
+        cloud_mcp.api_util,
+        "get_workspace",
+        lambda **_: SimpleNamespace(workspace_id="workspace-id", name="Workspace"),
+    )
+    result = cloud_mcp.describe_cloud_workspace(
+        cast(Context, object()), workspace_id=None
+    )
+    assert result.organization_id == "org-id"
+    assert result.organization_name == "Organization"
+
+
+def test_describe_cloud_workspace_allows_missing_parent_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = SimpleNamespace(
+        workspace_id="workspace-id",
+        api_root="https://api.airbyte.com/v1",
+        client_id=None,
+        client_secret=None,
+        bearer_token=None,
+        workspace_url=None,
+        get_organization=lambda **_: None,
+    )
+    monkeypatch.setattr(cloud_mcp, "_get_cloud_workspace", lambda *_: workspace)
+    monkeypatch.setattr(
+        cloud_mcp.api_util,
+        "get_workspace",
+        lambda **_: SimpleNamespace(workspace_id="workspace-id", name="Workspace"),
+    )
+    result = cloud_mcp.describe_cloud_workspace(
+        cast(Context, object()), workspace_id=None
+    )
+    assert result.organization_id is None
+    assert result.organization_name is None
+
+
+def test_get_cloud_organization_billing_status_returns_billing_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization = SimpleNamespace(
+        organization_id="org-id",
+        organization_name="Organization",
+        get_billing_status=lambda: SimpleNamespace(
+            payment_status="okay",
+            subscription_status="subscribed",
+            is_account_locked=False,
+        ),
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_client",
+        lambda _: SimpleNamespace(get_organization=lambda **_: organization),
+    )
+    result = cloud_mcp.get_cloud_organization_billing_status(
+        cast(Context, object()), organization_id=None, organization_name=None
+    )
+    assert result.billing_info_available is True
+    assert result.payment_status == "okay"
+    assert result.subscription_status == "subscribed"
+    assert result.is_account_locked is False
+
+
+def test_get_cloud_organization_billing_status_handles_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def get_billing_status() -> None:
+        raise cloud_mcp.AirbyteError(message="not allowed")
+
+    organization = SimpleNamespace(
+        organization_id="org-id",
+        organization_name="Organization",
+        get_billing_status=get_billing_status,
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_client",
+        lambda _: SimpleNamespace(get_organization=lambda **_: organization),
+    )
+    result = cloud_mcp.get_cloud_organization_billing_status(
+        cast(Context, object()), organization_id=None, organization_name=None
+    )
+    assert result.billing_info_available is False
+    assert result.payment_status is None
+    assert result.is_account_locked is False
+    assert result.message == "Billing information could not be retrieved: not allowed"
+
+
+def test_describe_cloud_organization_excludes_billing_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization = SimpleNamespace(
+        organization_id="org-id",
+        organization_name="Organization",
+        email="org@example.com",
+    )
+    monkeypatch.setattr(
+        cloud_mcp,
+        "_get_cloud_client",
+        lambda _: SimpleNamespace(get_organization=lambda **_: organization),
+    )
+    result = cloud_mcp.describe_cloud_organization(
+        cast(Context, object()), organization_id=None, organization_name=None
+    )
+    assert result.id == "org-id"
+    assert not hasattr(result, "payment_status")
+    assert not hasattr(result, "subscription_status")
+    assert not hasattr(result, "is_account_locked")


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Adds a plain "describe a workspace" tool that works for anyone who can see the workspace, and moves billing/account status into its own dedicated tool that says explicitly when the information could not be retrieved instead of silently returning nulls.

Specifically, this adds `describe_cloud_workspace` and `get_cloud_organization_billing_status`, adds `CloudOrganization.get_billing_status()` / `CloudOrganizationBillingInfo`, and removes `payment_status` / `subscription_status` / `is_account_locked` from `CloudOrganizationResult` (`describe_cloud_organization`) and `CloudWorkspaceResult`.

</td></tr></table>

Stacked on #1159 (which is stacked on #1158):
- #1159

## Changes

- New MCP tool `describe_cloud_workspace(workspace_id=None)` → `CloudWorkspaceResult` (id, name, URL, parent `organization_id`/`organization_name`). Workspace is resolved via the default-context precedence when omitted; the parent-org lookup uses `CloudWorkspace.get_organization(raise_on_error=False)`, so missing `ORGANIZATION_READER` yields `None` org fields rather than an error.
- New MCP tool `get_cloud_organization_billing_status(organization_id=None, organization_name=None)` → `CloudOrganizationBillingStatusResult` with `billing_info_available: bool` and `message` explaining a failed fetch (`AirbyteError` / `NotImplementedError`), alongside `payment_status`, `subscription_status`, `is_account_locked`.
- New core method `CloudOrganization.get_billing_status() -> CloudOrganizationBillingInfo` that calls `api_util.get_organization_info` directly and raises on failure (unlike the lazy `payment_status` properties, which swallow errors via `_fetch_organization_info`; those are left unchanged for library callers).
- `describe_cloud_organization` is now a plain description (id, name, email); billing fields removed from `CloudOrganizationResult` and from `CloudWorkspaceResult` (the latter were never populated by `list_cloud_workspaces`).

## Review Spotlight

Reviewers with limited time, please review first:
- [`airbyte/mcp/cloud.py` — `get_cloud_organization_billing_status`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789240189-describe-workspace-billing-tools/airbyte/mcp/cloud.py): the explicit-failure contract
- [`airbyte/cloud/organizations.py` — `get_billing_status`](https://github.com/airbytehq/PyAirbyte/blob/devin/1789240189-describe-workspace-billing-tools/airbyte/cloud/organizations.py): raising billing lookup

## Risks

- Breaking for MCP clients reading `payment_status` / `subscription_status` / `is_account_locked` from `describe_cloud_organization`; they should call `get_cloud_organization_billing_status` instead.

## Test plan

- `uv run ruff format .` / `uv run ruff check .` → All checks passed!
- `uv run --with mypy mypy airbyte/mcp/cloud.py airbyte/cloud/organizations.py airbyte/cloud/models.py` → Success: no issues found
- `uv run pytest tests/unit_tests/test_mcp_cloud.py tests/unit_tests/test_cloud_client.py tests/unit_tests/test_cloud_credentials.py -q` → 125 passed (new tests cover org lookup success/missing, billing success/permission failure, and the trimmed `describe_cloud_organization` shape)

Requested by AJ Steers (@aaronsteers).


Link to Devin session: https://app.devin.ai/sessions/901bc3edeba246eab5d18ae328943251
Open in Devin Desktop: https://app.devin.ai/desktop/session/901bc3edeba246eab5d18ae328943251?variant=devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace descriptions with workspace and parent organization details.
  - Added a dedicated organization billing status lookup, including payment status, subscription status, and account-lock information.
  - Billing availability and retrieval errors are now clearly reported when billing details cannot be obtained.

- **Changes**
  - Organization descriptions now focus on basic organization details; billing information is provided through the separate billing status lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->