### PR TITLE
fix(sql): parse dates on load by declared `date-time` type, not column name

### DIFF
--- a/airbyte/shared/sql_processor.py
+++ b/airbyte/shared/sql_processor.py
@@ -896,11 +896,26 @@ class SqlProcessorBase(abc.ABC):
         to improve performance.
         """
         temp_table_name = self._create_table_for_loading(stream_name, batch_id)
-        for file_path in files:
-            dataframe = pd.read_json(file_path, lines=True)
+        sql_column_definitions: dict[str, TypeEngine] = self._get_sql_column_definitions(
+            stream_name
+        )
 
-            sql_column_definitions: dict[str, TypeEngine] = self._get_sql_column_definitions(
-                stream_name
+        # Parse dates only where the schema says date-time. `pd.read_json`
+        # otherwise coerces by column NAME (`date`, `_at`, `_time`), which
+        # turns a numeric column into a datetime and breaks the insert
+        # against the DECIMAL column this same schema created.
+        datetime_columns: list[str] = [
+            column_name
+            for column_name, sql_type in sql_column_definitions.items()
+            if isinstance(sql_type, sqlalchemy.types.DateTime)
+        ]
+
+        for file_path in files:
+            dataframe = pd.read_json(
+                file_path,
+                lines=True,
+                convert_dates=datetime_columns,
+                keep_default_dates=False,
             )
 
             # Remove fields that are not in the schema

--- a/tests/unit_tests/test_numeric_date_columns.py
+++ b/tests/unit_tests/test_numeric_date_columns.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""Date parsing on load follows the declared type, not the column name."""
+
+from __future__ import annotations
+
+import io
+
+import pandas as pd
+import sqlalchemy
+
+from airbyte.types import SQLTypeConverter
+
+
+def _read(row: str, datetime_columns: list[str]) -> pd.DataFrame:
+    """Read one JSONL record the way the SQL processor now does."""
+    return pd.read_json(
+        io.StringIO(row),
+        lines=True,
+        convert_dates=datetime_columns,
+        keep_default_dates=False,
+    )
+
+
+def _declared_datetime_columns(schema: dict[str, dict]) -> list[str]:
+    """The columns a stream's JSON schema declares as timestamps."""
+    converter = SQLTypeConverter()
+    return [
+        name
+        for name, prop in schema.items()
+        if isinstance(converter.to_sql_type(prop), sqlalchemy.types.DateTime)
+    ]
+
+
+class TestSchemaDrivenDateParsing:
+    def test_numeric_column_named_date_stays_numeric(self) -> None:
+        """Epoch milliseconds in a column called `date`, declared a number."""
+        schema = {"date": {"type": "number"}, "id": {"type": "string"}}
+        row = '{"date": 1788528600000, "id": "abc"}'
+
+        frame = _read(row, _declared_datetime_columns(schema))
+
+        assert frame["date"].dtype == "int64"
+        assert frame["date"].iloc[0] == 1788528600000
+
+    def test_numeric_column_ending_in_at_stays_numeric(self) -> None:
+        """`_at` is one of pandas' default date-like suffixes."""
+        schema = {"score_at": {"type": "number"}}
+        frame = _read('{"score_at": 1788528600000}', _declared_datetime_columns(schema))
+        assert frame["score_at"].dtype == "int64"
+
+    def test_declared_timestamp_is_still_parsed(self) -> None:
+        """Declared date-time still becomes a timestamp."""
+        schema = {"updated_at": {"type": "string", "format": "date-time"}}
+        frame = _read(
+            '{"updated_at": "2026-09-04T13:30:00.000Z"}',
+            _declared_datetime_columns(schema),
+        )
+        assert "datetime64" in str(frame["updated_at"].dtype)
+
+    def test_declared_timestamp_sent_as_epoch_is_still_parsed(self) -> None:
+        """Declared date-time sent as an epoch still parses, so nothing regresses."""
+        schema = {"occurred_at": {"type": "string", "format": "date-time"}}
+        frame = _read(
+            '{"occurred_at": 1788528600000}', _declared_datetime_columns(schema)
+        )
+        assert "datetime64" in str(frame["occurred_at"].dtype)
+
+    def test_name_alone_does_not_decide(self) -> None:
+        """Same value, different declared types, different results."""
+        schema = {
+            "date": {"type": "number"},
+            "captured_at": {"type": "string", "format": "date-time"},
+        }
+        row = '{"date": 1788528600000, "captured_at": 1788528600000}'
+
+        frame = _read(row, _declared_datetime_columns(schema))
+
+        assert frame["date"].dtype == "int64", "declared a number"
+        assert "datetime64" in str(frame["captured_at"].dtype), "declared date-time"
+
+    def test_conversion_no_longer_depends_on_the_values(self) -> None:
+        """The same declared type gives the same column type every batch."""
+        schema = {"end_time": {"type": "number"}}
+        columns = _declared_datetime_columns(schema)
+
+        small = _read('{"end_time": 900}', columns)
+        epoch_sized = _read('{"end_time": 1788528600000}', columns)
+
+        assert small["end_time"].dtype == epoch_sized["end_time"].dtype == "int64"
+
+
+class TestPandasDefaultIsTheBug:
+    """Pin the pandas behaviour being corrected."""
+
+    def test_pandas_default_coerces_by_name(self) -> None:
+        """Same value, three names, three outcomes."""
+        row = (
+            '{"date": 1788528600000, "score_at": 1788528600000, '
+            '"plain_num": 1788528600000}'
+        )
+        frame = pd.read_json(io.StringIO(row), lines=True)
+
+        assert "datetime64" in str(frame["date"].dtype)
+        assert "datetime64" in str(frame["score_at"].dtype)
+        assert frame["plain_num"].dtype == "int64"

--- a/tests/unit_tests/test_numeric_date_columns.py
+++ b/tests/unit_tests/test_numeric_date_columns.py
@@ -4,11 +4,25 @@
 from __future__ import annotations
 
 import io
+from typing import TYPE_CHECKING
 
 import pandas as pd
+import pytest
 import sqlalchemy
+from airbyte_protocol.models import (
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    DestinationSyncMode,
+    SyncMode,
+)
 
+from airbyte._processors.sql.postgres import PostgresConfig, PostgresSqlProcessor
+from airbyte.shared.catalog_providers import CatalogProvider
 from airbyte.types import SQLTypeConverter
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _read(row: str, datetime_columns: list[str]) -> pd.DataFrame:
@@ -103,3 +117,87 @@ class TestPandasDefaultIsTheBug:
         assert "datetime64" in str(frame["date"].dtype)
         assert "datetime64" in str(frame["score_at"].dtype)
         assert frame["plain_num"].dtype == "int64"
+
+
+class TestProcessorLevelDateParsing:
+    """Drive `_write_files_to_new_table` end to end, without a database."""
+
+    def test_write_files_uses_declared_types_not_names(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A numeric column named `date`/`score_at` must load as int64."""
+        stream_schema = {
+            "type": "object",
+            "properties": {
+                "date": {"type": "number"},
+                "score_at": {"type": "number"},
+                "captured_at": {"type": "string", "format": "date-time"},
+                "id": {"type": "string"},
+            },
+        }
+        catalog = ConfiguredAirbyteCatalog(
+            streams=[
+                ConfiguredAirbyteStream(
+                    stream=AirbyteStream(
+                        name="events",
+                        json_schema=stream_schema,
+                        supported_sync_modes=[SyncMode.full_refresh],
+                    ),
+                    sync_mode=SyncMode.full_refresh,
+                    destination_sync_mode=DestinationSyncMode.overwrite,
+                )
+            ]
+        )
+
+        # The processor constructor would otherwise connect to Postgres.
+        monkeypatch.setattr(
+            PostgresSqlProcessor, "_ensure_schema_exists", lambda self: None
+        )
+        processor = PostgresSqlProcessor(
+            sql_config=PostgresConfig(
+                host="localhost",
+                port=5432,
+                username="user",
+                password="pass",
+                database="db",
+            ),
+            catalog_provider=CatalogProvider(catalog),
+            temp_dir=tmp_path,
+            temp_file_cleanup=True,
+        )
+
+        monkeypatch.setattr(
+            processor,
+            "_create_table_for_loading",
+            lambda *args, **kwargs: "temp_events",
+        )
+        monkeypatch.setattr(processor, "_table_exists", lambda *args, **kwargs: True)
+
+        written_frames: list[pd.DataFrame] = []
+
+        def _capture_to_sql(
+            self: pd.DataFrame, *args: object, **kwargs: object
+        ) -> None:
+            written_frames.append(self.copy())
+
+        monkeypatch.setattr(pd.DataFrame, "to_sql", _capture_to_sql)
+
+        jsonl_path = tmp_path / "batch.jsonl"
+        jsonl_path.write_text(
+            '{"date": 1788528600000, "score_at": 1788528600000, '
+            '"captured_at": 1788528600000, "id": "abc"}\n'
+        )
+
+        table_name = processor._write_files_to_new_table(
+            [jsonl_path], "events", "batch1"
+        )
+
+        assert table_name == "temp_events"
+        assert len(written_frames) == 1
+        frame = written_frames[0]
+        assert frame["date"].dtype == "int64", "declared a number"
+        assert frame["score_at"].dtype == "int64", "declared a number"
+        assert "datetime64" in str(frame["captured_at"].dtype), "declared date-time"
+        assert frame["id"].dtype == "object"


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Loading records into Postgres/MySQL no longer turns numeric columns into timestamps just because they are named `date` or end in `_at`; only fields the stream schema declares as date-times are parsed as dates. This PR carries the community fix plus a processor-level regression test.

Specifically, `SqlProcessorBase._write_files_to_new_table` passes `convert_dates=<declared date-time columns>, keep_default_dates=False` to `pd.read_json`.

</td></tr></table>

Stacked on #1153 (contributor commit cherry-picked; stacked fast-follow if #1153 merges first, replacement otherwise):
- #1153

## Summary

This PR extends the contribution from @Sh1vam09 (_thank you! 🙏_), cherry-picked from airbytehq/PyAirbyte#1153 so the original commit authorship is preserved. Requested by @aaronsteers.

**Maintainer recommendation:** airbytehq/PyAirbyte#1153 is safe and correct to merge as-is. This PR is a stacked fast-follow: it carries the contributor's commit unchanged (`6890570`) plus one maintainer commit (`ce3a78a`) adding a regression test that exercises the real processor path. If airbytehq/PyAirbyte#1153 lands first, this PR rebases to just the test commit; if not, it can land in its place.

## ❓ What it does

`SqlProcessorBase._write_files_to_new_table` reads JSONL batches with `pd.read_json(..., lines=True)`, whose default `convert_dates=True` coerces columns to timestamps **by name** (`date`, `datetime`, `modified`, `*_at`, `*_time`, `timestamp*`) whenever the values look like epochs. The fix restricts date parsing to the columns the stream schema declares as `date-time`:

```diff
-dataframe = pd.read_json(file_path, lines=True)
+datetime_columns = [name for name, t in sql_column_definitions.items()
+                    if isinstance(t, sqlalchemy.types.DateTime)]
+dataframe = pd.read_json(file_path, lines=True,
+                         convert_dates=datetime_columns, keep_default_dates=False)
```

## ❗ Feature or RCA Impact

Root cause: pandas' name-based date inference, not the stream schema, decided the dtype of the loaded column. A `number` field named `date`/`*_at` holding epoch-sized values became `datetime64`, and the insert into the `NUMERIC` column this same schema created failed with `DatatypeMismatch`. Whether a sync failed depended on both the column *name* and the batch's *values*.

Affects caches on the generic pandas load path (Postgres, MySQL). DuckDB/BigQuery/Snowflake override `_write_files_to_new_table` and are unchanged. Declared `date-time` columns still parse exactly as before (including epoch-valued ones); only undeclared columns stop being coerced.

## 📋 Enumerated changes

1. `SqlProcessorBase._write_files_to_new_table`: compute `datetime_columns` from `_get_sql_column_definitions` and pass `convert_dates=datetime_columns, keep_default_dates=False` (contributor commit).
2. `tests/unit_tests/test_numeric_date_columns.py`: contributor's pandas-level behavior tests (contributor commit, untouched).
3. `TestProcessorLevelDateParsing.test_write_files_uses_declared_types_not_names`: builds a real `PostgresSqlProcessor` (stubbing `_ensure_schema_exists`, `_create_table_for_loading`, `_table_exists`, `DataFrame.to_sql`), runs `_write_files_to_new_table` on a JSONL file, and asserts `date`/`score_at` load as `int64`, `captured_at` as `datetime64`, `id` as `object` (maintainer commit).

## 🙋 Maintainer Decisions

- Contributor commit is untouched; all maintainer work is in a separate commit on top.
- The contributor's tests re-implement the `pd.read_json` call rather than exercising the processor, so they can't catch a regression in `_write_files_to_new_table` itself. Rather than relocating/rewriting them, I left them and added one processor-level test that fails on pre-fix code (verified by reverting the fix locally: `AssertionError: assert dtype('<M8[ns]') == 'int64'`).
- The test uses `monkeypatch` on the instance/`pd.DataFrame` instead of a DB fixture so it runs in the no-credentials unit suite.
- Known narrow edge, **not** addressed here (pre-existing, same raw-vs-normalized mismatch as the existing drop-columns loop): `datetime_columns` uses normalized names, while `read_json` sees raw JSON keys. A declared `date-time` property with a name that changes under normalization (e.g. `Created_At`) sent as an epoch would stop being parsed. Worth a follow-up if it bites anyone.
- Repo uses `pyrefly` rather than mypy for type-checking; `ruff format --check`, `ruff check`, `pyrefly check` all clean.

## ✔️ Repro of Issue, Proof of Fix?

Harness: `postgres:13` in Docker; script builds a `PostgresCache`, gets the record processor for an `events` stream with schema `{date: number, score_at: number, captured_at: string/date-time, id: string}`, writes one JSONL row `{"date": 1788528600000, "score_at": 1788528600000, "captured_at": 1788528600000, "id": "abc"}`, calls `_write_files_to_new_table`, then `SELECT pg_typeof(...)`.

**Repro on `main` (`58471f7`):**
```
$ PYTHONPATH=<main worktree> uv run python repro.py
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DatatypeMismatch) column "date" is of type numeric but expression is of type timestamp without time zone
[parameters: {'date': datetime.datetime(2026, 9, 4, 13, 30), 'score_at': datetime.datetime(2026, 9, 4, 13, 30), ...}]
exit 1
```

**Proof on this branch:**
```
$ PYTHONPATH=<this branch> uv run python repro.py
=== SUCCESS: loaded into events_batch1 ===
date: numeric=1788528600000.000000000 | score_at: numeric=1788528600000.000000000 | captured_at: timestamp without time zone=2026-09-04 13:30:00
exit 0
```

**New unit test, fix reverted vs. applied:**
```
$ uv run pytest tests/unit_tests/test_numeric_date_columns.py
# with 6890570's diff reversed:
E   AssertionError: declared a number
E   assert dtype('<M8[ns]') == 'int64'
1 failed, 7 passed
# on this branch:
8 passed
```


Link to Devin session: https://app.devin.ai/sessions/12df3ba8cdc24445bfef315d26fb88be
Open in Devin Desktop: https://app.devin.ai/desktop/session/12df3ba8cdc24445bfef315d26fb88be?variant=devin